### PR TITLE
Download files to project root when viewing web pages in .web documents

### DIFF
--- a/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -352,7 +352,7 @@
     <value>You have no recent projects.</value>
   </data>
   <data name="NewProjectDialog_CreateSubfolder" xml:space="preserve">
-    <value>Create project in a new subfolder</value>
+    <value>Place project in a subfolder with the same name</value>
   </data>
   <data name="NewProjectDialog_CreateSubfolderTooltip" xml:space="preserve">
     <value>Places the project file in a new subfolder with the same name as the project</value>

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Utilities/IUtilityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Utilities/IUtilityService.cs
@@ -1,4 +1,4 @@
-﻿namespace Celbridge.Utilities;
+namespace Celbridge.Utilities;
 
 /// <summary>
 /// Provides access to common low-level utility methods.
@@ -10,6 +10,11 @@ public interface IUtilityService
     /// The path includes the specified folder name and extension.
     /// </summary>
     string GetTemporaryFilePath(string folderName, string extension);
+
+    /// <summary>
+    /// Returns a path which is guaranteed not to clash with any existing file or folder.
+    /// </summary>
+    Result<string> GetUniquePath(string path);
 
     /// <summary>
     /// Returns environment information the runtime application.

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/MainPage.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/MainPage.cs
@@ -90,6 +90,27 @@ public sealed partial class MainPage : Page
 
         // Begin listening for user navigation events
         _mainNavigation.ItemInvoked += OnMainPage_NavigationViewItemInvoked;
+
+        // Listen for keyboard input events (required for undo / redo)
+#if WINDOWS
+        mainWindow.Content.KeyDown += (s, e) =>
+        {
+            if (OnKeyDown(e.Key))
+            {
+                e.Handled = true;
+            }
+        };
+#else
+        Guard.IsNotNull(mainWindow);
+        Guard.IsNotNull(mainWindow.CoreWindow);
+        mainWindow.CoreWindow.KeyDown += (s, e) =>
+        {
+            if (OnKeyDown(e.VirtualKey))
+            {
+                e.Handled = true;
+            }
+        };
+#endif
     }
 
     private void OnMainPage_Unloaded(object sender, RoutedEventArgs e)

--- a/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
+++ b/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
@@ -24,6 +24,44 @@ public class UtilityService : IUtilityService
         return archivePath;
     }
 
+    public Result<string> GetUniquePath(string path)
+    {
+        try
+        {
+            path = Path.GetFullPath(path);
+
+            string directoryPath = Path.GetDirectoryName(path)!;
+            string nameWithoutExtension = Path.GetFileNameWithoutExtension(path);
+            string extension = Path.GetExtension(path);
+            string uniqueName = Path.GetFileName(path);
+            int count = 1;
+
+            while (File.Exists(Path.Combine(directoryPath, uniqueName)) || 
+                Directory.Exists(Path.Combine(directoryPath, uniqueName)))
+            {
+                if (!string.IsNullOrEmpty(extension))
+                {
+                    // If it's a file, add the number before the extension
+                    uniqueName = $"{nameWithoutExtension} ({count}){extension}";
+                }
+                else
+                {
+                    // If it's a folder (or file with no extension), just append the number
+                    uniqueName = $"{nameWithoutExtension} ({count})";
+                }
+                count++;
+            }
+
+            var output = Path.Combine(directoryPath, uniqueName);
+
+            return Result<string>.Ok(output);
+        }
+        catch (Exception ex)
+        {
+            return Result<string>.Fail(ex, $"An exception occurred when generating a unique path: {path}");
+        }
+    }
+
     public EnvironmentInfo GetEnvironmentInfo()
     {
 #if WINDOWS

--- a/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
@@ -1,11 +1,20 @@
+using Celbridge.Commands;
 using Celbridge.Documents.ViewModels;
 using Celbridge.Explorer;
+using Celbridge.Logging;
+using Celbridge.Utilities;
 using Celbridge.Workspace;
+using Microsoft.Web.WebView2.Core;
+
+using Path = System.IO.Path;
 
 namespace Celbridge.Documents.Views;
 
 public sealed partial class WebPageDocumentView : DocumentView
 {
+    private ILogger<WebPageDocumentView> _logger;
+    private ICommandService _commandService;
+    private IUtilityService _utilityService;
     private IResourceRegistry _resourceRegistry;
 
     public WebPageDocumentViewModel ViewModel { get; }
@@ -13,9 +22,16 @@ public sealed partial class WebPageDocumentView : DocumentView
     private WebView2 _webView;
 
     public WebPageDocumentView(
+        ILogger<WebPageDocumentView> logger,
         IServiceProvider serviceProvider,
+        ICommandService commandService,
+        IUtilityService utilityService,
         IWorkspaceWrapper workspaceWrapper)
     {
+        _logger = logger;
+        _commandService = commandService;
+        _utilityService = utilityService;
+
         ViewModel = serviceProvider.GetRequiredService<WebPageDocumentViewModel>();
 
         _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
@@ -33,6 +49,74 @@ public sealed partial class WebPageDocumentView : DocumentView
 
         this.DataContext(ViewModel, (userControl, vm) => userControl
             .Content(_webView));
+    }
+
+    private async Task InitializeWebView()
+    {
+        await _webView.EnsureCoreWebView2Async();
+
+        // Ensure we only register once for this event
+        _webView.CoreWebView2.DownloadStarting -= CoreWebView2_DownloadStarting;
+        _webView.CoreWebView2.DownloadStarting += CoreWebView2_DownloadStarting;
+    }
+
+
+    private async void CoreWebView2_DownloadStarting(CoreWebView2 sender, CoreWebView2DownloadStartingEventArgs args)
+    {
+        var downloadPath = args.ResultFilePath; 
+        var filename = Path.GetFileName(downloadPath);
+
+        //
+        // Map the download path to a unique path in the project folder 
+        //
+        var requestedPath = _resourceRegistry.GetResourcePath(filename);
+        var getResult = _utilityService.GetUniquePath(requestedPath);
+        if (getResult.IsFailure)
+        {
+            // Don't allow the download to proceed if we can't generate a unique path
+            args.Cancel = true;
+            return;
+        }
+        var savePath = getResult.Value;
+
+        //
+        // Get the resource key for the save path
+        //
+        var getResourceResult = _resourceRegistry.GetResourceKey(savePath);
+        if (getResourceResult.IsFailure)
+        {
+            args.Cancel = true;
+            return;
+        }
+        var saveResourceKey = getResourceResult.Value;
+
+        //
+        // Redirect download to a temporary path
+        //
+        var extension = Path.GetExtension(filename);
+        var tempPath = _utilityService.GetTemporaryFilePath("Downloads", extension);
+        args.ResultFilePath = tempPath;
+
+        //
+        // Handle download state changes
+        //
+        args.DownloadOperation.StateChanged += (s, e) =>
+        {
+            if (s.State == CoreWebView2DownloadState.Completed)
+            {
+                // _logger.LogInformation($"Downloaded: {requestedPath}");
+                _commandService.Execute<IAddResourceCommand>(command =>
+                {
+                    command.ResourceType = ResourceType.File;
+                    command.SourcePath = tempPath;
+                    command.DestResource = saveResourceKey;
+                });
+            }
+            else if (s.State == CoreWebView2DownloadState.Interrupted)
+            {
+                File.Delete(tempPath);
+            }
+        };
     }
 
     public override async Task<Result> SetFileResource(ResourceKey fileResource)
@@ -59,6 +143,8 @@ public sealed partial class WebPageDocumentView : DocumentView
 
     public override async Task<Result> LoadContent()
     {
+        await InitializeWebView();
+
         return await ViewModel.LoadContent();
     }
 }

--- a/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
@@ -104,6 +104,7 @@ public sealed partial class WebPageDocumentView : DocumentView
         {
             if (s.State == CoreWebView2DownloadState.Completed)
             {
+                // Move the file to the requested path, with undo support.
                 // _logger.LogInformation($"Downloaded: {requestedPath}");
                 _commandService.Execute<IAddResourceCommand>(command =>
                 {

--- a/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
+++ b/Celbridge/Extensions/Workspace/Celbridge.Documents/Views/WebPageDocumentView.cs
@@ -61,7 +61,7 @@ public sealed partial class WebPageDocumentView : DocumentView
     }
 
 
-    private async void CoreWebView2_DownloadStarting(CoreWebView2 sender, CoreWebView2DownloadStartingEventArgs args)
+    private void CoreWebView2_DownloadStarting(CoreWebView2 sender, CoreWebView2DownloadStartingEventArgs args)
     {
         var downloadPath = args.ResultFilePath; 
         var filename = Path.GetFileName(downloadPath);


### PR DESCRIPTION
Intercept the file download from WebView2 and save the file to a temporary location.
Uses the AddResource command to then move the file into the project, with undo support.