### PR TITLE
Handle errors when loading workspace page and view model

### DIFF
--- a/Celbridge/Celbridge.BaseLibrary/Workspace/IWorkspaceWrapper.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Workspace/IWorkspaceWrapper.cs
@@ -2,19 +2,21 @@
 
 /// <summary>
 /// Wrapper for the workspace service.
-/// The workspace service is only available when a project workspace is loaded.
+/// The workspace service is only available when a project is loaded.
 /// Use this wrapper to check if the workspace is loaded and to access it via dependency injection.
 /// </summary>
 public interface IWorkspaceWrapper
 {
     /// <summary>
-    /// Returns trues if a project workspace is currently loaded.
+    /// Returns true if the workspace page is currently loaded.
     /// </summary>
-    bool IsWorkspaceLoaded { get; }
+    bool IsWorkspacePageLoaded { get; }
 
     /// <summary>
-    /// The workspace that is currently loaded.
-    /// Attempting to access this property when no workspace is loaded will throw an InvalidOperationException.
+    /// Returns the workspace service for the currently loaded project.
+    /// This property is populated prior to the workspace page UI loading, so it can be accessed while the workspace 
+    /// is in the process of loading.
+    /// Attempting to access this property when no workspace service is present throws an InvalidOperationException.
     /// </summary>
     IWorkspaceService WorkspaceService { get; }
 }

--- a/Celbridge/CoreApplication/Celbridge.Logging/Services/ConsoleLogEventSink.cs
+++ b/Celbridge/CoreApplication/Celbridge.Logging/Services/ConsoleLogEventSink.cs
@@ -23,7 +23,7 @@ public class ConsoleLogEventSink : ILogEventSink
 
     public void Emit(LogEvent logEvent)
     {
-        if (!_workspaceWrapper.IsWorkspaceLoaded)
+        if (!_workspaceWrapper.IsWorkspacePageLoaded)
         {
             return;
         }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/LoadProjectCommand.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/LoadProjectCommand.cs
@@ -11,6 +11,8 @@ namespace Celbridge.ProjectAdmin.Commands;
 
 public class LoadProjectCommand : CommandBase, ILoadProjectCommand
 {
+    private const string HomePageName = "HomePage";
+
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly IProjectDataService _projectDataService;
     private readonly INavigationService _navigationService;
@@ -66,6 +68,9 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
             var okString = _stringLocalizer.GetString("DialogButton_Ok");
 
             await _dialogService.ShowAlertDialogAsync(titleString, bodyString, okString);
+
+            // Return to the home page so the user can decide what to do next
+            _navigationService.NavigateToPage(HomePageName);
 
             return Result.Fail($"Failed to load project: {ProjectPath}. {loadResult.Error}.");
         }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/UnloadProjectCommand.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/UnloadProjectCommand.cs
@@ -24,7 +24,7 @@ public class UnloadProjectCommand : CommandBase, IUnloadProjectCommand
 
     public override async Task<Result> ExecuteAsync()
     {
-        if (!_workspaceWrapper.IsWorkspaceLoaded && _projectDataService.LoadedProjectData is null)
+        if (!_workspaceWrapper.IsWorkspacePageLoaded && _projectDataService.LoadedProjectData is null)
         {
             // We're already in the desired state so we can early out.
             return Result.Ok();

--- a/Celbridge/CoreApplication/Celbridge.UserInterface/Services/WorkspaceWrapper.cs
+++ b/Celbridge/CoreApplication/Celbridge.UserInterface/Services/WorkspaceWrapper.cs
@@ -11,6 +11,7 @@ public class WorkspaceWrapper : IWorkspaceWrapper
     {
         _messengerService = messengerService;
         _messengerService.Register<WorkspaceServiceCreatedMessage>(this, OnWorkspaceServiceCreated);
+        _messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoadedMessage);
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloadedMessage);
     }
 
@@ -22,14 +23,20 @@ public class WorkspaceWrapper : IWorkspaceWrapper
         _workspaceService = loadedMessage.WorkspaceService;
     }
 
+    private void OnWorkspaceLoadedMessage(object recipient, WorkspaceLoadedMessage message)
+    {
+        IsWorkspacePageLoaded = true;
+    }
+
     private void OnWorkspaceUnloadedMessage(object recipient, WorkspaceUnloadedMessage message)
     {
         // Clear the reference to the workspace service when the workspace is unloaded.
         Guard.IsNotNull(_workspaceService);
         _workspaceService = null;
+        IsWorkspacePageLoaded = false;
     }
 
-    public bool IsWorkspaceLoaded => _workspaceService is not null;
+    public bool IsWorkspacePageLoaded { get; private set; }
 
     public IWorkspaceService WorkspaceService
     {
@@ -37,7 +44,7 @@ public class WorkspaceWrapper : IWorkspaceWrapper
         {
             if (_workspaceService is null)
             {
-                throw new InvalidOperationException("Failed to acquire workspace because no project is loaded");
+                throw new InvalidOperationException("Failed to acquire workspace because no workspace is loaded");
             }
             return _workspaceService;
         }

--- a/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/MainPageViewModel.cs
+++ b/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/MainPageViewModel.cs
@@ -51,7 +51,7 @@ public partial class MainPageViewModel : ObservableObject, INavigationProvider
         _editorSettings = editorSettings;
     }
 
-    public bool IsWorkspaceLoaded => _workspaceWrapper.IsWorkspaceLoaded;
+    public bool IsWorkspaceLoaded => _workspaceWrapper.IsWorkspacePageLoaded;
 
     public event Func<Type, object, Result>? OnNavigate;
 

--- a/Celbridge/CoreExtensions/Celbridge.Project/Commands/RefreshResourceTreeCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Commands/RefreshResourceTreeCommand.cs
@@ -16,7 +16,7 @@ public class RefreshResourceTreeCommand : CommandBase, IRefreshResourceTreeComma
 
     public override async Task<Result> ExecuteAsync()
     {
-        if (!_workspaceWrapper.IsWorkspaceLoaded)
+        if (!_workspaceWrapper.IsWorkspacePageLoaded)
         {
             return Result.Fail($"Failed to execute {nameof(RefreshResourceTreeCommand)} because workspace is not loaded");
         }

--- a/Celbridge/CoreExtensions/Celbridge.Workspace/Commands/SaveWorkspaceStateCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Workspace/Commands/SaveWorkspaceStateCommand.cs
@@ -17,7 +17,7 @@ public class SaveWorkspaceStateCommand : CommandBase, ISaveWorkspaceStateCommand
 
     public override async Task<Result> ExecuteAsync()
     {
-        if (!_workspaceWrapper.IsWorkspaceLoaded)
+        if (!_workspaceWrapper.IsWorkspacePageLoaded)
         {
             return Result.Fail("Failed to Save Workspace State because workspace is not loaded");
         }


### PR DESCRIPTION
Use a cancellation token to indicate when the WorkpaceViewModel encounters a fatal error loading the workspace page and content.