### PR TITLE
Use "Path" and "ResourcePath" consistently in variable names

### DIFF
--- a/Celbridge/Celbridge.BaseLibrary/Project/IAddFileCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IAddFileCommand.cs
@@ -8,7 +8,7 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IAddFileCommand : IExecutableCommand
 {
     /// <summary>
-    /// Project-relative path to the new file.
+    /// Resource path for the new file to create.
     /// </summary>
-    string FilePath { get; set; }
+    string ResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IAddFolderCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IAddFolderCommand.cs
@@ -8,7 +8,7 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IAddFolderCommand : IExecutableCommand
 {
     /// <summary>
-    /// Project-relative path to the new folder.
+    /// Resource path for the new folder to create.
     /// </summary>
-    string FolderPath { get; set; }
+    string ResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IDeleteFileCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IDeleteFileCommand.cs
@@ -8,7 +8,7 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IDeleteFileCommand : IExecutableCommand
 {
     /// <summary>
-    /// Project-relative path to the file to delete.
+    /// Resource path for the file to delete.
     /// </summary>
-    string FilePath { get; set; }
+    string ResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IDeleteFolderCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IDeleteFolderCommand.cs
@@ -8,7 +8,7 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IDeleteFolderCommand : IExecutableCommand
 {
     /// <summary>
-    /// Project-relative path to the folder to delete.
+    /// Resource path for the folder to delete.
     /// </summary>
-    string FolderPath { get; set; }
+    string ResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/ILoadProjectCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/ILoadProjectCommand.cs
@@ -3,9 +3,9 @@
 namespace Celbridge.BaseLibrary.Project;
 
 /// <summary>
-/// Load the project at the specified path.
+/// Load the project file at the specified path.
 /// </summary>
 public interface ILoadProjectCommand : IExecutableCommand
 {
-    string ProjectPath { get; set; }
+    string ProjectFilePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IMoveFileCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IMoveFileCommand.cs
@@ -8,12 +8,12 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IMoveFileCommand : IExecutableCommand
 {
     /// <summary>
-    /// The file resource to move.
+    /// Resource path of the file to be moved.
     /// </summary>
-    string FromFilePath { get; set; }
+    string FromResourcePath { get; set; }
 
     /// <summary>
-    /// Path to move the file resource to.
+    /// Resource path to move the file to.
     /// </summary>
-    string ToFilePath { get; set; }
+    string ToResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IMoveFolderCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IMoveFolderCommand.cs
@@ -8,12 +8,12 @@ namespace Celbridge.BaseLibrary.Project;
 public interface IMoveFolderCommand : IExecutableCommand
 {
     /// <summary>
-    /// Project-relative path to the folder to move.
+    /// Resource path of the folder to be moved.
     /// </summary>
-    string FromFolderPath { get; set; }
+    string FromResourcePath { get; set; }
 
     /// <summary>
-    /// Project-relative path to move the folder resource to
+    /// Resource path to move the folder to.
     /// </summary>
-    string ToFolderPath { get; set; }
+    string ToResourcePath { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IProjectDataService.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IProjectDataService.cs
@@ -23,7 +23,7 @@ public interface IProjectDataService
     /// <summary>
     /// Load the project file at the specified path.
     /// </summary>
-    Result LoadProjectData(string projectPath);
+    Result LoadProjectData(string projectFilePath);
 
     /// <summary>
     /// Unloads the currently loaded project.

--- a/Celbridge/Celbridge.BaseLibrary/Resources/IResourceRegistry.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Resources/IResourceRegistry.cs
@@ -13,20 +13,21 @@ public interface IResourceRegistry
     ObservableCollection<IResource> Resources { get; }
 
     /// <summary>
-    /// Returns the project relative path for a resource.
+    /// Returns the resource path for a resource.
     /// </summary>
     string GetResourcePath(IResource resource);
 
     /// <summary>
     /// Returns the absolute path for a resource.
+    /// The path uses the directory separator character of the current platform.
     /// </summary>
-    string GetAbsolutePath(IResource resource);
+    string GetPath(IResource resource);
 
     /// <summary>
-    /// Returns the resource corresponding a project relative path.
+    /// Returns the resource at the specified resource path.
     /// Fails if no matching resource is found.
     /// </summary>
-    Result<IResource> GetResourceAtPath(string folderPath);
+    Result<IResource> GetResource(string resourcePath);
 
     /// <summary>
     /// Updates the registry to mirror the current state of the resources in the project folder.
@@ -45,7 +46,7 @@ public interface IResourceRegistry
     void SetExpandedFolders(List<string> expandedFolders);
 
     /// <summary>
-    /// Returns true if the folder resource at the specified path is expanded.
+    /// Returns true if the folder at the specified resource path is expanded.
     /// </summary>
-    public bool IsFolderExpanded(string folderPath);
+    public bool IsFolderExpanded(string resourcePath);
 }

--- a/Celbridge/Celbridge.BaseLibrary/Utilities/IUtilityService.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Utilities/IUtilityService.cs
@@ -14,9 +14,9 @@ public interface IUtilityService
     bool IsValidResourcePath(string resourcePath);
 
     /// <summary>
-    /// Returns true if the string represents a valid path segment.
+    /// Returns true if the string represents a valid resource path segment.
     /// </summary>
-    bool IsValidPathSegment(string segment);
+    bool IsValidResourcePathSegment(string resourcePathSegment);
 
     /// <summary>
     /// Returns a path to a randomly named file in temporary storage.

--- a/Celbridge/Celbridge.Tests/ResourceRegistryTests.cs
+++ b/Celbridge/Celbridge.Tests/ResourceRegistryTests.cs
@@ -7,31 +7,31 @@ namespace Celbridge.Tests;
 [TestFixture]
 public class ResourceRegistryTests
 {
-    private string? _resourceFolder;
+    private string? _resourceFolderPath;
 
     [SetUp]
     public void Setup()
     {
-        _resourceFolder = Path.Combine(Path.GetTempPath(), $"Celbridge/{nameof(ResourceRegistryTests)}");
-        if (Directory.Exists(_resourceFolder))
+        _resourceFolderPath = Path.Combine(Path.GetTempPath(), $"Celbridge/{nameof(ResourceRegistryTests)}");
+        if (Directory.Exists(_resourceFolderPath))
         {
-            Directory.Delete(_resourceFolder, true);
+            Directory.Delete(_resourceFolderPath, true);
         }
     }
 
     [TearDown]
     public void TearDown()
     {
-        if (Directory.Exists(_resourceFolder))
+        if (Directory.Exists(_resourceFolderPath))
         {
-            Directory.Delete(_resourceFolder!, true);
+            Directory.Delete(_resourceFolderPath!, true);
         }
     }
 
     [Test]
     public void ICanScanFileAndFolderResources()
     {
-        Guard.IsNotNull(_resourceFolder);
+        Guard.IsNotNull(_resourceFolderPath);
 
         const string FolderNameA = "FolderA";
         const string FileNameA = "FileA.txt";
@@ -43,26 +43,26 @@ public class ResourceRegistryTests
         // Create some files and folders on disk
         //
 
-        Directory.CreateDirectory(_resourceFolder);
-        Directory.Exists(_resourceFolder).Should().BeTrue();
+        Directory.CreateDirectory(_resourceFolderPath);
+        Directory.Exists(_resourceFolderPath).Should().BeTrue();
 
-        var resourceFileA = Path.Combine(_resourceFolder, FileNameA);
-        File.WriteAllText(resourceFileA, FileContents);
-        File.Exists(resourceFileA).Should().BeTrue();
+        var filePathA = Path.Combine(_resourceFolderPath, FileNameA);
+        File.WriteAllText(filePathA, FileContents);
+        File.Exists(filePathA).Should().BeTrue();
 
-        var resourceFolder = Path.Combine(_resourceFolder, FolderNameA);
-        Directory.CreateDirectory(resourceFolder);
-        Directory.Exists(resourceFolder).Should().BeTrue();
+        var folderPathA = Path.Combine(_resourceFolderPath, FolderNameA);
+        Directory.CreateDirectory(folderPathA);
+        Directory.Exists(folderPathA).Should().BeTrue();
 
-        var resourceFileB = Path.Combine(_resourceFolder, FolderNameA, FileNameB);
-        File.WriteAllText(resourceFileB, FileContents);
-        File.Exists(resourceFileB).Should().BeTrue();
+        var filePathB = Path.Combine(_resourceFolderPath, FolderNameA, FileNameB);
+        File.WriteAllText(filePathB, FileContents);
+        File.Exists(filePathB).Should().BeTrue();
 
         //
         // Scan the files and folders
         //
 
-        var resourceRegistry = new ResourceRegistry(_resourceFolder);
+        var resourceRegistry = new ResourceRegistry(_resourceFolderPath);
         var scanResult = resourceRegistry.UpdateRegistry();
         scanResult.IsSuccess.Should().BeTrue();
 
@@ -79,11 +79,11 @@ public class ResourceRegistryTests
         (resources[1] is FileResource).Should().BeTrue();
         resources[1].Name.Should().Be(FileNameA);
 
-        var subFolder = resources[0] as FolderResource;
-        Guard.IsNotNull(subFolder);
+        var subFolderResource = resources[0] as FolderResource;
+        Guard.IsNotNull(subFolderResource);
 
-        subFolder.Children.Count.Should().Be(1);
-        subFolder.Children[0].Name.Should().Be(FileNameB);
+        subFolderResource.Children.Count.Should().Be(1);
+        subFolderResource.Children[0].Name.Should().Be(FileNameB);
 
         //
         // Expand a folder and retrieve it from the registry
@@ -91,14 +91,14 @@ public class ResourceRegistryTests
         var expandedFoldersIn = new List<string>() { FolderNameA };
         resourceRegistry.SetExpandedFolders(expandedFoldersIn);
 
-        var folder = (resources[0] as FolderResource)!;
-        folder.Expanded.Should().BeTrue();
+        var folderResource = (resources[0] as FolderResource)!;
+        folderResource.Expanded.Should().BeTrue();
 
         var expandedFoldersOut = resourceRegistry.GetExpandedFolders();
         expandedFoldersOut.Count.Should().Be(1);
         expandedFoldersOut[0].Should().Be(FolderNameA);
 
-        var folderPath = resourceRegistry.GetResourcePath(folder);
+        var folderPath = resourceRegistry.GetResourcePath(folderResource);
         resourceRegistry.IsFolderExpanded(folderPath).Should().BeTrue();
     }
 }

--- a/Celbridge/Celbridge.Tests/UtilitiesTests.cs
+++ b/Celbridge/Celbridge.Tests/UtilitiesTests.cs
@@ -7,7 +7,7 @@ namespace Celbridge.Tests;
 public class UtilitiesTests
 {
     [Test]
-    public void ICanValidatePaths()
+    public void ICanValidateResourcePaths()
     {
         IUtilityService utilityService = new UtilityService();
 
@@ -15,14 +15,14 @@ public class UtilitiesTests
         // Check valid paths pass
         //
 
-        utilityService.IsValidPathSegment("ValidSegment").Should().BeTrue();
+        utilityService.IsValidResourcePathSegment("ValidSegment").Should().BeTrue();
         utilityService.IsValidResourcePath(@"Some/Path/File.txt").Should().BeTrue();
 
         //
         // Check invalid paths fail
         //
 
-        utilityService.IsValidPathSegment("Invalid\"Segment").Should().BeFalse();
+        utilityService.IsValidResourcePathSegment("Invalid\"Segment").Should().BeFalse();
         utilityService.IsValidResourcePath(@"C:\\AbsolutePath").Should().BeFalse();
         utilityService.IsValidResourcePath(@"\AbsolutePath").Should().BeFalse();
         utilityService.IsValidResourcePath(@"/Some/Path/File.txt").Should().BeFalse();

--- a/Celbridge/Celbridge.Tests/WorkspaceDataTests.cs
+++ b/Celbridge/Celbridge.Tests/WorkspaceDataTests.cs
@@ -9,18 +9,18 @@ public class WorkspaceDataTests
 {
     private IWorkspaceDataService? _workspaceDataService;
 
-    private string? _workspaceFolder;
+    private string? _workspaceFolderPath;
 
     [SetUp]
     public void Setup()
     {
-        _workspaceFolder = Path.Combine(Path.GetTempPath(), "Celbridge", $"{nameof(WorkspaceDataTests)}");
-        if (Directory.Exists(_workspaceFolder))
+        _workspaceFolderPath = Path.Combine(Path.GetTempPath(), "Celbridge", $"{nameof(WorkspaceDataTests)}");
+        if (Directory.Exists(_workspaceFolderPath))
         {
-            Directory.Delete(_workspaceFolder, true);
+            Directory.Delete(_workspaceFolderPath, true);
         }
 
-        Directory.CreateDirectory(_workspaceFolder);
+        Directory.CreateDirectory(_workspaceFolderPath);
 
         _workspaceDataService = new WorkspaceDataService();
     }
@@ -28,9 +28,9 @@ public class WorkspaceDataTests
     [TearDown]
     public void TearDown()
     {
-        if (Directory.Exists(_workspaceFolder))
+        if (Directory.Exists(_workspaceFolderPath))
         {
-            Directory.Delete(_workspaceFolder!, true);
+            Directory.Delete(_workspaceFolderPath!, true);
         }
     }
 
@@ -38,9 +38,9 @@ public class WorkspaceDataTests
     public async Task ICanCreateAndLoadWorkspaceDataAsync()
     {
         Guard.IsNotNull(_workspaceDataService);
-        Guard.IsNotNullOrEmpty(_workspaceFolder);
+        Guard.IsNotNullOrEmpty(_workspaceFolderPath);
 
-        var databasePath = Path.Combine(_workspaceFolder, "Workspace.db");
+        var databasePath = Path.Combine(_workspaceFolderPath, "Workspace.db");
 
         var createResult = await _workspaceDataService.CreateWorkspaceDataAsync(databasePath);
         createResult.IsSuccess.Should().BeTrue();
@@ -81,7 +81,7 @@ public class WorkspaceDataTests
         // Delete the workspace database files
         //
 
-        Directory.Delete(_workspaceFolder, true);
+        Directory.Delete(_workspaceFolderPath, true);
         File.Exists(databasePath).Should().BeFalse();
     }
 }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/CreateProjectCommand.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/CreateProjectCommand.cs
@@ -38,7 +38,7 @@ public class CreateProjectCommand : CommandBase, ICreateProjectCommand
 
         if (File.Exists(projectFilePath))
         {
-            return Result.Fail($"Failed to create project because it already exists: {projectFilePath}");
+            return Result.Fail($"Failed to create project file at '{projectFilePath}' because the file already exists.");
         }
 
         // Close any open project.
@@ -53,7 +53,7 @@ public class CreateProjectCommand : CommandBase, ICreateProjectCommand
         }
 
         // Load the new project
-        _commandService.Execute<ILoadProjectCommand>(command => command.ProjectPath = projectFilePath);
+        _commandService.Execute<ILoadProjectCommand>(command => command.ProjectFilePath = projectFilePath);
 
         return Result.Ok();
     }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/LoadProjectCommand.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Commands/LoadProjectCommand.cs
@@ -36,16 +36,16 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
         _stringLocalizer = stringLocalizer;
     }
 
-    public string ProjectPath { get; set; } = string.Empty;
+    public string ProjectFilePath { get; set; } = string.Empty;
 
     public override async Task<Result> ExecuteAsync()
     {
-        if (string.IsNullOrEmpty(ProjectPath))
+        if (string.IsNullOrEmpty(ProjectFilePath))
         {
             return Result.Fail("Failed to load project because path is empty.");
         }
 
-        if (_projectDataService.LoadedProjectData?.ProjectFilePath == ProjectPath)
+        if (_projectDataService.LoadedProjectData?.ProjectFilePath == ProjectFilePath)
         {
             // The project is already loaded.
             // We can just early out here as we're already in the expected end state.
@@ -57,31 +57,31 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
         await ProjectUtils.UnloadProjectAsync(_workspaceWrapper, _navigationService, _projectDataService);
 
         // Load the project
-        var loadResult = await ProjectUtils.LoadProjectAsync(_workspaceWrapper, _navigationService, _projectDataService, ProjectPath);
+        var loadResult = await ProjectUtils.LoadProjectAsync(_workspaceWrapper, _navigationService, _projectDataService, ProjectFilePath);
 
         if (loadResult.IsFailure)
         {
             _editorSettings.PreviousLoadedProject = string.Empty;
 
             var titleString = _stringLocalizer.GetString("LoadProjectFailedAlert_Title");
-            var messageString = _stringLocalizer.GetString("LoadProjectFailedAlert_Message", ProjectPath);
+            var messageString = _stringLocalizer.GetString("LoadProjectFailedAlert_Message", ProjectFilePath);
 
             await _dialogService.ShowAlertDialogAsync(titleString, messageString);
 
             // Return to the home page so the user can decide what to do next
             _navigationService.NavigateToPage(HomePageName);
 
-            return Result.Fail($"Failed to load project: {ProjectPath}. {loadResult.Error}.");
+            return Result.Fail($"Failed to load project file: {ProjectFilePath}. {loadResult.Error}.");
         }
 
-        _editorSettings.PreviousLoadedProject = ProjectPath;
+        _editorSettings.PreviousLoadedProject = ProjectFilePath;
 
         return Result.Ok();
     }
 
-    public static void LoadProject(string projectPath)
+    public static void LoadProject(string projectFilePath)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<ILoadProjectCommand>(command => command.ProjectPath = projectPath);
+        commandService.Execute<ILoadProjectCommand>(command => command.ProjectFilePath = projectFilePath);
     }
 }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Services/ProjectDataService.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Services/ProjectDataService.cs
@@ -30,7 +30,7 @@ public class ProjectDataService : IProjectDataService
             return Result.Fail("Project folder is empty.");
         }
 
-        if (!_utilityService.IsValidPathSegment(config.ProjectName))
+        if (!_utilityService.IsValidResourcePathSegment(config.ProjectName))
         {
             return Result.Fail($"Project name is not valid: {config.ProjectName}");
         }

--- a/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Services/ProjectUtils.cs
+++ b/Celbridge/CoreApplication/Celbridge.ProjectAdmin/Services/ProjectUtils.cs
@@ -26,12 +26,12 @@ public static class ProjectUtils
         IWorkspaceWrapper workspaceWrapper,
         INavigationService navigationService, 
         IProjectDataService projectDataService, 
-        string projectPath)
+        string projectFilePath)
     {
-        var openResult = projectDataService.LoadProjectData(projectPath);
-        if (openResult.IsFailure)
+        var loadResult = projectDataService.LoadProjectData(projectFilePath);
+        if (loadResult.IsFailure)
         {
-            return Result.Fail($"Failed to open project '{projectPath}'. {openResult.Error}");
+            return Result.Fail($"Failed to open project file '{projectFilePath}'. {loadResult.Error}");
         }
 
         var loadPageCancelationToken = new CancellationTokenSource();

--- a/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/MainPageViewModel.cs
+++ b/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/MainPageViewModel.cs
@@ -91,7 +91,7 @@ public partial class MainPageViewModel : ObservableObject, INavigationProvider
         {
             _commandService.Execute<ILoadProjectCommand>((command) =>
             {
-                command.ProjectPath = previousProjectFile;
+                command.ProjectFilePath = previousProjectFile;
             });
         }
         else
@@ -155,11 +155,11 @@ public partial class MainPageViewModel : ObservableObject, INavigationProvider
         var result = await _filePickerService.PickSingleFileAsync(new List<string> { ".celbridge" });
         if (result.IsSuccess)
         {
-            var projectPath = result.Value;
+            var projectFilePath = result.Value;
 
             _commandService.Execute<ILoadProjectCommand>((command) =>
             {
-                command.ProjectPath = projectPath;
+                command.ProjectFilePath = projectFilePath;
             });
         }
     }

--- a/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/NewProjectDialogViewModel.cs
+++ b/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/NewProjectDialogViewModel.cs
@@ -48,7 +48,7 @@ public partial class NewProjectDialogViewModel : ObservableObject
         if (e.PropertyName == nameof(ProjectFolder) ||
             e.PropertyName == nameof(ProjectName))
         {
-            var isValid = _utilityService.IsValidPathSegment(ProjectName);
+            var isValid = _utilityService.IsValidResourcePathSegment(ProjectName);
 
             // Todo: Show a message explaining why the create button is disabled
             IsCreateButtonEnabled = isValid && parentFolderExists && !projectFolderExists;

--- a/Celbridge/CoreApplication/Celbridge.Utilities/Services/UtilityService.cs
+++ b/Celbridge/CoreApplication/Celbridge.Utilities/Services/UtilityService.cs
@@ -39,10 +39,10 @@ public class UtilityService : IUtilityService
         }
 
         // Each segment in the resource path must be a valid filename
-        var segments = resourcePath.Split('/');
-        foreach (var segment in segments)
+        var resourcePathSegments = resourcePath.Split('/');
+        foreach (var segment in resourcePathSegments)
         {
-            if (!IsValidPathSegment(segment))
+            if (!IsValidResourcePathSegment(segment))
             {
                 return false;
             }
@@ -51,9 +51,9 @@ public class UtilityService : IUtilityService
         return true;
     }
 
-    public bool IsValidPathSegment(string segment)
+    public bool IsValidResourcePathSegment(string resourcePathSegment)
     {
-        if (string.IsNullOrWhiteSpace(segment))
+        if (string.IsNullOrWhiteSpace(resourcePathSegment))
         {
             return false;
         }
@@ -63,7 +63,7 @@ public class UtilityService : IUtilityService
         // Note that we're using GetInvalidFileNameChars() instead of GetInvalidPathChars() here.
         var invalidChars = Path.GetInvalidFileNameChars();
 
-        foreach (var c in segment)
+        foreach (var c in resourcePathSegment)
         {
             if (invalidChars.Contains(c))
             {

--- a/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.cs
@@ -65,7 +65,7 @@ public partial class ResourceTreeViewModel : ObservableObject
 
                 // Execute a command to add the folder resource
                 var resourcePath = string.IsNullOrEmpty(path) ? showResult.Value : $"{path}/{showResult.Value}";
-                _commandService.Execute<IAddFolderCommand>(command => command.FolderPath = resourcePath);
+                _commandService.Execute<IAddFolderCommand>(command => command.ResourcePath = resourcePath);
             }
         }
 
@@ -94,7 +94,7 @@ public partial class ResourceTreeViewModel : ObservableObject
 
                 // Execute a command to add the file resource
                 var resourcePath = string.IsNullOrEmpty(path) ? showResult.Value : $"{path}/{showResult.Value}";
-                _commandService.Execute<IAddFileCommand>(command => command.FilePath = resourcePath);
+                _commandService.Execute<IAddFileCommand>(command => command.ResourcePath = resourcePath);
             }
         }
 
@@ -118,7 +118,7 @@ public partial class ResourceTreeViewModel : ObservableObject
                 if (confirmed)
                 {
                     // Execute a command to delete the folder resource
-                    _commandService.Execute<IDeleteFolderCommand>(command => command.FolderPath = resourcePath);
+                    _commandService.Execute<IDeleteFolderCommand>(command => command.ResourcePath = resourcePath);
                 }
             }
         }
@@ -143,7 +143,7 @@ public partial class ResourceTreeViewModel : ObservableObject
                 if (confirmed)
                 {
                     // Execute a command to delete the file resource
-                    _commandService.Execute<IDeleteFileCommand>(command => command.FilePath = resourcePath);
+                    _commandService.Execute<IDeleteFileCommand>(command => command.ResourcePath = resourcePath);
                 }
             }
         }
@@ -175,15 +175,15 @@ public partial class ResourceTreeViewModel : ObservableObject
             {
                 var inputText = showResult.Value;
 
-                var fromPath = resourcePath;
-                var toPath = Path.GetDirectoryName(resourcePath);
-                toPath = string.IsNullOrEmpty(toPath) ? inputText : toPath + "/" + inputText;
+                var fromResourcePath = resourcePath;
+                var toResourcePath = Path.GetDirectoryName(resourcePath);
+                toResourcePath = string.IsNullOrEmpty(toResourcePath) ? inputText : toResourcePath + "/" + inputText;
 
-                // Execute a command to rename the folder resource
+                // Execute a command to move the folder resource to perform the rename
                 _commandService.Execute<IMoveFolderCommand>(command =>
                 {
-                    command.FromFolderPath = resourcePath;
-                    command.ToFolderPath = toPath;
+                    command.FromResourcePath = fromResourcePath;
+                    command.ToResourcePath = toResourcePath;
                 });
             }
         }
@@ -216,15 +216,15 @@ public partial class ResourceTreeViewModel : ObservableObject
             {
                 var inputText = showResult.Value;
 
-                var fromPath = resourcePath;
-                var toPath = Path.GetDirectoryName(resourcePath);
-                toPath = string.IsNullOrEmpty(toPath) ? inputText : toPath + "/" + inputText;
+                var fromResourcePath = resourcePath;
+                var toResourcePath = Path.GetDirectoryName(resourcePath);
+                toResourcePath = string.IsNullOrEmpty(toResourcePath) ? inputText : toResourcePath + "/" + inputText;
 
-                // Execute a command to rename the folder resource
+                // Execute a command to move the file resource to perform the rename
                 _commandService.Execute<IMoveFileCommand>(command =>
                 {
-                    command.FromFilePath = resourcePath;
-                    command.ToFilePath = toPath;
+                    command.FromResourcePath = fromResourcePath;
+                    command.ToResourcePath = toResourcePath;
                 });
             }
         }
@@ -247,13 +247,13 @@ public partial class ResourceTreeViewModel : ObservableObject
             int resourceNumber = 1;
             while (true)
             {
-                var parentDir = resourceRegistry.GetAbsolutePath(parentFolder);
-                var candidateResourceName = _stringLocalizer.GetString(stringKey, resourceNumber).ToString();
-                var candidateResourcePath = Path.Combine(parentDir, candidateResourceName);
-                if (!Directory.Exists(candidateResourcePath) &&
-                    !File.Exists(candidateResourcePath))
+                var parentFolderPath = resourceRegistry.GetPath(parentFolder);
+                var candidateName = _stringLocalizer.GetString(stringKey, resourceNumber).ToString();
+                var candidatePath = Path.Combine(parentFolderPath, candidateName);
+                if (!Directory.Exists(candidatePath) &&
+                    !File.Exists(candidatePath))
                 {
-                    defaultResourceName = candidateResourceName;
+                    defaultResourceName = candidateName;
                     break;
                 }
                 resourceNumber++;


### PR DESCRIPTION
"Path" indicates an absolute path and uses the platform directory separator. 
"ResourcePath" indicates a project relative path and uses the '/' separator exclusively.