### PR TITLE
Simplify event handling for panel visibility changes

### DIFF
--- a/Celbridge/Celbridge.BaseLibrary/UserInterface/UserInterfaceMessages.cs
+++ b/Celbridge/Celbridge.BaseLibrary/UserInterface/UserInterfaceMessages.cs
@@ -22,8 +22,3 @@ public record WorkspaceLoadedMessage(IWorkspaceService WorkspaceService);
 /// Sent when the workspace has been unloaded.
 /// </summary>
 public record WorkspaceUnloadedMessage();
-
-/// <summary>
-/// Sent when any workspace panel's visibility has changed.
-/// </summary>
-public record WorkspacePanelVisibilityChangedMessage(bool IsLeftPanelVisible, bool IsRightPanelVisible, bool IsBottomPanelVisible);

--- a/Celbridge/CoreExtensions/Celbridge.Documents/Views/DocumentsPanel.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Documents/Views/DocumentsPanel.cs
@@ -1,5 +1,4 @@
 ﻿using Celbridge.Documents.ViewModels;
-using Microsoft.Extensions.Localization;
 
 namespace Celbridge.Documents.Views;
 
@@ -39,6 +38,8 @@ public sealed partial class DocumentsPanel : UserControl
         this.DataContext(ViewModel, (userControl, vm) => userControl
             .Content(_tabView));
 
+        UpdateTabstripEnds();
+
         // Listen for property changes on the ViewModel
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
@@ -62,34 +63,37 @@ public sealed partial class DocumentsPanel : UserControl
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(ViewModel.IsLeftPanelVisible))
+        if (e.PropertyName == nameof(ViewModel.IsLeftPanelVisible) ||
+            e.PropertyName == nameof(ViewModel.IsRightPanelVisible))
         {
-            // When the left and right workspace panels are visible, the panel visibility toggle buttons overlap the
-            // TabView in the center panel. To fix this, we dynamically add an invisible TabStripHeader and TabStripFooter
-            // which offsets the position of the tabs so that they don't overlap these buttons.
+            UpdateTabstripEnds();
+        }
+    }
 
-            if (ViewModel.IsLeftPanelVisible)
-            {
-                _tabView.TabStripHeader = null;
-            }
-            else
-            {
-                _tabView.TabStripHeader = new Grid()
-                    .Width(96);
-            }
+    private void UpdateTabstripEnds()
+    {
+        // When the left and right workspace panels are hidden, the panel visibility toggle buttons may overlap the
+        // TabStrip at the top of the center panel. To fix this, we dynamically add an invisible TabStripHeader and
+        // TabStripFooter which adjusts the position of the tabs so that they don't overlap the toggle buttons.
+
+        if (ViewModel.IsLeftPanelVisible)
+        {
+            _tabView.TabStripHeader = null;
+        }
+        else
+        {
+            _tabView.TabStripHeader = new Grid()
+                .Width(96);
         }
 
-        if (e.PropertyName == nameof(ViewModel.IsRightPanelVisible))
+        if (ViewModel.IsRightPanelVisible)
         {
-            if (ViewModel.IsRightPanelVisible)
-            {
-                _tabView.TabStripFooter = null;
-            }
-            else
-            {
-                _tabView.TabStripFooter = new Grid()
-                    .Width(48);
-            }
+            _tabView.TabStripFooter = null;
+        }
+        else
+        {
+            _tabView.TabStripFooter = new Grid()
+                .Width(48);
         }
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Workspace/ViewModels/WorkspacePageViewModel.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Workspace/ViewModels/WorkspacePageViewModel.cs
@@ -27,33 +27,12 @@ public partial class WorkspacePageViewModel : ObservableObject
 
         _editorSettings = editorSettings;
         _editorSettings.PropertyChanged += OnSettings_PropertyChanged;
-
-        PropertyChanged += OnViewModel_PropertyChanged;
     }
 
     private void OnSettings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         // Forward editor setting change notifications to this View Model class
         OnPropertyChanged(e);
-    }
-
-    private void OnViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        switch (e.PropertyName)
-        {
-            case nameof(IsLeftPanelVisible):
-            case nameof(IsRightPanelVisible):
-            case nameof(IsBottomPanelVisible):
-
-                // Notify listeners that the visibility state of the workspace panels has changed
-                var message = new WorkspacePanelVisibilityChangedMessage(
-                    IsLeftPanelVisible: this.IsLeftPanelVisible,
-                    IsRightPanelVisible: this.IsRightPanelVisible,
-                    IsBottomPanelVisible: this.IsBottomPanelVisible);
-                _messengerService.Send(message);
-
-                break;
-        }
     }
 
     public float LeftPanelWidth
@@ -131,17 +110,11 @@ public partial class WorkspacePageViewModel : ObservableObject
         // the WorkspaceService.
         var panels = workspaceService.CreateWorkspacePanels();
         WorkspacePanelsCreated?.Invoke(panels);
-
-        // Send a "fake" panel visibility change message so that the workspace panels can configure
-        // themselves based on the initial panel visibility state.
-        OnPropertyChanged(nameof(IsLeftPanelVisible));
-        OnPropertyChanged(nameof(IsRightPanelVisible));
     }
 
     public void OnWorkspacePageUnloaded()
     {
         _editorSettings.PropertyChanged -= OnSettings_PropertyChanged;
-        PropertyChanged -= OnViewModel_PropertyChanged;
 
         // Notify listeners that the workspace page has been unloaded.
         // All workspace related resources must be released at this point.


### PR DESCRIPTION
DocumentsPanel observes panel visibility changes directly via the EditorSettings, so there's no need for a dedicated message type.