### PR TITLE
Use a token system to control visibility of Progress Dialog

### DIFF
--- a/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IDialogFactory.cs
+++ b/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IDialogFactory.cs
@@ -9,7 +9,7 @@ public interface IDialogFactory
 
 
     /// <summary>
-    /// Create an Progress Dialog with configurable title..
+    /// Create an Progress Dialog.
     /// </summary>
-    IProgressDialog CreateProgressDialog(string titleText);
+    IProgressDialog CreateProgressDialog();
 }

--- a/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IDialogService.cs
+++ b/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IDialogService.cs
@@ -8,9 +8,16 @@ public interface IDialogService
     Task ShowAlertDialogAsync(string titleText, string messageText, string closeText);
 
     /// <summary>
-    /// Display a Progress Dialog with configurable title and cancel button text.
+    /// Aqcuire a progress dialog token.
+    /// The progress dialog will be displayed as long as any token is active, and will display the title of the
+    /// most recently acquired token that is still active. The progress dialog is temporarily hidden while any other type 
+    /// of dialog is displayed.
     /// </summary>
-    void ShowProgressDialog(string titleText);
+    IProgressDialogToken AcquireProgressDialog(string titleText);
 
-    void HideProgressDialog();
+    /// <summary>
+    /// Release a previously acquired progress dialog token.
+    /// The progress dialog is hidden when all tokens are released.
+    /// </summary>
+    void ReleaseProgressDialog(IProgressDialogToken token);
 }

--- a/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IProgressDialogToken.cs
+++ b/Celbridge/Celbridge.BaseLibrary/UserInterface/Dialog/IProgressDialogToken.cs
@@ -1,0 +1,19 @@
+﻿namespace Celbridge.BaseLibrary.UserInterface.Dialog;
+
+/// <summary>
+/// A token representing an active progress dialog.
+/// The progress dialog will be displayed as long as any token is active, and will display the title of 
+/// the most recently acquired token that is still active.
+/// </summary>
+public interface IProgressDialogToken
+{
+    /// <summary>
+    /// A unique identifier for this token.
+    /// </summary>
+    public Guid Token { get; }
+
+    /// <summary>
+    /// The title to display in the progress dialog when this token is active.
+    /// </summary>
+    public string DialogTitle { get; init; }
+}

--- a/Celbridge/Celbridge.Services/UserInterface/Dialog/ProgressDialogToken.cs
+++ b/Celbridge/Celbridge.Services/UserInterface/Dialog/ProgressDialogToken.cs
@@ -1,0 +1,12 @@
+﻿using Celbridge.BaseLibrary.UserInterface.Dialog;
+
+public record ProgressDialogToken : IProgressDialogToken
+{
+    public Guid Token { get; private set; } = Guid.NewGuid();
+    public string DialogTitle { get; init; }
+
+    public ProgressDialogToken(string DialogTitle)
+    {
+        this.DialogTitle = DialogTitle;
+    }
+}

--- a/Celbridge/Celbridge.ViewModels/Pages/StartPageViewModel.cs
+++ b/Celbridge/Celbridge.ViewModels/Pages/StartPageViewModel.cs
@@ -2,6 +2,7 @@
 using Celbridge.BaseLibrary.UserInterface.Navigation;
 using Celbridge.BaseLibrary.UserInterface;
 using Celbridge.BaseLibrary.Tasks;
+using Celbridge.BaseLibrary.UserInterface.Dialog;
 
 namespace Celbridge.ViewModels.Pages;
 
@@ -89,7 +90,7 @@ public partial class StartPageViewModel : ObservableObject
     {
         var dialogService = _userInterfaceService.DialogService;
 
-        dialogService.ShowProgressDialog("Some title");
+        dialogService.AcquireProgressDialog("Some title");
     }
 
     public ICommand ScheduleTaskCommand => new RelayCommand(ScheduleTask_Executed);
@@ -97,16 +98,16 @@ public partial class StartPageViewModel : ObservableObject
     {
         var dialogService = _userInterfaceService.DialogService;
 
-        _schedulerService.ScheduleFunction(async () =>
-        {
-            dialogService.ShowProgressDialog("Doing stuff");
-            await Task.Delay(1000);            
-            dialogService.HideProgressDialog();
-        });
+        IProgressDialogToken? token;
 
         _schedulerService.ScheduleFunction(async () =>
         {
+            token = dialogService.AcquireProgressDialog("Doing stuff");
+            await Task.Delay(1000);            
+            // Displaying this alert automatically suppresses the progress dialog until the alert is dismissed
             await dialogService.ShowAlertDialogAsync("Scheduled Alert", "An alert message", "Ok");
+            await Task.Delay(1000);
+            dialogService.ReleaseProgressDialog(token);
         });
     }
 }

--- a/Celbridge/Celbridge.Views/Dialogs/DialogFactory.cs
+++ b/Celbridge/Celbridge.Views/Dialogs/DialogFactory.cs
@@ -15,12 +15,9 @@ public class DialogFactory : IDialogFactory
         return dialog;
     }
 
-    public IProgressDialog CreateProgressDialog(string titleText)
+    public IProgressDialog CreateProgressDialog()
     {
         var dialog = ServiceLocator.ServiceProvider.GetRequiredService<IProgressDialog>();
-
-        dialog.TitleText = titleText;
- 
         return dialog;
     }
 }


### PR DESCRIPTION
The Progress Dialog is displayed while any valid tokens are active, and is hidden when there are no active tokens.
Displaying another dialog (e.g. the Alert Dialog) temporarily hides the Progress Dialog until the dialog is closed.