### PR TITLE
Ignore hidden files and folder

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Settings/IEditorSettings.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Settings/IEditorSettings.cs
@@ -3,33 +3,72 @@ using System.ComponentModel;
 namespace Celbridge.Settings;
 
 /// <summary>
-/// Manage persitent user settings via named setting containers.
+/// Manage persistent user settings via named setting containers.
 /// </summary>
 public interface IEditorSettings : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether the explorer panel is visible.
+    /// </summary>
     bool IsExplorerPanelVisible { get; set; }
 
+    /// <summary>
+    /// Gets or sets the width of the explorer panel.
+    /// </summary>
     float ExplorerPanelWidth { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the inspector panel is visible.
+    /// </summary>
     bool IsInspectorPanelVisible { get; set; }
 
+    /// <summary>
+    /// Gets or sets the width of the inspector panel.
+    /// </summary>
     float InspectorPanelWidth { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the tools panel is visible.
+    /// </summary>
     bool IsToolsPanelVisible { get; set; }
 
+    /// <summary>
+    /// Gets or sets the height of the tools panel.
+    /// </summary>
     float ToolsPanelHeight { get; set; }
 
+    /// <summary>
+    /// Gets or sets the height of the detail panel.
+    /// </summary>
     float DetailPanelHeight { get; set; }
 
+    /// <summary>
+    /// Gets or sets the previous new project folder path.
+    /// </summary>
     string PreviousNewProjectFolderPath { get; set; }
 
+    /// <summary>
+    /// Gets or sets the previous project.
+    /// </summary>
     string PreviousProject { get; set; }
 
+    /// <summary>
+    /// Gets or sets the list of recent projects.
+    /// </summary>
     List<string> RecentProjects { get; set; }
 
+    /// <summary>
+    /// Gets or sets the OpenAI key.
+    /// </summary>
     string OpenAIKey { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Sheets API key.
+    /// </summary>
     string SheetsAPIKey { get; set; }
 
+    /// <summary>
+    /// Resets the settings to their default values.
+    /// </summary>
     void Reset();
 }

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Workspace/IWorkspaceService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Workspace/IWorkspaceService.cs
@@ -53,6 +53,11 @@ public interface IWorkspaceService
     IDataTransferService DataTransferService { get; }
 
     /// <summary>
+    /// Toggle focus mode on/off by hiding and showing the workspace panels.
+    /// </summary>
+    void ToggleFocusMode();
+
+    /// <summary>
     /// Set a flag to indicate that the workspace state is dirty and needs to be saved.
     /// </summary>
     void SetWorkspaceStateIsDirty();

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/MainPage.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/MainPage.cs
@@ -90,27 +90,6 @@ public sealed partial class MainPage : Page
 
         // Begin listening for user navigation events
         _mainNavigation.ItemInvoked += OnMainPage_NavigationViewItemInvoked;
-
-        // Listen for keyboard input events
-#if WINDOWS
-        mainWindow.Content.KeyDown += (s, e) =>
-        {
-            if (OnKeyDown(e.Key))
-            {
-                e.Handled = true;
-            }
-        };
-#else
-        Guard.IsNotNull(mainWindow);
-        Guard.IsNotNull(mainWindow.CoreWindow);
-        mainWindow.CoreWindow.KeyDown += (s, e) =>
-        {
-            if (OnKeyDown(e.VirtualKey))
-            {
-                e.Handled = true;
-            }
-        };
-#endif
     }
 
     private void OnMainPage_Unloaded(object sender, RoutedEventArgs e)

--- a/Celbridge/Extensions/Workspace/Celbridge.Workspace/Commands/ToggleFocusModeCommand.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Workspace/Commands/ToggleFocusModeCommand.cs
@@ -1,35 +1,26 @@
 using Celbridge.Commands;
-using Celbridge.Settings;
 
 namespace Celbridge.Workspace.Commands;
 
 public class ToggleFocusModeCommand : CommandBase, IToggleFocusModeCommand
 {
-    private readonly IEditorSettings _editorSettings;
+    private readonly IWorkspaceWrapper _workspaceWrapper;
 
-    public ToggleFocusModeCommand(IEditorSettings editorSettings)
+    public ToggleFocusModeCommand(IWorkspaceWrapper workspaceWrapper)
     {
-        _editorSettings = editorSettings;
+        _workspaceWrapper = workspaceWrapper;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
-        // Are we in focus mode?
-        bool isFocusModeActive = !_editorSettings.IsExplorerPanelVisible && 
-            !_editorSettings.IsInspectorPanelVisible;
+        if (!_workspaceWrapper.IsWorkspacePageLoaded)
+        {
+            return Result.Fail("Workspace is not loaded.");
+        }
 
-        if (isFocusModeActive) 
-        {
-            // Exit focus mode
-            _editorSettings.IsExplorerPanelVisible = true;
-            _editorSettings.IsInspectorPanelVisible = true;
-        }
-        else
-        {
-            // Enter focus mode
-            _editorSettings.IsExplorerPanelVisible = false;
-            _editorSettings.IsInspectorPanelVisible = false;
-        }
+        var workspaceService = _workspaceWrapper.WorkspaceService;
+
+        workspaceService.ToggleFocusMode();
 
         await Task.CompletedTask;
 


### PR DESCRIPTION
Hidden files and folders do not get added to the resource registry.
Toggle focus command now remembers if the tools panel was previously visible when exiting focus mode.