### PR TITLE
Store OpenAI Key in the user's local settings instead of hard coding

### DIFF
--- a/Celbridge.sln
+++ b/Celbridge.sln
@@ -29,6 +29,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{A13B9DDB-364C-4EB7-A100-B243618EEF76}"
 	ProjectSection(SolutionItems) = preProject
 		Docs\UnoPlatformNotes.md = Docs\UnoPlatformNotes.md
+		StoringSecrets.md = StoringSecrets.md
+		Docs\UsingGithub.md = Docs\UsingGithub.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CelStandardLibrary", "CelStandardLibrary\CelStandardLibrary.csproj", "{C17A6B9B-7C07-4ACA-BF6B-562FBF0B290E}"

--- a/Celbridge/Celbridge/App.cs
+++ b/Celbridge/Celbridge/App.cs
@@ -108,7 +108,7 @@ namespace Celbridge
             IDocumentService documentService = new DocumentService(messengerService);
             IDialogService dialogService = new DialogService(messengerService);
             IProjectService projectService = new ProjectService(messengerService, settingsService, saveDataService, resourceService, documentService, dialogService, inspectorService);
-            IAIService aiService = new AIService();
+            IAIService aiService = new AIService(settingsService);
             IConsoleService consoleService = new ConsoleService(messengerService, aiService);
             ICelTypeService celTypeService = new CelTypeService();
             ICelScriptService celScriptService = new CelScriptService(messengerService, celTypeService, resourceService, projectService, dialogService);

--- a/Celbridge/Celbridge/Models/EditorSettings.cs
+++ b/Celbridge/Celbridge/Models/EditorSettings.cs
@@ -41,6 +41,9 @@ namespace Celbridge.Models
         [ObservableProperty]
         private List<string> _previousOpenDocuments = new();
 
+        [ObservableProperty]
+        private string _openAIKey = string.Empty;
+
         public EditorSettings()
         {
             // Required for serialization.

--- a/Celbridge/Celbridge/Services/ConsoleService.cs
+++ b/Celbridge/Celbridge/Services/ConsoleService.cs
@@ -199,7 +199,7 @@ namespace Celbridge.Services
 
         private void DoChatInput(string commandText)
         {
-            if (commandText.Trim().StartsWith("EndChat()"))
+            if (commandText.Trim().EndsWith("EndChat()"))
             {
                 ExitChatMode();
                 return;
@@ -359,6 +359,8 @@ namespace Celbridge.Services
             }
             _isChatModeEnabled = false;
             _chatFile = string.Empty;
+
+            _aiService.EndChat();
 
             return new SuccessResult();
         }

--- a/Celbridge/Celbridge/ViewModels/SettingsViewModel.cs
+++ b/Celbridge/Celbridge/ViewModels/SettingsViewModel.cs
@@ -22,6 +22,23 @@ namespace Celbridge.ViewModels
 
         public List<string> ThemeValues { get; } = new() { "Light", "Dark" };
 
+
+        public string OpenAIKey
+        {
+            get
+            {
+                Guard.IsNotNull(_settingsService.EditorSettings);
+                return _settingsService.EditorSettings.OpenAIKey;
+            }
+
+            set
+            {
+                Guard.IsNotNull(_settingsService.EditorSettings);
+                _settingsService.EditorSettings.OpenAIKey = value;
+                OnPropertyChanged(nameof(OpenAIKey));
+            }
+        }
+
         private void SettingsViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(ThemeIndex))

--- a/Celbridge/Celbridge/Views/SettingsDialog.xaml
+++ b/Celbridge/Celbridge/Views/SettingsDialog.xaml
@@ -12,9 +12,14 @@
 
     <StackPanel VerticalAlignment="Stretch" 
                 HorizontalAlignment="Stretch">
-        <ComboBox ItemsSource="{x:Bind ViewModel.ThemeValues}"
+        <ComboBox Header="Theme" 
+                  ItemsSource="{x:Bind ViewModel.ThemeValues}"
                   SelectedIndex="{x:Bind ViewModel.ThemeIndex, Mode=TwoWay}"
-                  Header="Theme" 
-                  PlaceholderText="Application theme" Width="200"/>
+                  PlaceholderText="Application theme" Width="200"
+                  Margin="6"/>
+
+        <TextBox Header="Open AI Key"
+                 Text="{x:Bind ViewModel.OpenAIKey, Mode=TwoWay}"
+                 Margin="6"/>
     </StackPanel>
 </ContentDialog>

--- a/StoringSecrets.md
+++ b/StoringSecrets.md
@@ -1,0 +1,12 @@
+# Storing Secrets
+
+This [article](https://auth0.com/blog/secret-management-in-dotnet-applications/) provides a good overview of the 
+main options for storing secret keys in .NET Applications.
+
+For Celbridge, the main use case at the moment is allowing the user to provide their own secret keys for services 
+such as OpenAI. The user can enter these keys via the Settings dialog and they are persisted in the local settings
+for the application.
+
+
+Uno Platform does support the [Windows.Security.Credentials.PasswordVault API](https://platform.uno/docs/articles/features/PasswordVault.html?tabs=android) 
+but only on a limited number of platforms. We could use it in future if they extend support to Mac & Linux.


### PR DESCRIPTION
The Open AI key is hard coded and published in the source code on Github, not exactly secure!

This change adds an OpenAI Key field in the settings window where the user can enter their own OpenAI Key. This property is stored locally for the user.

Also added a doc explaining our approach to storing secrets.

Fixes #12