### PR TITLE
Set the current directory to the project folder path

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Console/IConsolePanel.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Console/IConsolePanel.cs
@@ -4,4 +4,9 @@ namespace Celbridge.Console;
 /// Interface for interacting with the ConsolePanel view.
 /// </summary>
 public interface IConsolePanel
-{}
+{
+    /// <summary>
+    /// Initialize the scripting support for the console panel.
+    /// </summary>
+    Task<Result> InitializeScripting();
+}

--- a/Celbridge/Extensions/Workspace/Celbridge.Console/Commands/PrintCommand.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Console/Commands/PrintCommand.cs
@@ -24,6 +24,8 @@ public class PrintCommand : CommandBase, IPrintCommand
         switch (MessageType)
         {
             case MessageType.Command:
+                // Command log entries have a specific icon in the console log.
+                // If the user attempts to print using MessageType.Command we just map it to MessageType.Information instead.
             case MessageType.Information:
                 _logger.LogInformation(Message);
                 break;

--- a/Celbridge/Extensions/Workspace/Celbridge.Console/Views/ConsolePanel.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Console/Views/ConsolePanel.cs
@@ -142,7 +142,12 @@ public partial class ConsolePanel : UserControl, IConsolePanel
             .Content(consoleGrid));
     }
 
-    public void CommandTextBox_KeyDown(object? sender, KeyRoutedEventArgs e)
+    public Task<Result> InitializeScripting()
+    {
+        return ViewModel.InitializeScripting();
+    }
+
+    private void CommandTextBox_KeyDown(object? sender, KeyRoutedEventArgs e)
     {
         if (e.Key == VirtualKey.Enter)
         {

--- a/Celbridge/Extensions/Workspace/Celbridge.Workspace/Services/WorkspaceLoader.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Workspace/Services/WorkspaceLoader.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 
 namespace Celbridge.Workspace.Services;
 
@@ -84,6 +84,18 @@ public class WorkspaceLoader
         await explorerService.StoreSelectedResource();
         await documentsService.StoreSelectedDocument();
         await documentsService.StoreOpenDocuments();
+
+        //
+        // Initialize console scripting support
+        //
+        var consoleService = workspaceService.ConsoleService;
+        var initResult = await consoleService.ConsolePanel.InitializeScripting();
+        if (initResult.IsFailure)
+        {
+            var failure = Result.Fail("Failed to initialize console scripting");
+            failure.MergeErrors(initResult);
+            return failure;
+        }
 
         return Result.Ok();
     }

--- a/Celbridge/Extensions/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
@@ -128,6 +128,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
                 // This helps avoid memory leaks and orphaned objects/tasks when the user edits multiple projects during a session.
 
                 (WorkspaceDataService as IDisposable)!.Dispose();
+                (ScriptingService as IDisposable)!.Dispose();
                 (ConsoleService as IDisposable)!.Dispose();
                 (DocumentsService as IDisposable)!.Dispose();
                 (InspectorService as IDisposable)!.Dispose();


### PR DESCRIPTION
Set the current directory in the .Net Interactive context to the project folder path.
This allows ResourceKeys to be treated as project relative paths when executing commands.
Refactored the initialization of the scripting service and the console panel.
