### PR TITLE
Shorten ResourceKey variables names

### DIFF
--- a/Celbridge/Celbridge.BaseLibrary/Clipboard/IClipboardService.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Clipboard/IClipboardService.cs
@@ -14,5 +14,5 @@ public interface IClipboardService
     /// If the target resource is a file, the resources are pasted into the parent folder of the file.
     /// Fails if the current clipboard content is not a resource.
     /// </summary>
-    Task<Result> PasteResources(ResourceKey FolderResourceKey);
+    Task<Result> PasteResources(ResourceKey FolderResource);
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IAddResourceCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IAddResourceCommand.cs
@@ -16,7 +16,7 @@ public interface IAddResourceCommand : IExecutableCommand
     /// <summary>
     /// Resource key for the new resource
     /// </summary>
-    ResourceKey ResourceKey { get; set; }
+    ResourceKey Resource { get; set; }
 
     /// <summary>
     /// Path to copy the resource from.

--- a/Celbridge/Celbridge.BaseLibrary/Project/ICopyResourceCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/ICopyResourceCommand.cs
@@ -11,12 +11,12 @@ public interface ICopyResourceCommand : IExecutableCommand
     /// <summary>
     /// Resource to be copied.
     /// </summary>
-    ResourceKey SourceResourceKey { get; set; }
+    ResourceKey SourceResource { get; set; }
 
     /// <summary>
     /// Location to move the resource to.
     /// </summary>
-    ResourceKey DestResourceKey { get; set; }
+    ResourceKey DestResource { get; set; }
 
     /// <summary>
     /// Controls whether the resource is copied or moved to the new location.

--- a/Celbridge/Celbridge.BaseLibrary/Project/ICopyResourceToClipboardCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/ICopyResourceToClipboardCommand.cs
@@ -13,7 +13,7 @@ public interface ICopyResourceToClipboardCommand : IExecutableCommand
     /// <summary>
     /// Resource to copy to the clipboard.
     /// </summary>
-    ResourceKey ResourceKey { get; set; }
+    ResourceKey Resource { get; set; }
 
     /// <summary>
     /// If set to true, the original resource will be moved to the new location 

--- a/Celbridge/Celbridge.BaseLibrary/Project/IDeleteResourceCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IDeleteResourceCommand.cs
@@ -11,5 +11,5 @@ public interface IDeleteResourceCommand : IExecutableCommand
     /// <summary>
     /// Resource to delete.
     /// </summary>
-    ResourceKey ResourceKey { get; set; }
+    ResourceKey Resource { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IPasteResourceFromClipboardCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IPasteResourceFromClipboardCommand.cs
@@ -11,5 +11,5 @@ public interface IPasteResourceFromClipboardCommand : IExecutableCommand
     /// <summary>
     /// Folder resource to paste the clipboard contents into.
     /// </summary>
-    ResourceKey FolderResourceKey { get; set; }
+    ResourceKey FolderResource { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IShowAddResourceDialogCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IShowAddResourceDialogCommand.cs
@@ -16,5 +16,5 @@ public interface IShowAddResourceDialogCommand : IExecutableCommand
     /// <summary>
     /// Resource key for the folder which will contain the new resource.
     /// </summary>
-    ResourceKey ParentFolderResourceKey { get; set; }
+    ResourceKey ParentFolderResource { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IShowDeleteResourceDialogCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IShowDeleteResourceDialogCommand.cs
@@ -11,5 +11,5 @@ public interface IShowDeleteResourceDialogCommand : IExecutableCommand
     /// <summary>
     /// Resource to delete.
     /// </summary>
-    ResourceKey ResourceKey { get; set; }
+    ResourceKey Resource { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Project/IShowRenameResourceDialogCommand.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Project/IShowRenameResourceDialogCommand.cs
@@ -11,5 +11,5 @@ public interface IShowRenameResourceDialogCommand : IExecutableCommand
     /// <summary>
     /// Resource to rename.
     /// </summary>
-    ResourceKey ResourceKey { get; set; }
+    ResourceKey Resource { get; set; }
 }

--- a/Celbridge/Celbridge.BaseLibrary/Resources/IResourceRegistry.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Resources/IResourceRegistry.cs
@@ -33,13 +33,13 @@ public interface IResourceRegistry
     /// The path will be generated even if the resource does not exist in the project.
     /// The path uses the directory separator character of the current platform.
     /// </summary>
-    string GetResourcePath(ResourceKey resourceKey);
+    string GetResourcePath(ResourceKey resource);
 
     /// <summary>
     /// Returns the resource with the specified resource key.
     /// Fails if no matching resource is found.
     /// </summary>
-    Result<IResource> GetResource(ResourceKey resourceKey);
+    Result<IResource> GetResource(ResourceKey resource);
 
     /// <summary>
     /// Updates the registry to mirror the current state of the files and folders in the project folder.
@@ -55,10 +55,10 @@ public interface IResourceRegistry
     /// Mark a folder resource as expanded or collapsed in the resource tree.
     /// This does not affect the IsExpanded property of the folder resource itself.
     /// </summary>
-    void SetFolderIsExpanded(ResourceKey resourceKey, bool isExpanded);
+    void SetFolderIsExpanded(ResourceKey folderResource, bool isExpanded);
 
     /// <summary>
     /// Returns true if the folder with the specified resource key is expanded.
     /// </summary>
-    public bool IsFolderExpanded(ResourceKey resourceKey);
+    public bool IsFolderExpanded(ResourceKey folderResource);
 }

--- a/Celbridge/Celbridge.BaseLibrary/Resources/ResourceKey.cs
+++ b/Celbridge/Celbridge.BaseLibrary/Resources/ResourceKey.cs
@@ -63,7 +63,7 @@ public readonly struct ResourceKey : IEquatable<ResourceKey>, IComparable<Resour
     /// <summary>
     /// Implicit conversion from ResourceKey to string
     /// </summary>
-    public static implicit operator string(ResourceKey resourceKey) => resourceKey._key;
+    public static implicit operator string(ResourceKey resource) => resource._key;
 
     /// <summary>
     /// Returns the resource name. This is the last segment of the resource key.
@@ -158,42 +158,42 @@ public readonly struct ResourceKey : IEquatable<ResourceKey>, IComparable<Resour
     /// - Specified relative to the project folder. 
     /// - Absolute paths, parent and same directory references are not supported.
     /// - '/' is used as the path separator on all platforms, backslashes are not allowed.
-    public static bool IsValidKey(string resourceKey)
+    public static bool IsValidKey(string key)
     {
-        if (string.IsNullOrWhiteSpace(resourceKey))
+        if (string.IsNullOrWhiteSpace(key))
         {
             // An empty resource key is valid, and refers to the project folder.
             return true;
         }
 
         // Backslashes are not permitted
-        if (resourceKey.Contains("\\"))
+        if (key.Contains("\\"))
         {
             return false;
         }
 
         // Empty segments are not permitted
-        if (resourceKey.Contains("//"))
+        if (key.Contains("//"))
         {
             return false;
         }
 
         // Resource keys must represent a relative path
-        if (Path.IsPathRooted(resourceKey))
+        if (Path.IsPathRooted(key))
         {
             return false;
         }
 
         // Resource keys may not contain parent or same directory references
-        if (resourceKey.Contains("..") ||
-            resourceKey.Contains("./") ||
-            resourceKey.Contains(".\\"))
+        if (key.Contains("..") ||
+            key.Contains("./") ||
+            key.Contains(".\\"))
         {
             return false;
         }
 
         // Resource keys may not start with a separator character
-        if (resourceKey[0] == '/')
+        if (key[0] == '/')
         {
             return false;
         }
@@ -201,7 +201,7 @@ public readonly struct ResourceKey : IEquatable<ResourceKey>, IComparable<Resour
         // Each segment in the resource key must be a valid filename
         // Note: This constraint may prove to be too restrictive for cross-platform projects which
         // work with exotic file names. If this proves to be a problem we could relax this constraint in the future.
-        var resourceKeySegments = resourceKey.Split('/');
+        var resourceKeySegments = key.Split('/');
         foreach (var segment in resourceKeySegments)
         {
             if (!IsValidSegment(segment))

--- a/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/NewProjectDialogViewModel.cs
+++ b/Celbridge/CoreApplication/Celbridge.UserInterface/ViewModels/NewProjectDialogViewModel.cs
@@ -46,7 +46,7 @@ public partial class NewProjectDialogViewModel : ObservableObject
         if (e.PropertyName == nameof(ProjectFolderPath) ||
             e.PropertyName == nameof(ProjectName))
         {
-            var isValid = ResourceKey.IsValidKey(ProjectName);
+            var isValid = ResourceKey.IsValidSegment(ProjectName);
 
             // Todo: Show a message explaining why the create button is disabled
             IsCreateButtonEnabled = isValid && parentFolderExists && !projectFolderExists;

--- a/Celbridge/CoreExtensions/Celbridge.Project/Commands/AddResourceCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Commands/AddResourceCommand.cs
@@ -12,7 +12,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
     public override string UndoStackName => UndoStackNames.Project;
 
     public ResourceType ResourceType { get; set; }
-    public ResourceKey ResourceKey { get; set; }
+    public ResourceKey Resource { get; set; }
     public string SourcePath { get; set; } = string.Empty;
 
     private readonly IMessengerService _messengerService;
@@ -37,7 +37,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         //if (addResult.IsFailure)
         //{
         //    var titleString = _stringLocalizer.GetString("ResourceTree_AddFile");
-        //    var messageString = _stringLocalizer.GetString("ResourceTree_AddFileFailed", ResourceKey);
+        //    var messageString = _stringLocalizer.GetString("ResourceTree_AddFileFailed", Resource);
 
         //    // Show alert
         //    await _dialogService.ShowAlertDialogAsync(titleString, messageString);
@@ -52,7 +52,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         //if (undoResult.IsFailure)
         //{
         //    var titleString = _stringLocalizer.GetString("ResourceTree_AddFile");
-        //    var messageString = _stringLocalizer.GetString("ResourceTree_UndoAddFileFailed", ResourceKey);
+        //    var messageString = _stringLocalizer.GetString("ResourceTree_UndoAddFileFailed", Resource);
 
         //    // Show alert
         //    await _dialogService.ShowAlertDialogAsync(titleString, messageString);
@@ -79,14 +79,14 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         // Validate the resource key
         //
 
-        if (ResourceKey.IsEmpty)
+        if (Resource.IsEmpty)
         {
             return Result.Fail("Failed to create resource. Resource key is empty");
         }
 
-        if (!ResourceKey.IsValidKey(ResourceKey))
+        if (!ResourceKey.IsValidKey(Resource))
         {
-            return Result.Fail($"Failed to create resource. Resource key '{ResourceKey}' is not valid.");
+            return Result.Fail($"Failed to create resource. Resource key '{Resource}' is not valid.");
         }
 
         //
@@ -95,7 +95,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
 
         try
         {
-            var addedResourcePath = resourceRegistry.GetResourcePath(ResourceKey);
+            var addedResourcePath = resourceRegistry.GetResourcePath(Resource);
 
             // Fail if the parent folder for the new resource does not exist.
             // We could attempt to create any missing parent folders, but it would make the undo logic trickier.
@@ -165,7 +165,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         //
         // Expand the folder containing the newly created resource
         //
-        var parentFolderKey = ResourceKey.GetParent();
+        var parentFolderKey = Resource.GetParent();
         if (!parentFolderKey.IsEmpty)
         {
             resourceRegistry.SetFolderIsExpanded(parentFolderKey, true);
@@ -220,35 +220,35 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
     // Static methods for scripting support.
     //
 
-    public static void AddFile(ResourceKey resourceKey, string sourcePath)
+    public static void AddFile(ResourceKey resource, string sourcePath)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
         commandService.Execute<IAddResourceCommand>(command =>
         {
             command.ResourceType = ResourceType.File;
-            command.ResourceKey = resourceKey;
+            command.Resource = resource;
             command.SourcePath = sourcePath;
         });
     }
 
-    public static void AddFile(ResourceKey resourceKey)
+    public static void AddFile(ResourceKey resource)
     {
-        AddFile(resourceKey, string.Empty);
+        AddFile(resource, string.Empty);
     }
 
-    public static void AddFolder(ResourceKey resourceKey, string sourcePath)
+    public static void AddFolder(ResourceKey resource, string sourcePath)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
         commandService.Execute<IAddResourceCommand>(command =>
         {
             command.ResourceType = ResourceType.Folder;
-            command.ResourceKey = resourceKey;
+            command.Resource = resource;
             command.SourcePath = sourcePath;
         });
     }
 
-    public static void AddFolder(ResourceKey resourceKey)
+    public static void AddFolder(ResourceKey resource)
     {
-        AddFolder(resourceKey, string.Empty);
+        AddFolder(resource, string.Empty);
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/Commands/CopyResourceToClipboardCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Commands/CopyResourceToClipboardCommand.cs
@@ -11,7 +11,7 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
 {
     public override string UndoStackName => UndoStackNames.None;
 
-    public ResourceKey ResourceKey { get; set; }
+    public ResourceKey Resource { get; set; }
     public bool MoveResource { get; set; }
 
     private readonly IWorkspaceWrapper _workspaceWrapper;
@@ -25,7 +25,7 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
     {
         var resourceRegistry = _workspaceWrapper.WorkspaceService.ProjectService.ResourceRegistry;
 
-        var getResult = resourceRegistry.GetResource(ResourceKey);
+        var getResult = resourceRegistry.GetResource(Resource);
         if (getResult.IsFailure)
         {
             return getResult;
@@ -79,12 +79,12 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
         return Result.Ok();
     }
 
-    private static void CopyResourceToClipboard(ResourceKey resourceKey, bool moveResource)
+    private static void CopyResourceToClipboard(ResourceKey resource, bool moveResource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
         commandService.Execute<ICopyResourceToClipboardCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resource;
             command.MoveResource = moveResource;
         });
     }
@@ -93,13 +93,13 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
     // Static methods for scripting support.
     //
 
-    public static void CopyResourceToClipboard(ResourceKey resourceKey)
+    public static void CopyResourceToClipboard(ResourceKey resource)
     {
-        CopyResourceToClipboard(resourceKey, false);
+        CopyResourceToClipboard(resource, false);
     }
 
-    public static void CutResourceToClipboard(ResourceKey resourceKey)
+    public static void CutResourceToClipboard(ResourceKey resource)
     {
-        CopyResourceToClipboard(resourceKey, true);
+        CopyResourceToClipboard(resource, true);
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/Commands/PasteResourceFromClipboardCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Commands/PasteResourceFromClipboardCommand.cs
@@ -12,7 +12,7 @@ public class PasteResourceFromClipboardCommand : CommandBase, IPasteResourceFrom
 
     public override string UndoStackName => UndoStackNames.None;
 
-    public ResourceKey FolderResourceKey { get; set; }
+    public ResourceKey FolderResource { get; set; }
 
     public PasteResourceFromClipboardCommand(IWorkspaceWrapper workspaceWrapper)
     {
@@ -27,19 +27,19 @@ public class PasteResourceFromClipboardCommand : CommandBase, IPasteResourceFrom
             return Result.Fail("Clipboard does not contain a resource to paste");
         }
 
-        return await clipboardService.PasteResources(FolderResourceKey);
+        return await clipboardService.PasteResources(FolderResource);
     }
 
     //
     // Static methods for scripting support.
     //
 
-    public static void PasteResourceFromClipboard(ResourceKey folderResourceKey)
+    public static void PasteResourceFromClipboard(ResourceKey folderResource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
         commandService.Execute<IPasteResourceFromClipboardCommand>(command =>
         {
-            command.FolderResourceKey = folderResourceKey;
+            command.FolderResource = folderResource;
         });
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/Commands/ShowDeleteResourceDialogCommand.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Commands/ShowDeleteResourceDialogCommand.cs
@@ -11,7 +11,7 @@ public class ShowDeleteResourceDialogCommand : CommandBase, IShowDeleteResourceD
 {
     public override string UndoStackName => UndoStackNames.None;
 
-    public ResourceKey ResourceKey { get; set; }
+    public ResourceKey Resource { get; set; }
 
     private readonly IMessengerService _messengerService;
     private readonly IStringLocalizer _stringLocalizer;
@@ -47,7 +47,7 @@ public class ShowDeleteResourceDialogCommand : CommandBase, IShowDeleteResourceD
 
         var resourceRegistry = _workspaceWrapper.WorkspaceService.ProjectService.ResourceRegistry;
 
-        var getResult = resourceRegistry.GetResource(ResourceKey);
+        var getResult = resourceRegistry.GetResource(Resource);
         if (getResult.IsFailure)
         {
             return Result.Fail(getResult.Error);
@@ -81,7 +81,7 @@ public class ShowDeleteResourceDialogCommand : CommandBase, IShowDeleteResourceD
                 // Execute a command to delete the resource
                 _commandService.Execute<IDeleteResourceCommand>(command =>
                 {
-                    command.ResourceKey = ResourceKey;
+                    command.Resource = Resource;
                 });
 
                 var message = new RequestResourceTreeUpdateMessage();
@@ -96,12 +96,12 @@ public class ShowDeleteResourceDialogCommand : CommandBase, IShowDeleteResourceD
     // Static methods for scripting support.
     //
 
-    public static void ShowDeleteResourceDialog(ResourceKey resourceKey)
+    public static void ShowDeleteResourceDialog(ResourceKey resource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
         commandService.Execute<IShowDeleteResourceDialogCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resource;
         });
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/Services/ResourceRegistry.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/Services/ResourceRegistry.cs
@@ -71,23 +71,23 @@ public class ResourceRegistry : IResourceRegistry
         return GetResourcePath(resourceKey);
     }
 
-    public string GetResourcePath(ResourceKey resourceKey)
+    public string GetResourcePath(ResourceKey resource)
     {
-        var resourcePath = Path.Combine(_projectFolderPath, resourceKey);
+        var resourcePath = Path.Combine(_projectFolderPath, resource);
         var normalized = Path.GetFullPath(resourcePath);
 
         return normalized;
     }
 
-    public Result<IResource> GetResource(ResourceKey resourceKey)
+    public Result<IResource> GetResource(ResourceKey resource)
     {
-        if (resourceKey.IsEmpty)
+        if (resource.IsEmpty)
         {
             // An empty resource key refers to the root folder
             return Result<IResource>.Ok(RootFolder);
         }
 
-        var segments = resourceKey.ToString().Split('/');
+        var segments = resource.ToString().Split('/');
         var searchFolder = RootFolder;
 
         // Attempt to match each segment with the corresponding resource in the tree
@@ -132,7 +132,7 @@ public class ResourceRegistry : IResourceRegistry
             segmentIndex++;
         }
 
-        return Result<IResource>.Fail($"Failed to find a resource matching the resource key '{resourceKey}'.");
+        return Result<IResource>.Fail($"Failed to find a resource matching the resource key '{resource}'.");
     }
 
     public Result UpdateResourceTree()
@@ -209,24 +209,24 @@ public class ResourceRegistry : IResourceRegistry
 
     public List<string> ExpandedFolders { get; } = new();
 
-    public void SetFolderIsExpanded(ResourceKey resourceKey, bool isExpanded)
+    public void SetFolderIsExpanded(ResourceKey folderResource, bool isExpanded)
     {
         if (isExpanded)
         {
-            if (!ExpandedFolders.Contains(resourceKey))
+            if (!ExpandedFolders.Contains(folderResource))
             {
-                ExpandedFolders.Add(resourceKey);
+                ExpandedFolders.Add(folderResource);
                 ExpandedFolders.Sort();
             }
         }
         else
         {
-            ExpandedFolders.Remove(resourceKey);
+            ExpandedFolders.Remove(folderResource);
         }
     }
 
-    public bool IsFolderExpanded(ResourceKey resourceKey)
+    public bool IsFolderExpanded(ResourceKey folderResource)
     {
-        return ExpandedFolders.Contains(resourceKey);
+        return ExpandedFolders.Contains(folderResource);
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Clipboard.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Clipboard.cs
@@ -17,7 +17,7 @@ public partial class ResourceTreeViewModel
         // Execute a command to cut the resource to the clipboard
         _commandService.Execute<ICopyResourceToClipboardCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resourceKey;
             command.MoveResource = true;
         });
     }
@@ -31,7 +31,7 @@ public partial class ResourceTreeViewModel
         // Execute a command to copy the resource to the clipboard
         _commandService.Execute<ICopyResourceToClipboardCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resourceKey;
         });
     }
 
@@ -40,25 +40,28 @@ public partial class ResourceTreeViewModel
         var rootFolder = _projectService.ResourceRegistry.RootFolder;
 
         IFolderResource pasteFolder;
-        if (resource is IFileResource fileResource)
+        if (resource is IFileResource file)
         {
-            pasteFolder = fileResource.ParentFolder ?? rootFolder;
+            // Paste to the parent folder of the file resource
+            pasteFolder = file.ParentFolder ?? rootFolder;
         }
-        else if (resource is IFolderResource folderResource)
+        else if (resource is IFolderResource folder)
         {
-            pasteFolder = folderResource ?? rootFolder;
+            // Paste to the folder resource
+            pasteFolder = folder ?? rootFolder;
         }
         else
         {
+            // Paste to the root folder
             pasteFolder = rootFolder;
         }
 
-        var folderResourceKey = _projectService.ResourceRegistry.GetResourceKey(pasteFolder);
+        var folderResource = _projectService.ResourceRegistry.GetResourceKey(pasteFolder);
 
         // Execute a command to paste the clipboard content to the folder resource
         _commandService.Execute<IPasteResourceFromClipboardCommand>(command =>
         {
-            command.FolderResourceKey = folderResourceKey;
+            command.FolderResource = folderResource;
         });
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Edit.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Edit.cs
@@ -18,13 +18,13 @@ public partial class ResourceTreeViewModel
             parentFolder = resourceRegistry.RootFolder;
         }
 
-        var parentFolderResourceKey = resourceRegistry.GetResourceKey(parentFolder);
+        var parentFolderResource = resourceRegistry.GetResourceKey(parentFolder);
 
         // Execute a command to show the add resource dialog
         _commandService.Execute<IShowAddResourceDialogCommand>(command =>
         {
             command.ResourceType = resourceType;
-            command.ParentFolderResourceKey = parentFolderResourceKey;
+            command.ParentFolderResource = parentFolderResource;
         });
     }
 
@@ -36,7 +36,7 @@ public partial class ResourceTreeViewModel
         // Execute a command to show the delete resource dialog
         _commandService.Execute<IShowDeleteResourceDialogCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resourceKey;
         });
     }
 
@@ -48,7 +48,7 @@ public partial class ResourceTreeViewModel
         // Execute a command to show the rename resource dialog
         _commandService.Execute<IShowRenameResourceDialogCommand>(command =>
         {
-            command.ResourceKey = resourceKey;
+            command.Resource = resourceKey;
         });
     }
 }

--- a/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Utilities.cs
+++ b/Celbridge/CoreExtensions/Celbridge.Project/ViewModels/ResourceTreeViewModel.Utilities.cs
@@ -16,15 +16,15 @@ public partial class ResourceTreeViewModel
     public void SetFolderIsExpanded(IFolderResource folderResource, bool isExpanded)
     {
         var resourceRegistry = _projectService.ResourceRegistry;
-        var resourceKey = resourceRegistry.GetResourceKey(folderResource);
+        var resource = resourceRegistry.GetResourceKey(folderResource);
 
-        bool currentState = resourceRegistry.IsFolderExpanded(resourceKey);
+        bool currentState = resourceRegistry.IsFolderExpanded(resource);
         if (currentState == isExpanded)
         {
             return;
         }
 
-        resourceRegistry.SetFolderIsExpanded(resourceKey, isExpanded);
+        resourceRegistry.SetFolderIsExpanded(resource, isExpanded);
 
         // Save the workspace data (with a delay) to ensure the new expanded state is persisted
         _commandService.RemoveCommandsOfType<ISaveWorkspaceStateCommand>();
@@ -44,10 +44,10 @@ public partial class ResourceTreeViewModel
 
         foreach (var resource in resources)
         {
-            var sourceResourceKey = _projectService.ResourceRegistry.GetResourceKey(resource);
-            var destResourceKey = _projectService.ResourceRegistry.GetResourceKey(parentFolder);
+            var sourceResource = _projectService.ResourceRegistry.GetResourceKey(resource);
+            var destResource = _projectService.ResourceRegistry.GetResourceKey(parentFolder);
 
-            if (sourceResourceKey == destResourceKey)
+            if (sourceResource == destResource)
             {
                 // Moving a resource to the same location is technically a no-op, but we still need to update
                 // the resource tree because the TreeView may now be displaying the resources in the wrong order.
@@ -57,8 +57,8 @@ public partial class ResourceTreeViewModel
 
             _commandService.Execute<ICopyResourceCommand>(command =>
             {
-                command.SourceResourceKey = sourceResourceKey;
-                command.DestResourceKey = destResourceKey;
+                command.SourceResource = sourceResource;
+                command.DestResource = destResource;
                 command.Operation = CopyResourceOperation.Move;
             });
         }


### PR DESCRIPTION
The "Key" part at the end of the variable name can be omitted in most cases without reducing clarity.