### PR TITLE
Fix tooltip bug on documents tab view

### DIFF
--- a/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml
+++ b/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="Celbridge.Documents.Views.DocumentsPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Celbridge.Documents.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    DataContext="{x:Bind ViewModel}">
+  <TabView
+        x:Name="TabView"
+        IsAddTabButtonVisible="False"
+        TabWidthMode="SizeToContent"
+        VerticalAlignment="Stretch"
+        TabCloseRequested="TabView_CloseRequested"
+        SelectionChanged="TabView_SelectionChanged"
+        TabItemsChanged="TabView_TabItemsChanged" />
+</UserControl>


### PR DESCRIPTION
Issue only occurs when using C# Markup, so converting to XAML fixed it.