### PR TITLE
Fix unpackaged Windows builds to support HotReload

### DIFF
--- a/Celbridge/Celbridge.Services/ServiceConfiguration.cs
+++ b/Celbridge/Celbridge.Services/ServiceConfiguration.cs
@@ -15,9 +15,39 @@ public static class ServiceConfiguration
         // Register services
         //
         services.AddSingleton<INavigationService, NavigationService>();
-        services.AddTransient<ISettingsGroup, SettingsGroup>();
         services.AddSingleton<IEditorSettings, EditorSettings>();
         services.AddSingleton<IMessengerService, MessengerService>();
         services.AddSingleton<ILoggingService, LoggingService>();
+
+        if (IsStorageAPIAvailable)
+        {
+            services.AddTransient<ISettingsGroup, SettingsGroup>();
+        }
+        else
+        {
+            services.AddTransient<ISettingsGroup, TempSettingsGroup>();
+        }
+    }
+
+    private static bool IsStorageAPIAvailable
+    {
+        get
+        {
+#if WINDOWS
+            try
+            {
+                var package = Windows.ApplicationModel.Package.Current;
+                return package is not null;
+            }
+            catch (InvalidOperationException)
+            {
+                // Exception thrown if the app is unpackaged
+                return false;
+            }
+#else
+            return true;
+#endif
+        }
+
     }
 }

--- a/Celbridge/Celbridge.Services/Settings/SettingsGroup.cs
+++ b/Celbridge/Celbridge.Services/Settings/SettingsGroup.cs
@@ -5,6 +5,11 @@ using Windows.Storage;
 
 namespace Celbridge.Services.Settings;
 
+/// <summary>
+/// Persists a set of key value properties using the Uno Platform Storage API.
+/// The Storage API is not available in unpackaged Windows builds, but you can use TempSettingsGroup as a non-persistant
+/// replacement for unit tests, etc.
+/// </summary>
 public class SettingsGroup : ISettingsGroup
 {
     private ILoggingService _loggingService;

--- a/Celbridge/Celbridge.Services/Settings/TempSettingsGroup.cs
+++ b/Celbridge/Celbridge.Services/Settings/TempSettingsGroup.cs
@@ -1,15 +1,13 @@
-﻿using Celbridge.BaseLibrary.Core;
-using Celbridge.BaseLibrary.Settings;
-using CommunityToolkit.Diagnostics;
+﻿using Celbridge.BaseLibrary.Settings;
 using Newtonsoft.Json;
 
-namespace Celbridge.Tests.Fakes;
+namespace Celbridge.Services.Settings;
 
 /// <summary>
-/// A fake implementation of ISettingsGroup for use with automated tests.
-/// We can't use the real SettingsGroup class because it has a dependency on Windows.Storage which isn't supported for unit testing.
+/// A non-persistent implementation of ISettingsGroup for use with automated tests and other unpackaged builds.
+/// Any properties stored in this class are discarded after the application exits.
 /// </summary>
-public class FakeSettingsGroup : ISettingsGroup
+public class TempSettingsGroup : ISettingsGroup
 {
     private string? _groupName;
     private Dictionary<string, object> _container = new();

--- a/Celbridge/Celbridge.Tests/EditorSettingsTests.cs
+++ b/Celbridge/Celbridge.Tests/EditorSettingsTests.cs
@@ -1,6 +1,5 @@
 ﻿using Celbridge.BaseLibrary.Settings;
 using Celbridge.Services.Settings;
-using Celbridge.Tests.Fakes;
 using CommunityToolkit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,7 +15,7 @@ public class EditorSettingsTests
     {
         var services = new ServiceCollection();
 
-        services.AddTransient<ISettingsGroup, FakeSettingsGroup>();
+        services.AddTransient<ISettingsGroup, TempSettingsGroup>();
         services.AddSingleton<IEditorSettings, EditorSettings>();
 
         _serviceProvider = services.BuildServiceProvider();
@@ -27,24 +26,21 @@ public class EditorSettingsTests
     {}
 
     [Test]
-    public void ICanCanGetAndSetTheApplicationTheme()
+    public void ICanCanGetAndSetEditorSettings()
     {
         Guard.IsNotNull(_serviceProvider);
 
         var editorSettings = _serviceProvider.GetRequiredService<IEditorSettings>();
 
-        // Get the default value
-        editorSettings.Theme.Should().Be(ApplicationColorTheme.Light.ToString());
-
-        // Set a new value
-        editorSettings.Theme = ApplicationColorTheme.Dark.ToString();
-        editorSettings.Theme.Should().Be(ApplicationColorTheme.Dark.ToString());
-
-        // Reset the settings
-        editorSettings.Reset();
-        editorSettings.Theme.Should().Be(ApplicationColorTheme.Light.ToString());
-
         // Check the default value system is working
+        editorSettings.LeftPanelVisible.Should().BeTrue();
+
+        // Set a property
+        editorSettings.LeftPanelVisible = false;
+        editorSettings.LeftPanelVisible.Should().BeFalse();
+
+        // Reset the property to default
+        editorSettings.Reset();
         editorSettings.LeftPanelVisible.Should().BeTrue();
     }
 }


### PR DESCRIPTION
Rename FakeSettingsGroup to TempSettingsGroup and use it when running an unpackaged Windows build.