### PR TITLE
Store console log as records instead of just strings

### DIFF
--- a/Celbridge/CoreExtensions/Celbridge.Console/ConsoleLogItem.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Console/ConsoleLogItem.cs
@@ -1,0 +1,56 @@
+﻿namespace Celbridge.Console;
+
+public enum ConsoleLogType
+{
+    Command,
+    Info,
+    Warning,
+    Error,
+}
+
+public record ConsoleLogItem(ConsoleLogType LogType, string LogText, DateTime Timestamp)
+{
+    private const string ChevronRightGlyph = "\ue76C";
+    private const string InfoGlyph = "\ue946";
+    private const string WarningGlyph = "\ue7BA";
+    private const string ErrorGlyph = "\ue783";
+
+    public string Color
+    {
+        get
+        {
+            switch (LogType)
+            {
+                case ConsoleLogType.Command:
+                    return "LightBlue";
+                default:
+                case ConsoleLogType.Info:
+                    return "LightGreen";
+                case ConsoleLogType.Warning:
+                    return "Yellow";
+                case ConsoleLogType.Error:
+                    return "Red";
+
+            }
+        }
+    }
+
+    public string Glyph
+    {
+        get
+        {
+            switch (LogType)
+            {
+                case ConsoleLogType.Command:
+                    return ChevronRightGlyph;
+                default:
+                case ConsoleLogType.Info:
+                    return InfoGlyph;
+                case ConsoleLogType.Warning:
+                    return WarningGlyph;
+                case ConsoleLogType.Error:
+                    return ErrorGlyph;
+            }
+        }
+    }
+}

--- a/Celbridge/CoreExtensions/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
@@ -14,14 +14,14 @@ public partial class ConsolePanelViewModel : ObservableObject
     [ObservableProperty]
     private string _commandText = string.Empty;
 
-    private ObservableCollection<string> _outputItems = new ();
-    public ObservableCollection<string> OutputItems
+    private ObservableCollection<ConsoleLogItem> _consoleLogItems = new();
+    public ObservableCollection<ConsoleLogItem> ConsoleLogItems
     {
-        get => _outputItems;
+        get => _consoleLogItems;
         set
         {
-            _outputItems = value;
-            OnPropertyChanged(nameof(OutputItems));
+            _consoleLogItems = value;
+            OnPropertyChanged(nameof(ConsoleLogItems));
         }
     }
 
@@ -40,13 +40,16 @@ public partial class ConsolePanelViewModel : ObservableObject
     public ICommand ClearCommand => new RelayCommand(Clear_Executed);
     private void Clear_Executed()
     {
-        _outputItems.Clear();
+        _consoleLogItems.Clear();
     }
 
     public ICommand SubmitCommand => new RelayCommand(Submit_Executed);
     private void Submit_Executed()
     {
-        _outputItems.Add(CommandText);
+        _consoleLogItems.Add(new ConsoleLogItem(ConsoleLogType.Command, CommandText, DateTime.Now));
+
+        // _consoleLogItems.Add(new ConsoleLogItem(ConsoleLogType.Info, CommandText, DateTime.Now));
+
         _commandHistory.AddCommand(CommandText);
 
         CommandText = string.Empty;

--- a/Celbridge/CoreExtensions/Celbridge.Console/Views/ConsolePanel.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Console/Views/ConsolePanel.cs
@@ -7,6 +7,10 @@ namespace Celbridge.Console.Views;
 public sealed partial class ConsolePanel : UserControl
 {
     private const string StrokeEraseGlyph = "\ued60";
+    private const string ChevronRightGlyph = "\ue76C";
+    private const string InfoGlyph = "\ue946";
+    private const string WarningGlyph = "\ue7BA";
+    private const string ErrorGlyph = "\ue783";
 
     public LocalizedString Title => _stringLocalizer.GetString($"{nameof(ConsolePanel)}_{nameof(Title)}");
     public LocalizedString ClearButtonTooltip => _stringLocalizer.GetString($"{nameof(ConsolePanel)}_{nameof(ClearButtonTooltip)}");
@@ -55,15 +59,25 @@ public sealed partial class ConsolePanel : UserControl
             .Grid(row: 1)
             .Background(ThemeResource.Get<Brush>("PanelBackgroundBBrush"))
             .Content(new ListView()
-                .ItemTemplate(() =>
+                .ItemTemplate<ConsoleLogItem>(item =>
                 {
-                    var textBlock = new TextBlock()
-                        .Text(x => x.Bind(() => x))
-                        .Margin(0)
-                        .Padding(0);
-                    return textBlock;
+                    return new StackPanel()
+                        .Orientation(Orientation.Horizontal)
+                        .Children(
+                            new FontIcon()
+                                .FontFamily(fontFamily)
+                                .FontSize(12)
+                                .Foreground(() => item.Color)
+                                .VerticalAlignment(VerticalAlignment.Center)
+                                .Margin(0)
+                                .Glyph(() => item.Glyph),
+                            new TextBlock()
+                                .Text(() => item.LogText)
+                                .Margin(6, 0, 0, 0)
+                                .Padding(0)
+                            );
                 })
-                .ItemsSource(x => x.Bind(() => ViewModel.OutputItems).OneWay())
+                .ItemsSource(x => x.Bind(() => ViewModel.ConsoleLogItems).OneWay())
                 .ItemContainerStyle(new Style(typeof(ListViewItem))
                 {
                     Setters =


### PR DESCRIPTION
Records allow us to store richer information about each log item, such as timestamp, log type, stack traces, etc.