### PR TITLE
Add instructions for building markdown string data

### DIFF
--- a/CelRuntime/Environment.cs
+++ b/CelRuntime/Environment.cs
@@ -6,10 +6,6 @@ namespace CelRuntime
     public static class Environment
     {
         public static string ProjectFolder { get; private set; }
-        public static string GetPath(string file)
-        {
-            return Path.Combine(ProjectFolder, file);
-        }
 
         private static Action<string> _onPrint;
         public static void Print(object message)
@@ -26,6 +22,7 @@ namespace CelRuntime
         public static TextFile TextFile { get; private set; }
         public static Process Process { get; private set; }
         public static Chat Chat { get; private set; }
+        public static Markdown Markdown { get; private set; }
 
         public static bool Init(string projectFolder, Action<string> onPrint, string chatAPIKey)
         {
@@ -57,6 +54,7 @@ namespace CelRuntime
                 PrintError("Failed to init Chat API");
                 return false;
             }
+            Markdown = new Markdown();
 
             return true;
         }

--- a/CelRuntime/Markdown.cs
+++ b/CelRuntime/Markdown.cs
@@ -1,0 +1,56 @@
+﻿using System.Text;
+
+namespace CelRuntime
+{
+    public class Markdown
+    {
+        private static StringBuilder _markdownBuilder = new StringBuilder();
+        private static int _sectionCount;
+
+        public void ClearMarkdown()
+        {
+            _markdownBuilder.Clear();
+        }
+
+        public string GetMarkdown() => _markdownBuilder.ToString();
+
+        public void AddLine(string markdownText)
+        {
+            _markdownBuilder.AppendLine($"{markdownText}");
+        }
+
+        public void StartSection(string title)
+        {
+            _sectionCount++;
+            _markdownBuilder.Append(new string('#', _sectionCount));
+            _markdownBuilder.Append(" ");
+            _markdownBuilder.Append(title.Trim());
+            _markdownBuilder.AppendLine();
+            _markdownBuilder.AppendLine();
+        }
+
+        public void EndSection()
+        {
+            _sectionCount--;
+            _markdownBuilder.AppendLine();
+        }
+
+        public void SetBackground(string imageResource)
+        {
+            _markdownBuilder.AppendLine($"![bg]({imageResource})");
+            _markdownBuilder.AppendLine();
+        }
+
+        public void AddComment(string comment)
+        {
+            _markdownBuilder.AppendLine($"<!-- {comment} -->");
+            _markdownBuilder.AppendLine();
+        }
+
+        public void AddSeparator()
+        {
+            _markdownBuilder.AppendLine($"---");
+            _markdownBuilder.AppendLine();
+        }
+    }
+}

--- a/CelRuntime/TextFile.cs
+++ b/CelRuntime/TextFile.cs
@@ -1,15 +1,24 @@
-﻿using System;
+﻿using CelUtilities.ErrorHandling;
+using CelUtilities.Resources;
+using System;
 using System.IO;
 
 namespace CelRuntime
 {
     public class TextFile
     {
-        public string ReadText(string resourceFile)
+        public string ReadText(string resourceKey)
         {
             try
             {
-                var path = Environment.GetPath(resourceFile);
+                var pathResult = ResourceUtils.GetResourcePath(resourceKey, Environment.ProjectFolder, false);
+                if (pathResult is ErrorResult<string> pathError)
+                {
+                    Environment.PrintError(pathError.Message);
+                    return string.Empty;
+                }
+                var path = pathResult.Data;
+
                 var text = File.ReadAllText(path);
                 return text;
             }
@@ -21,16 +30,25 @@ namespace CelRuntime
             return string.Empty;
         }
 
-        public void WriteText(string resourceFile, string text)
+        public void WriteText(string resourceKey, string text)
         {
             try
             {
-                var path = Environment.GetPath(resourceFile);
+                var pathResult = ResourceUtils.GetResourcePath(resourceKey, Environment.ProjectFolder, false);
+                if (pathResult is ErrorResult<string> pathError)
+                {
+                    Environment.PrintError(pathError.Message);
+                    return;
+                }
+                var path = pathResult.Data;
+
+                var folder = Path.GetDirectoryName(path);
+                Directory.CreateDirectory(folder);
+
                 File.WriteAllText(path, text);
             }
             catch (Exception ex)
             {
-                // Todo: Log errors using the Environment.Log thingy
                 Environment.PrintError(ex.ToString());
             }
         }

--- a/CelUtilities/Resources/ResourceUtils.cs
+++ b/CelUtilities/Resources/ResourceUtils.cs
@@ -1,0 +1,64 @@
+﻿using CelUtilities.ErrorHandling;
+using System;
+using System.IO;
+
+namespace CelUtilities.Resources
+{
+    public static class ResourceUtils
+    {
+        /// <summary>
+        /// Returns an absolute path to a file in the project folder for the specified resourceKey.
+        /// The resource key must start with:
+        ///   '@' : Project folder resource
+        ///   '#' : Relative or absolute path
+        /// </summary>
+        public static Result<string> GetResourcePath(string resourceKey, string projectFolder, bool mustExist)
+        {
+            if (string.IsNullOrEmpty(resourceKey))
+            {
+                return new ErrorResult<string>($"Failed to get resource path. Resource key is empty.");
+            }
+
+            string path = null;
+            if (resourceKey.StartsWith("@"))
+            {
+                // Resource in the project folder, map it to an absolute path
+                try
+                {
+                    var relativePath = resourceKey.Substring(1);
+                    var combined = Path.Combine(projectFolder, relativePath);
+                    path = Path.GetFullPath(combined);
+                }
+                catch (Exception ex)
+                {
+                    return new ErrorResult<string>($"Failed to get resource path. {ex}");
+                }
+            }
+            else if (resourceKey.StartsWith("#"))
+            {
+                // Resource in the file system
+                try
+                {
+                    path = resourceKey.Substring(1);
+                    path = Path.GetFullPath(path);
+                }
+                catch (Exception ex)
+                {
+                    return new ErrorResult<string>($"Failed to get resource path. {ex}");
+                }
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return new ErrorResult<string>($"Failed to get path for resource key: {resourceKey}");
+            }
+
+            if (mustExist && !Path.Exists(path))
+            {
+                return new ErrorResult<string>($"Failed to get path for resource '{resourceKey}'. Resource does not exist at '{path}'");
+            }
+
+            return new SuccessResult<string>(path);
+        }
+    }
+}

--- a/Celbridge/Celbridge/Models/CelMixins/BasicMixin.cs
+++ b/Celbridge/Celbridge/Models/CelMixins/BasicMixin.cs
@@ -196,6 +196,8 @@
 
             public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
 
+            public override string ReturnType => nameof(PrimitivesMixin.String);
+
             public override InstructionSummary GetInstructionSummary(PropertyContext context)
             {
                 return new InstructionSummary(

--- a/Celbridge/Celbridge/Models/CelMixins/ChatMixin.cs
+++ b/Celbridge/Celbridge/Models/CelMixins/ChatMixin.cs
@@ -36,6 +36,9 @@
 
             public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
 
+            public override string ReturnType => nameof(PrimitivesMixin.String);
+
+
             public override InstructionSummary GetInstructionSummary(PropertyContext context)
             {
                 return new InstructionSummary(

--- a/Celbridge/Celbridge/Models/CelMixins/FileMixin.cs
+++ b/Celbridge/Celbridge/Models/CelMixins/FileMixin.cs
@@ -14,6 +14,8 @@
 
             public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
 
+            public override string ReturnType => nameof(PrimitivesMixin.String);
+
             public override InstructionSummary GetInstructionSummary(PropertyContext context)
             {
                 return new InstructionSummary(
@@ -23,6 +25,7 @@
 
             public override Result<string> GenerateCode()
             {
+                var resource = Resource.GetSummary();
                 var code = $"_env.TextFile.ReadText(\"{Resource}\");";
                 return new SuccessResult<string>(code);
             }

--- a/Celbridge/Celbridge/Models/CelMixins/MarkdownMixin.cs
+++ b/Celbridge/Celbridge/Models/CelMixins/MarkdownMixin.cs
@@ -1,0 +1,149 @@
+﻿namespace Celbridge.Models.CelMixins
+{
+    public class MarkdownMixin : ICelMixin
+    {
+        public Dictionary<string, Type> InstructionTypes { get; } = new()
+        {
+            { nameof(ClearMarkdown), typeof(ClearMarkdown) },
+            { nameof(StartSection), typeof(StartSection) },
+            { nameof(EndSection), typeof(EndSection) },
+            { nameof(AddLine), typeof(AddLine) },
+            { nameof(AddComment), typeof(AddComment) },
+            { nameof(AddSeparator), typeof(AddSeparator) },
+            { nameof(SetBackground), typeof(SetBackground) },
+            { nameof(GetMarkdown), typeof(GetMarkdown) },
+        };
+
+        public record ClearMarkdown : InstructionBase
+        {
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override Result<string> GenerateCode()
+            {
+                var code = $"_env.Markdown.ClearMarkdown();";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record StartSection : InstructionBase
+        {
+            public StringExpression Title { get; set; } = new();
+
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+            public override IndentModifier IndentModifier => IndentModifier.PostIncrement;
+
+            public override InstructionSummary GetInstructionSummary(PropertyContext context)
+            {
+                return new InstructionSummary(
+                    SummaryFormat: SummaryFormat.PlainText,
+                    SummaryText: $"{Title.GetSummary()}");
+            }
+
+            public override Result<string> GenerateCode()
+            {
+                var title = Title.GetSummary();
+                var code = $"_env.Markdown.StartSection({title});";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record EndSection : InstructionBase
+        {
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+            public override IndentModifier IndentModifier => IndentModifier.PreDecrement;
+
+            public override Result<string> GenerateCode()
+            {
+                var code = $"_env.Markdown.EndSection();";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record AddLine : InstructionBase
+        {
+            public StringExpression MarkdownText { get; set; } = new();
+
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override InstructionSummary GetInstructionSummary(PropertyContext context)
+            {
+                return new InstructionSummary(
+                    SummaryFormat: SummaryFormat.PlainText,
+                    SummaryText: $"{MarkdownText.GetSummary()}");
+            }
+
+            public override Result<string> GenerateCode()
+            {
+                var markdownText = MarkdownText.GetSummary();
+                var code = $"_env.Markdown.AddLine({markdownText});";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record AddComment : InstructionBase
+        {
+            public StringExpression Comment { get; set; } = new();
+
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override InstructionSummary GetInstructionSummary(PropertyContext context)
+            {
+                return new InstructionSummary(
+                    SummaryFormat: SummaryFormat.PlainText,
+                    SummaryText: $"{Comment.GetSummary()}");
+            }
+
+            public override Result<string> GenerateCode()
+            {
+                var comment = Comment.GetSummary();
+                var code = $"_env.Markdown.AddComment({comment});";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record AddSeparator : InstructionBase
+        {
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override Result<string> GenerateCode()
+            {
+                var code = $"_env.Markdown.AddSeparator();";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record SetBackground : InstructionBase
+        {
+            public StringExpression ImageResource { get; set; } = new();
+
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override InstructionSummary GetInstructionSummary(PropertyContext context)
+            {
+                return new InstructionSummary(
+                    SummaryFormat: SummaryFormat.PlainText,
+                    SummaryText: $"{ImageResource.GetSummary()}");
+            }
+
+            public override Result<string> GenerateCode()
+            {
+                var imageResource = ImageResource.GetSummary();
+                var code = $"_env.Markdown.SetBackground({imageResource});";
+                return new SuccessResult<string>(code);
+            }
+        }
+
+        public record GetMarkdown : InstructionBase
+        {
+            public override InstructionCategory InstructionCategory => InstructionCategory.FunctionCall;
+
+            public override string ReturnType => nameof(PrimitivesMixin.String);
+
+            public override Result<string> GenerateCode()
+            {
+                var code = $"_env.Markdown.GetMarkdown();";
+                return new SuccessResult<string>(code);
+            }
+        }
+    }
+}

--- a/Celbridge/Celbridge/Models/CelTypes/BasicCelType.cs
+++ b/Celbridge/Celbridge/Models/CelTypes/BasicCelType.cs
@@ -19,6 +19,7 @@ namespace Celbridge.Models.CelTypes
                 new BasicMixin(),
                 new FileMixin(),
                 new ChatMixin(),
+                new MarkdownMixin(),
             };
         }
     }

--- a/Celbridge/Celbridge/Models/IInstruction.cs
+++ b/Celbridge/Celbridge/Models/IInstruction.cs
@@ -29,6 +29,9 @@ namespace Celbridge.Models
         [JsonIgnore]
         PipeState PipeState { get; set; }
 
+        [JsonIgnore]
+        string ReturnType { get; }
+
         InstructionSummary GetInstructionSummary(PropertyContext Context);
 
         Result<string> GenerateCode();

--- a/Celbridge/Celbridge/Models/InstructionBase.cs
+++ b/Celbridge/Celbridge/Models/InstructionBase.cs
@@ -1,5 +1,4 @@
 ﻿using Celbridge.Utils;
-using CommunityToolkit.Diagnostics;
 using Newtonsoft.Json;
 
 namespace Celbridge.Models
@@ -15,6 +14,8 @@ namespace Celbridge.Models
         public virtual IndentModifier IndentModifier => IndentModifier.NoChange;
 
         public virtual PipeState PipeState { get; set; }
+
+        public virtual string ReturnType => string.Empty;
 
         public virtual string Description
         {

--- a/Celbridge/Celbridge/Tasks/UpdateCelInstructionsTask.cs
+++ b/Celbridge/Celbridge/Tasks/UpdateCelInstructionsTask.cs
@@ -51,19 +51,9 @@ namespace Celbridge.Tasks
                         // Todo: Can we use a c# type instead of a string for the return type? This seems a bit flaky.
                         producerTypeName = callInstruction.Arguments.CelSignature.ReturnType;
                     }
-                    else if (nextInstruction is FileMixin.Read readInstruction)
-                    {
-                        // Todo: This is very hard coded, replace with a generic mechanism that works for any instruction
-                        // A PipeProducerType property would do the trick
-                        producerTypeName = nameof(PrimitivesMixin.String);
-                    }
-                    else if (nextInstruction is ChatMixin.Ask askInstruction)
-                    {
-                        producerTypeName = nameof(PrimitivesMixin.String);
-                    }
-                    else if (nextInstruction is BasicMixin.StartProcess startProcess)
-                    {
-                        producerTypeName = nameof(PrimitivesMixin.String);
+                    else if (nextInstruction is not null)
+                    { 
+                        producerTypeName = nextInstruction.ReturnType;
                     }
 
                     // Check if the type of the consuming instruction matches the type of the producing instruction


### PR DESCRIPTION
Add a property to specify Instruction return type (to allow piping).
Implement '@' and '+' markup to indicate project folder relative and path resources respectively. 

Fixes #44