### PR TITLE
Rename ClearLog to Clear

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Console/IClearCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Console/IClearCommand.cs
@@ -3,7 +3,7 @@ using Celbridge.Commands;
 namespace Celbridge.Console;
 
 /// <summary>
-/// Clears the console log.
+/// Clear the console log.
 /// </summary>
-public interface IClearLogCommand : IExecutableCommand
+public interface IClearCommand : IExecutableCommand
 {}

--- a/Celbridge/Extensions/Workspace/Celbridge.Console/Commands/ClearCommand.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Console/Commands/ClearCommand.cs
@@ -5,11 +5,11 @@ using CommunityToolkit.Diagnostics;
 
 namespace Celbridge.Console;
 
-public class ClearLogCommand : CommandBase, IClearLogCommand
+public class ClearCommand : CommandBase, IClearCommand
 {
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
-    public ClearLogCommand(IWorkspaceWrapper workspaceWrapper)
+    public ClearCommand(IWorkspaceWrapper workspaceWrapper)
     {
         _workspaceWrapper = workspaceWrapper;
     }
@@ -36,9 +36,9 @@ public class ClearLogCommand : CommandBase, IClearLogCommand
     // Static methods for scripting support.
     //
 
-    public static void ClearLog()
+    public static void Clear()
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IClearLogCommand>();
+        commandService.Execute<IClearCommand>();
     }
 }

--- a/Celbridge/Extensions/Workspace/Celbridge.Console/ServiceConfiguration.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Console/ServiceConfiguration.cs
@@ -32,7 +32,7 @@ public static class ServiceConfiguration
         // Register commands
         // 
 
-        config.AddTransient<IClearLogCommand, ClearLogCommand>();
+        config.AddTransient<IClearCommand, ClearCommand>();
         config.AddTransient<IClearHistoryCommand, ClearHistoryCommand>();
         config.AddTransient<IUndoCommand, UndoCommand>();
         config.AddTransient<IRedoCommand, RedoCommand>();

--- a/Celbridge/Extensions/Workspace/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
@@ -168,7 +168,7 @@ public partial class ConsolePanelViewModel : ObservableObject
     public ICommand ClearLogCommand => new RelayCommand(ClearLog_Executed);
     private void ClearLog_Executed()
     {
-        _commandService.Execute<IClearLogCommand>();
+        _commandService.Execute<IClearCommand>();
     }
 
     public ICommand ExecuteCommand => new AsyncRelayCommand(ExecuteCommand_Executed);


### PR DESCRIPTION
Most CLIs and REPLs have a Clear() command, so renaming this command for consistency.