### PR TITLE
Prevent text file from automatically reloading after a save

### DIFF
--- a/Celbridge/Celbridge/ViewModels/TextFileDocumentViewModel.cs
+++ b/Celbridge/Celbridge/ViewModels/TextFileDocumentViewModel.cs
@@ -1,16 +1,6 @@
-﻿using Celbridge.Models;
-using Celbridge.Services;
+﻿using Celbridge.Services;
 using Celbridge.Utils;
-using CommunityToolkit.Diagnostics;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.UI.Xaml;
-using Serilog;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Celbridge.ViewModels
 {
@@ -164,7 +154,9 @@ namespace Celbridge.ViewModels
                 return new ErrorResult(error.Message);
             }
 
-            return await FileUtils.SaveTextAsync(_path, Content);
+            _isSavingContent = true;
+
+           return await FileUtils.SaveTextAsync(_path, Content);
         }
 
         private void TextFileDocumentViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
When a Text File document is edited and saved, the File Watcher detects the change and triggers the Text File to reload.

Set a flag when the Text File is saved so we can ignore the file modified event in this case.

Fixes #5