### PR TITLE
Make titlebar draggable on Windows

### DIFF
--- a/Celbridge/Celbridge/App.cs
+++ b/Celbridge/Celbridge/App.cs
@@ -45,10 +45,7 @@ namespace Celbridge
 
                 // Place the frame in the current Window
                 MainWindow.Content = rootFrame;
-#if !HAS_UNO
-                // Extending the content into the titlebar is only supported on Windows
-                MainWindow.ExtendsContentIntoTitleBar = true;
-#endif
+
                 var localizer = Host.Services.GetRequiredService<IStringLocalizer>();
                 MainWindow.Title = localizer["ApplicationName.Text"];
             }

--- a/Celbridge/Celbridge/Views/Shell.xaml.cs
+++ b/Celbridge/Celbridge/Views/Shell.xaml.cs
@@ -51,8 +51,11 @@ namespace Celbridge
             Guard.IsNotNull(app);
 
 #if WINDOWS
-            // Todo: Set titlebar content again
-            // app.SetTitleBarContent(TitleBar);
+            var mainWindow = app.MainWindow;
+            Guard.IsNotNull(mainWindow);
+
+            mainWindow.ExtendsContentIntoTitleBar = true;
+            mainWindow.SetTitleBar(TitleBar);
 #endif
             BottomPanel.Children.Add(new ConsolePanel());
             LeftPanel.Children.Add(new ProjectPanel());


### PR DESCRIPTION
The previous fix for #1 prevents the user from moving the application by dragging the title bar on Windows.

This fix set the titlebar content via the SetTitleBar() method. This allows the user to move the window by dragging on the titlebar.

Related to #1