### PR TITLE
Add Resource Data system to store meta data for resources

### DIFF
--- a/Celbridge/Celbridge.sln
+++ b/Celbridge/Celbridge.sln
@@ -72,6 +72,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Celbridge.SharedTypes", "Sh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Celbridge.Extensions", "CoreServices\Celbridge.Extensions\Celbridge.Extensions.csproj", "{C02F2C06-42B9-40FF-A4B7-2295DC62171D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Celbridge.ResourceData", "Modules\Workspace\Celbridge.ResourceData\Celbridge.ResourceData.csproj", "{1A9C6DC7-8411-4F48-9473-F6160E207783}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -174,6 +176,10 @@ Global
 		{C02F2C06-42B9-40FF-A4B7-2295DC62171D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C02F2C06-42B9-40FF-A4B7-2295DC62171D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C02F2C06-42B9-40FF-A4B7-2295DC62171D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A9C6DC7-8411-4F48-9473-F6160E207783}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9C6DC7-8411-4F48-9473-F6160E207783}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A9C6DC7-8411-4F48-9473-F6160E207783}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9C6DC7-8411-4F48-9473-F6160E207783}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,6 +209,7 @@ Global
 		{C0096042-45E3-49A1-B41C-9A7C2C3FD304} = {ACFAE14E-C62C-4B0E-BE10-1221C8E90492}
 		{53BB762B-1EE5-4EAE-9E01-103A989FD96B} = {ACFAE14E-C62C-4B0E-BE10-1221C8E90492}
 		{C02F2C06-42B9-40FF-A4B7-2295DC62171D} = {CBDD78F8-9AF9-4805-8B33-6CDA18F7E94B}
+		{1A9C6DC7-8411-4F48-9473-F6160E207783} = {00D6636E-63D7-4B7C-AEB0-9A433AA10316}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {695F2378-3B43-4460-9FB8-6D27C121D85D}

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Core/ResourceDataConstants.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Core/ResourceDataConstants.cs
@@ -1,0 +1,14 @@
+namespace Celbridge.Core;
+
+public static class ResourceDataConstants
+{
+    /// <summary>
+    /// ShowEditor property for text file resources.
+    /// </summary>
+    public const string TextEditor_ShowEditor = "ShowEditor";
+
+    /// <summary>
+    /// ShowPreview property for text file resources.
+    /// </summary>
+    public const string TextEditor_ShowPreview = "ShowPreview";
+}

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
@@ -4,13 +4,23 @@ public interface IResourceDataService
 {
     /// <summary>
     /// Gets the value of a property from the "Properties" object in the root of the resource data.
+    /// If the property is not found, defaultValue is returned instead.
+    /// Throws an invalid operation exception if an error occurs while getting the property.
     /// </summary>
-    Result<T> GetProperty<T>(ResourceKey resource, string propertyName, T defaultValue = default(T)!) where T : notnull;
+    T? GetProperty<T>(ResourceKey resource, string propertyName, T? defaultValue) where T : notnull;
+
+    /// <summary>
+    /// Gets the value of a property from the "Properties" object in the root of the resource data.
+    /// If the property is not found, default(T) is returned instead.
+    /// Throws an invalid operation exception if an error occurs while getting the property.
+    /// </summary>
+    T? GetProperty<T>(ResourceKey resource, string propertyName) where T : notnull;
 
     /// <summary>
     /// Sets the value of a property in the "Properties" object in the root of the resource data.
+    /// Throws an invalid operation exception if an error occurs while setting the property.
     /// </summary>
-    Result SetProperty<T>(ResourceKey resource, string propertyName, T newValue) where T : notnull;
+    void SetProperty<T>(ResourceKey resource, string propertyName, T newValue) where T : notnull;
 
     /// <summary>
     /// Registers a callback that gets triggered when a property in the resource is modified.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
@@ -1,0 +1,50 @@
+namespace Celbridge.ResourceData;
+
+public interface IResourceDataService
+{
+    /// <summary>
+    /// Acquires the resource data for the given resource.
+    /// If a resource data file already exists, it is loaded into memory, otherwise a new
+    /// resource data instance is allocated.
+    /// </summary>
+    Result AcquireResourceData(ResourceKey resource);
+
+    /// <summary>
+    /// Gets the value at the specified JSON path for the given resource.
+    /// </summary>
+    Result<T> GetValue<T>(ResourceKey resource, string jsonPath) where T : notnull;
+
+    /// <summary>
+    /// Gets the value at the specified JSON path for the given resource.
+    /// If the path is not found, then defaultValue is returned.
+    /// </summary>
+    Result<T> GetValue<T>(ResourceKey resource, string jsonPath, T defaultValue) where T : notnull;
+
+    /// <summary>
+    /// Sets the value at the specified JSON path for the given resource key.
+    /// Automatically creates a new JSON file if it doesn't exist.
+    /// </summary>
+    public Result SetValue<T>(ResourceKey resource, string jsonPath, T newValue) where T : notnull;
+
+    /// <summary>
+    /// Updates all internal references from the old resource key to the new resource key.
+    /// Also renames the backing JSON file.
+    /// </summary>
+    Result RemapResourceKey(ResourceKey oldResource, ResourceKey newResource);
+
+    /// <summary>
+    /// Saves all modified resources to disk asynchronously and clears the modified list.
+    /// </summary>
+    Task<Result> SavePendingAsync();
+
+    /// <summary>
+    /// Registers a callback that gets triggered when the resource data for the specified key is modified.
+    /// Multiple listeners can register for the same resource, and each must pass an object.
+    /// </summary>
+    void RegisterNotifier(ResourceKey resourceKey, object recipient, Action<ResourceKey, string> callback);
+
+    /// <summary>
+    /// Unregisters a notifier callback for the given resource key based on the recipient object.
+    /// </summary>
+    void UnregisterNotifier(ResourceKey resourceKey, object recipient);
+}

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
@@ -1,5 +1,13 @@
 namespace Celbridge.ResourceData;
 
+/// <summary>
+/// Represents a callback method that is triggered when a property in a resource is modified.
+/// The callback provides the <see cref="ResourceKey"/> of the modified resource and the name of the modified property.
+/// </summary>
+/// <param name="resource">The resource that was modified.</param>
+/// <param name="propertyName">The name of the property that was modified.</param>
+public delegate void ResourcePropertyChangedNotifier(ResourceKey resource, string propertyName);
+
 public interface IResourceDataService
 {
     /// <summary>
@@ -25,7 +33,7 @@ public interface IResourceDataService
     /// <summary>
     /// Registers a callback that gets triggered when a property in the resource is modified.
     /// </summary>
-    void RegisterNotifier(ResourceKey resource, object recipient, Action<ResourceKey, string> callback);
+    void RegisterNotifier(ResourceKey resource, object recipient, ResourcePropertyChangedNotifier notifier);
 
     /// <summary>
     /// Unregisters a callback for the given resource key and recipient.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/ResourceData/IResourceDataService.cs
@@ -3,48 +3,33 @@ namespace Celbridge.ResourceData;
 public interface IResourceDataService
 {
     /// <summary>
-    /// Acquires the resource data for the given resource.
-    /// If a resource data file already exists, it is loaded into memory, otherwise a new
-    /// resource data instance is allocated.
+    /// Gets the value of a property from the "Properties" object in the root of the resource data.
     /// </summary>
-    Result AcquireResourceData(ResourceKey resource);
+    Result<T> GetProperty<T>(ResourceKey resource, string propertyName, T defaultValue = default(T)!) where T : notnull;
 
     /// <summary>
-    /// Gets the value at the specified JSON path for the given resource.
+    /// Sets the value of a property in the "Properties" object in the root of the resource data.
     /// </summary>
-    Result<T> GetValue<T>(ResourceKey resource, string jsonPath) where T : notnull;
+    Result SetProperty<T>(ResourceKey resource, string propertyName, T newValue) where T : notnull;
 
     /// <summary>
-    /// Gets the value at the specified JSON path for the given resource.
-    /// If the path is not found, then defaultValue is returned.
+    /// Registers a callback that gets triggered when a property in the resource is modified.
     /// </summary>
-    Result<T> GetValue<T>(ResourceKey resource, string jsonPath, T defaultValue) where T : notnull;
+    void RegisterNotifier(ResourceKey resource, object recipient, Action<ResourceKey, string> callback);
 
     /// <summary>
-    /// Sets the value at the specified JSON path for the given resource key.
-    /// Automatically creates a new JSON file if it doesn't exist.
+    /// Unregisters a callback for the given resource key and recipient.
     /// </summary>
-    public Result SetValue<T>(ResourceKey resource, string jsonPath, T newValue) where T : notnull;
+    void UnregisterNotifier(ResourceKey resource, object recipient);
 
     /// <summary>
-    /// Updates all internal references from the old resource key to the new resource key.
-    /// Also renames the backing JSON file.
+    /// Remaps the old resource key to a new resource key.
     /// </summary>
     Result RemapResourceKey(ResourceKey oldResource, ResourceKey newResource);
 
     /// <summary>
-    /// Saves all modified resources to disk asynchronously and clears the modified list.
+    /// Saves all modified resources to disk asynchronously.
     /// </summary>
     Task<Result> SavePendingAsync();
-
-    /// <summary>
-    /// Registers a callback that gets triggered when the resource data for the specified key is modified.
-    /// Multiple listeners can register for the same resource, and each must pass an object.
-    /// </summary>
-    void RegisterNotifier(ResourceKey resourceKey, object recipient, Action<ResourceKey, string> callback);
-
-    /// <summary>
-    /// Unregisters a notifier callback for the given resource key based on the recipient object.
-    /// </summary>
-    void UnregisterNotifier(ResourceKey resourceKey, object recipient);
 }
+

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Workspace/IWorkspaceService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Workspace/IWorkspaceService.cs
@@ -2,8 +2,8 @@ using Celbridge.Console;
 using Celbridge.DataTransfer;
 using Celbridge.Documents;
 using Celbridge.Explorer;
-using Celbridge.Extensions;
 using Celbridge.Inspector;
+using Celbridge.ResourceData;
 using Celbridge.Scripting;
 using Celbridge.Status;
 
@@ -58,6 +58,11 @@ public interface IWorkspaceService
     /// Returns the Data Transfer Service associated with the workspace.
     /// </summary>
     IDataTransferService DataTransferService { get; }
+
+    /// <summary>
+    /// Returns the Resource Data Service associated with the workspace.
+    /// </summary>
+    IResourceDataService ResourceDataService { get; }
 
     /// <summary>
     /// Toggle focus mode on/off by hiding and showing the workspace panels.

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
@@ -10,9 +10,6 @@ namespace Celbridge.Documents.ViewModels;
 
 public partial class TextEditorDocumentViewModel : ObservableObject
 {
-    private const string ShowEditorKey = "ShowEditor";
-    private const string ShowPreviewKey = "ShowPreview";
-
     private readonly ILogger<TextEditorDocumentViewModel> _logger;
     private readonly IDocumentsService _documentsService;
     private readonly IResourceDataService _resourceDataService;
@@ -66,8 +63,8 @@ public partial class TextEditorDocumentViewModel : ObservableObject
 
     private void FileResource_PropertyChanged(ResourceKey resource, string propertyName)
     {
-        if (propertyName == ShowEditorKey ||
-            propertyName == ShowPreviewKey)
+        if (propertyName == ResourceDataConstants.TextEditor_ShowEditor ||
+            propertyName == ResourceDataConstants.TextEditor_ShowPreview)
         {
             UpdatePanelVisibility();
         }
@@ -77,8 +74,8 @@ public partial class TextEditorDocumentViewModel : ObservableObject
     {
         try
         {
-            ShowEditor = _resourceDataService.GetProperty(_fileResource, ShowEditorKey, true);
-            ShowPreview = _resourceDataService.GetProperty(_fileResource, ShowPreviewKey, true);
+            ShowEditor = _resourceDataService.GetProperty(_fileResource, ResourceDataConstants.TextEditor_ShowEditor, true);
+            ShowPreview = _resourceDataService.GetProperty(_fileResource, ResourceDataConstants.TextEditor_ShowPreview, true);
         }
         catch (Exception ex)
         {

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
@@ -1,4 +1,5 @@
 using Celbridge.ExtensionAPI;
+using Celbridge.Logging;
 using Celbridge.ResourceData;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -12,6 +13,7 @@ public partial class TextEditorDocumentViewModel : ObservableObject
     private const string ShowEditorKey = "ShowEditor";
     private const string ShowPreviewKey = "ShowPreview";
 
+    private readonly ILogger<TextEditorDocumentViewModel> _logger;
     private readonly IDocumentsService _documentsService;
     private readonly IResourceDataService _resourceDataService;
 
@@ -23,8 +25,11 @@ public partial class TextEditorDocumentViewModel : ObservableObject
     [ObservableProperty]
     private bool _showPreview = true;
 
-    public TextEditorDocumentViewModel(IWorkspaceWrapper workspaceWrapper)
+    public TextEditorDocumentViewModel(
+        ILogger<TextEditorDocumentViewModel> logger,
+        IWorkspaceWrapper workspaceWrapper)
     {
+        _logger = logger;
         _documentsService = workspaceWrapper.WorkspaceService.DocumentsService;
         _resourceDataService = workspaceWrapper.WorkspaceService.ResourceDataService;
     }
@@ -70,16 +75,14 @@ public partial class TextEditorDocumentViewModel : ObservableObject
 
     private void UpdatePanelVisibility()
     {
-        var getEditorResult = _resourceDataService.GetProperty(_fileResource, ShowEditorKey, true);
-        if (getEditorResult.IsSuccess)
+        try
         {
-            ShowEditor = getEditorResult.Value;
+            ShowEditor = _resourceDataService.GetProperty(_fileResource, ShowEditorKey, true);
+            ShowPreview = _resourceDataService.GetProperty(_fileResource, ShowPreviewKey, true);
         }
-
-        var getPreviewResult = _resourceDataService.GetProperty(_fileResource, ShowPreviewKey, true);
-        if (getPreviewResult.IsSuccess)
+        catch (Exception ex)
         {
-            ShowPreview = getPreviewResult.Value;
+            _logger.LogError(ex.Message);
         }
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml
@@ -12,7 +12,7 @@
 
   <Grid HorizontalAlignment="Stretch">
     <Grid.ColumnDefinitions>
-      <ColumnDefinition x:Name="LeftColumn" Width="*"/>
+      <ColumnDefinition x:Name="LeftColumn" Width="*" />
       <ColumnDefinition x:Name="RightColumn" Width="*" />
     </Grid.ColumnDefinitions>
 

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml.cs
@@ -126,8 +126,15 @@ public sealed partial class TextEditorDocumentView : UserControl, IDocumentView
 
     private void UpdatePanelVisibility()
     {
-        bool isEditorVisible = _supportsPreview && ViewModel.ShowEditor; 
-        bool isPreviewVisible = _supportsPreview && ViewModel.ShowPreview;
+        // Default to no preview available
+        bool isEditorVisible = true;
+        bool isPreviewVisible = false;
+
+        if (_supportsPreview)
+        {
+            isEditorVisible = ViewModel.ShowEditor;
+            isPreviewVisible = ViewModel.ShowPreview;
+        }
 
 #if WINDOWS
         LeftColumn.Width = isEditorVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0);

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
@@ -49,48 +49,36 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     public IRelayCommand ToggleEditorCommand => new RelayCommand(ToggleEditor_Executed);
     private void ToggleEditor_Executed()
     {
-        var getResult = _resourceDataService.GetProperty(Resource, ShowEditorKey, false);
-        if (getResult.IsFailure)
+        try
         {
-            _logger.LogError(getResult.Error);
-            return;
+            bool showEditor = _resourceDataService.GetProperty(Resource, ShowEditorKey, false);
+            showEditor = !showEditor;
+            _resourceDataService.SetProperty(Resource, ShowEditorKey, showEditor);
+
+            // Todo: Save the resource data on a timer
+            _resourceDataService.SavePendingAsync();
         }
-        bool showEditor = getResult.Value;
-
-        showEditor = !showEditor;
-
-        var setResult = _resourceDataService.SetProperty(Resource, ShowEditorKey, showEditor);
-        if (setResult.IsFailure)
+        catch (Exception ex)
         {
-            _logger.LogError(getResult.Error);
-            return;
+            _logger.LogError(ex.Message);
         }
-
-        // Todo: Save the resource data on a timer
-        _resourceDataService.SavePendingAsync();
     }
 
     public IRelayCommand TogglePreviewCommand => new RelayCommand(TogglePreview_Executed);
     private void TogglePreview_Executed()
     {
-        var getResult = _resourceDataService.GetProperty(Resource, ShowPreviewKey, false);
-        if (getResult.IsFailure)
+        try
         {
-            _logger.LogError(getResult.Error);
-            return;
+            bool showPreview = _resourceDataService.GetProperty(Resource, ShowPreviewKey, false);
+            showPreview = !showPreview;
+            _resourceDataService.SetProperty(Resource, ShowPreviewKey, showPreview);
+
+            // Todo: Save the resource data on a timer
+            _resourceDataService.SavePendingAsync();
         }
-        bool showPreview = getResult.Value;
-
-        showPreview = !showPreview;
-
-        var setResult = _resourceDataService.SetProperty(Resource, ShowPreviewKey, showPreview);
-        if (setResult.IsFailure)
+        catch (Exception ex)
         {
-            _logger.LogError(getResult.Error);
-            return;
+            _logger.LogError(ex.Message);
         }
-
-        // Todo: Save the resource data on a timer
-        _resourceDataService.SavePendingAsync();
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
@@ -4,19 +4,27 @@ using Celbridge.Explorer;
 using Celbridge.Logging;
 using Celbridge.ResourceData;
 using Celbridge.Workspace;
+using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace Celbridge.Inspector.ViewModels;
 
 public partial class MarkdownInspectorViewModel : InspectorViewModel
 {
-    private const string ShowPreviewKey = "ShowPreview";
-    private const string ShowEditorKey = "ShowEditor";
-
     private readonly ILogger<MarkdownInspectorViewModel> _logger;
     private readonly ICommandService _commandService;
     private readonly IResourceRegistry _resourceRegistry;
     private readonly IResourceDataService _resourceDataService;
+
+    [ObservableProperty]
+    private bool _showEditorEnabled;
+
+    [ObservableProperty]
+    private bool _showBothEnabled;
+
+    [ObservableProperty]
+    private bool _showPreviewEnabled;
 
     // Code gen requires a parameterless constructor
     public MarkdownInspectorViewModel()
@@ -33,6 +41,16 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
         _commandService = commandService;
         _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
         _resourceDataService = workspaceWrapper.WorkspaceService.ResourceDataService;
+
+        PropertyChanged += MarkdownInspectorViewModel_PropertyChanged;
+    }
+
+    private void MarkdownInspectorViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(Resource))
+        {
+            UpdateButtonState();
+        }
     }
 
     public IRelayCommand OpenDocumentCommand => new RelayCommand(OpenDocument_Executed);
@@ -46,14 +64,34 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
         });
     }
 
-    public IRelayCommand ToggleEditorCommand => new RelayCommand(ToggleEditor_Executed);
-    private void ToggleEditor_Executed()
+    public IRelayCommand ShowEditorCommand => new RelayCommand(ShowEditor_Executed);
+    private void ShowEditor_Executed()
     {
+        SetPanelVisibility(true, false);
+    }
+
+    public IRelayCommand ShowPreviewCommand => new RelayCommand(ShowPreview_Executed);
+    private void ShowPreview_Executed()
+    {
+        SetPanelVisibility(false, true);
+    }
+
+    public IRelayCommand ShowBothCommand => new RelayCommand(ShowEditorAndPreview_Executed);
+    private void ShowEditorAndPreview_Executed()
+    {
+        SetPanelVisibility(true, true);
+    }
+
+    private void SetPanelVisibility(bool showEditor, bool showPreview)
+    {
+        Guard.IsTrue(showEditor || showPreview);
+
         try
         {
-            bool showEditor = _resourceDataService.GetProperty(Resource, ShowEditorKey, false);
-            showEditor = !showEditor;
-            _resourceDataService.SetProperty(Resource, ShowEditorKey, showEditor);
+            _resourceDataService.SetProperty(Resource, ResourceDataConstants.TextEditor_ShowEditor, showEditor);
+            _resourceDataService.SetProperty(Resource, ResourceDataConstants.TextEditor_ShowPreview, showPreview);
+
+            UpdateButtonState();
 
             // Todo: Save the resource data on a timer
             _resourceDataService.SavePendingAsync();
@@ -64,21 +102,22 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
         }
     }
 
-    public IRelayCommand TogglePreviewCommand => new RelayCommand(TogglePreview_Executed);
-    private void TogglePreview_Executed()
+    private void UpdateButtonState()
     {
         try
         {
-            bool showPreview = _resourceDataService.GetProperty(Resource, ShowPreviewKey, false);
-            showPreview = !showPreview;
-            _resourceDataService.SetProperty(Resource, ShowPreviewKey, showPreview);
+            bool showingEditor = _resourceDataService.GetProperty(Resource, ResourceDataConstants.TextEditor_ShowEditor, true);
+            bool showingPreview = _resourceDataService.GetProperty(Resource, ResourceDataConstants.TextEditor_ShowPreview, true);
+            bool showingBoth = showingEditor && showingPreview;
 
-            // Todo: Save the resource data on a timer
-            _resourceDataService.SavePendingAsync();
+            ShowEditorEnabled = !showingEditor || (showingBoth);
+            ShowPreviewEnabled = !showingPreview || (showingBoth);
+            ShowBothEnabled = !showingBoth;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex.Message);
         }
     }
+
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
@@ -31,7 +31,7 @@ public partial class MarkdownInspector : UserControl, IInspector
 
         DataContext = viewModel;
 
-        this.DataContext<WebInspectorViewModel>((inspector, vm) => inspector
+        this.DataContext<MarkdownInspectorViewModel>((inspector, vm) => inspector
             .Content
             (
                 new Grid()
@@ -43,51 +43,55 @@ public partial class MarkdownInspector : UserControl, IInspector
                         new StackPanel()
                             .Orientation(Orientation.Horizontal)
                             .HorizontalAlignment(HorizontalAlignment.Center)
-                            .Spacing(2)
                             .Children
                             (
                                 new Button()
-                                    .Grid(column: 1)
-                                    .Margin(2, 0, 2, 0)
+                                    .Margin(2, 2, 8, 0)
                                     .HorizontalAlignment(HorizontalAlignment.Center)
-                                    .Command(ViewModel.OpenDocumentCommand)
+                                    .Command(() => vm.OpenDocumentCommand)
                                     .ToolTipService(null, null, "Open document")
                                     .Content
                                     (
-                                        new StackPanel()
-                                            .Orientation(Orientation.Horizontal)
-                                            .Children(
-                                                new SymbolIcon()
-                                                    .Symbol(Symbol.OpenFile)
-                                                    .Margin(8, 0, 0, 0)
-                                            )
+                                        new SymbolIcon()
+                                            .Symbol(Symbol.OpenFile)
                                     ),
-                                new Button()
+                                new StackPanel()
+                                    .Orientation(Orientation.Horizontal)
                                     .HorizontalAlignment(HorizontalAlignment.Center)
-                                    .Command(ViewModel.ToggleEditorCommand)
-                                    .ToolTipService(null, null, "Show editor panel")
-                                    .Content
-                                    (
-                                        new StackPanel()
-                                            .Orientation(Orientation.Horizontal)
-                                            .Children(
+                                    .VerticalAlignment(VerticalAlignment.Center)
+                                    .Children(
+                                        new Button()
+                                            .Margin(2)
+                                            .Command(() => vm.ShowEditorCommand)
+                                            .IsEnabled(x => x.Binding(() => vm.ShowEditorEnabled)
+                                                .Mode(BindingMode.OneWay))
+                                            .ToolTipService(null, null, "Show editor panel only")
+                                            .Content
+                                            (
                                                 new SymbolIcon()
-                                                    .Symbol(Symbol.Document)
-                                                    .Margin(8, 0, 0, 0)
-                                            )
-                                    ),
-                                new Button()
-                                    .HorizontalAlignment(HorizontalAlignment.Center)
-                                    .Command(ViewModel.TogglePreviewCommand)
-                                    .ToolTipService(null, null, "Show preview panel")
-                                    .Content
-                                    (
-                                        new StackPanel()
-                                            .Orientation(Orientation.Horizontal)
-                                            .Children(
+                                                    .Symbol(Symbol.DockRight)
+                                            ),
+                                        new Button()
+                                            .Margin(2)
+                                            .Command(() => vm.ShowBothCommand)
+                                            .IsEnabled(x => x.Binding(() => vm.ShowBothEnabled)
+                                                .Mode(BindingMode.OneWay))
+                                            .ToolTipService(null, null, "Show both editor and preview panels")
+                                            .Content
+                                            (
                                                 new SymbolIcon()
-                                                    .Symbol(Symbol.PreviewLink)
-                                                    .Margin(8, 0, 0, 0)
+                                                    .Symbol(Symbol.DockBottom)
+                                            ),
+                                        new Button()
+                                            .Margin(2)
+                                            .Command(() => vm.ShowPreviewCommand)
+                                            .IsEnabled(x => x.Binding(() => vm.ShowPreviewEnabled)
+                                                .Mode(BindingMode.OneWay))
+                                            .ToolTipService(null, null, "Show preview panel only")
+                                            .Content
+                                            (
+                                                new SymbolIcon()
+                                                    .Symbol(Symbol.DockLeft)
                                             )
                                     )
                             )

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
@@ -64,6 +64,7 @@ public partial class MarkdownInspector : UserControl, IInspector
                                     ),
                                 new Button()
                                     .HorizontalAlignment(HorizontalAlignment.Center)
+                                    .Command(ViewModel.ToggleEditorCommand)
                                     .ToolTipService(null, null, "Show editor panel")
                                     .Content
                                     (
@@ -77,6 +78,7 @@ public partial class MarkdownInspector : UserControl, IInspector
                                     ),
                                 new Button()
                                     .HorizontalAlignment(HorizontalAlignment.Center)
+                                    .Command(ViewModel.TogglePreviewCommand)
                                     .ToolTipService(null, null, "Show preview panel")
                                     .Content
                                     (

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Celbridge.ResourceData.csproj
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Celbridge.ResourceData.csproj
@@ -21,22 +21,14 @@
     </UnoFeatures>
 
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />
-	  <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" />
-    <PackageReference Include="Newtonsoft.Json"/>
-	  <PackageReference Include="sqlite-net-pcl" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <ProjectReference Include="..\Celbridge.Console\Celbridge.Console.csproj" />
-    <ProjectReference Include="..\Celbridge.Documents\Celbridge.Documents.csproj" />
-    <ProjectReference Include="..\Celbridge.Explorer\Celbridge.Explorer.csproj" />
-    <ProjectReference Include="..\Celbridge.Inspector\Celbridge.Inspector.csproj" />
-    <ProjectReference Include="..\Celbridge.ResourceData\Celbridge.ResourceData.csproj" />
-    <ProjectReference Include="..\Celbridge.Scripting\Celbridge.Scripting.csproj" />
-    <ProjectReference Include="..\Celbridge.Status\Celbridge.Status.csproj" />
+    <ProjectReference Include="..\..\..\CoreServices\Celbridge.BaseLibrary\Celbridge.BaseLibrary.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/GlobalUsings.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Celbridge.Foundation;
+

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/ServiceConfiguration.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/ServiceConfiguration.cs
@@ -1,0 +1,16 @@
+using Celbridge.Modules;
+using Celbridge.ResourceData.Services;
+
+namespace Celbridge.ResourceData;
+
+public static class ServiceConfiguration
+{
+    public static void ConfigureServices(IModuleServiceCollection config)
+    {
+        //
+        // Register services
+        //
+
+        config.AddTransient<IResourceDataService, ResourceDataService>();
+    }
+}

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
@@ -101,7 +101,7 @@ public class ResourceData
     /// <summary>
     /// Gets the value of a property from the "Properties" object in the root.
     /// </summary>
-    public Result<T> GetProperty<T>(string propertyName, T defaultValue = default(T)!) where T : notnull
+    public Result<T> GetProperty<T>(string propertyName) where T : notnull
     {
         try
         {
@@ -113,14 +113,19 @@ public class ResourceData
             if (properties.ContainsKey(propertyName))
             {
                 var value = properties[propertyName]!.ToObject<T>();
-                return value is null ? Result<T>.Ok(defaultValue) : Result<T>.Ok(value);
+                if (value is not null)
+                {
+                    return Result<T>.Ok(value);
+                }
             }
 
-            return Result<T>.Ok(defaultValue);
+            // Property value not found
+            return Result<T>.Fail();
         }
         catch (Exception ex)
         {
-            return Result<T>.Fail($"Failed to get property '{propertyName}' from resource '{Resource}'").WithException(ex);
+            return Result<T>.Fail($"An exception occurred when getting property '{propertyName}' from resource '{Resource}'")
+                .WithException(ex);
         }
     }
 

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
@@ -10,7 +10,7 @@ namespace Celbridge.ResourceData.Services;
 public class ResourceData
 {
     private readonly JObject _jsonData;
-    private readonly ConcurrentDictionary<WeakReference<object>, Action<ResourceKey, string>> _notifiers;
+    private readonly ConcurrentDictionary<WeakReference<object>, ResourcePropertyChangedNotifier> _notifiers;
     private bool _isModified;
 
     public ResourceKey Resource { get; private set; }
@@ -19,7 +19,7 @@ public class ResourceData
     public ResourceData()
     {
         _jsonData = new JObject();
-        _notifiers = new ConcurrentDictionary<WeakReference<object>, Action<ResourceKey, string>>();
+        _notifiers = new ConcurrentDictionary<WeakReference<object>, ResourcePropertyChangedNotifier>();
         _isModified = false;
 
         EnsurePropertiesExists();
@@ -155,10 +155,10 @@ public class ResourceData
     /// Registers a callback to be triggered when a property is modified.
     /// Uses WeakReference to allow automatic cleanup when the recipient goes out of scope.
     /// </summary>
-    public void RegisterNotifier(object recipient, Action<ResourceKey, string> callback)
+    public void RegisterNotifier(object recipient, ResourcePropertyChangedNotifier notifier)
     {
         var weakRecipient = new WeakReference<object>(recipient);
-        _notifiers[weakRecipient] = callback;
+        _notifiers[weakRecipient] = notifier;
     }
 
     /// <summary>

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceData.cs
@@ -1,0 +1,176 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Concurrent;
+using Path = System.IO.Path;
+
+namespace Celbridge.ResourceData.Services;
+
+public class ResourceData
+{
+    private readonly JObject _jsonData;
+    private readonly ConcurrentDictionary<object, Action<ResourceKey, string>> _notifiers;
+    private bool _isModified;
+
+    public ResourceKey Resource { get; private set; }
+    public string ResourceDataPath { get; private set; } = string.Empty;
+
+    public ResourceData()
+    {
+        _jsonData = new JObject();
+        _notifiers = new ConcurrentDictionary<object, Action<ResourceKey, string>>();
+        _isModified = false;
+
+        EnsurePropertiesExists();
+    }
+
+    public void SetResourceKey(ResourceKey resource, string resourceDataPath)
+    {
+        Resource = resource;
+        ResourceDataPath = resourceDataPath;
+    }
+
+    /// <summary>
+    /// Loads the resource data from disk. If the file doesn't exist, initializes an empty JObject with Properties.
+    /// </summary>
+    public Result Load(ResourceKey resource, string resourceDataPath)
+    {
+        try
+        {
+            Resource = resource;
+            ResourceDataPath = resourceDataPath;
+
+            if (File.Exists(resourceDataPath))
+            {
+                string jsonContent = File.ReadAllText(resourceDataPath);
+                var parsedData = JObject.Parse(jsonContent);
+                _jsonData.Merge(parsedData, new JsonMergeSettings
+                {
+                    MergeArrayHandling = MergeArrayHandling.Replace
+                });
+
+                EnsurePropertiesExists();
+            }
+
+            return Result.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"An exception occurred when loading resource data for '{Resource}'")
+                .WithException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Saves the resource data to disk if it has been modified.
+    /// </summary>
+    public async Task<Result> SaveAsync()
+    {
+        if (!_isModified)
+        {
+            return Result.Ok();
+        }
+
+        try
+        {
+            string jsonContent = _jsonData.ToString(Formatting.Indented);
+
+            var folder = Path.GetDirectoryName(ResourceDataPath);
+            if (!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
+            using (var writer = new StreamWriter(ResourceDataPath))
+            {
+                await writer.WriteAsync(jsonContent);
+            }
+
+            _isModified = false; // Reset modification status after saving
+            return Result.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"Failed to save resource data for '{Resource}'").WithException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Gets the value of a property from the "Properties" object in the root.
+    /// </summary>
+    public Result<T> GetProperty<T>(string propertyName, T defaultValue = default(T)!) where T : notnull
+    {
+        try
+        {
+            EnsurePropertiesExists();
+
+            var properties = (JObject)_jsonData["Properties"]!;
+            if (properties.ContainsKey(propertyName))
+            {
+                var value = properties[propertyName].ToObject<T>();
+                return value is null ? Result<T>.Ok(defaultValue) : Result<T>.Ok(value);
+            }
+
+            return Result<T>.Ok(defaultValue);
+        }
+        catch (Exception ex)
+        {
+            return Result<T>.Fail($"Failed to get property '{propertyName}' from resource '{Resource}'").WithException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Sets the value of a property in the "Properties" object in the root.
+    /// </summary>
+    public Result SetProperty<T>(string propertyName, T newValue) where T : notnull
+    {
+        try
+        {
+            EnsurePropertiesExists();
+
+            var properties = (JObject)_jsonData["Properties"]!;
+            properties[propertyName] = JToken.FromObject(newValue);
+
+            _isModified = true; // Compare the previous and new values
+            NotifyChanges(propertyName);
+            return Result.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"Failed to set property '{propertyName}' in resource '{Resource}'").WithException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Registers a callback to be triggered when a property is modified.
+    /// </summary>
+    public void RegisterNotifier(object recipient, Action<ResourceKey, string> callback)
+    {
+        _notifiers[recipient] = callback;
+    }
+
+    /// <summary>
+    /// Unregisters a callback for the given recipient.
+    /// </summary>
+    public void UnregisterNotifier(object recipient)
+    {
+        _notifiers.TryRemove(recipient, out _);
+    }
+
+    private void NotifyChanges(string propertyName)
+    {
+        foreach (var notifier in _notifiers)
+        {
+            notifier.Value.Invoke(Resource, propertyName);
+        }
+    }
+
+    private void EnsurePropertiesExists()
+    {
+        // Ensure the Properties object exists in the root
+        if (!_jsonData.ContainsKey("Properties"))
+        {
+            _jsonData["Properties"] = new JObject();
+        }
+    }
+}
+

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceDataService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceDataService.cs
@@ -1,0 +1,230 @@
+using CommunityToolkit.Diagnostics;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Concurrent;
+
+namespace Celbridge.ResourceData.Services;
+
+public class ResourceDataService : IResourceDataService
+{
+    private readonly ConcurrentDictionary<ResourceKey, JObject> _loadedResources = new();
+    private readonly ConcurrentDictionary<ResourceKey, ConcurrentDictionary<object, Action<ResourceKey, string>>> _notifiers = new(); 
+    private readonly ConcurrentBag<ResourceKey> _modifiedResources = new(); // Track modified resources
+
+    public Result AcquireResourceData(ResourceKey resource)
+    {
+        if (_loadedResources.ContainsKey(resource))
+        {
+            return Result.Ok();
+        }
+
+        try
+        {
+            string fullPath = GetFullPath(resource);
+            if (File.Exists(fullPath))
+            {
+                string jsonContent = File.ReadAllText(fullPath);
+                JObject jsonObject = JObject.Parse(jsonContent);
+                _loadedResources[resource] = jsonObject;
+            }
+            else
+            {
+                _loadedResources[resource] = new JObject(); // Create a new empty JObject if the file doesn't exist
+            }
+
+            return Result.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"An exception occurred when loading resource data: '{resource}'")
+                .WithException(ex);
+        }
+    }
+
+    public Result<T> GetValue<T>(ResourceKey resource, string jsonPath)
+        where T : notnull
+    {
+        var obj = default(T);
+        Guard.IsNotNull(obj);
+
+        return GetValue(resource, jsonPath, obj);
+    }
+
+    public Result<T> GetValue<T>(ResourceKey resource, string jsonPath, T defaultValue)
+        where T : notnull
+    {
+        var loadResult = AcquireResourceData(resource);
+        if (loadResult.IsFailure)
+        {
+            return Result<T>.Fail("Failed to load resource data")
+                .WithErrors(loadResult);
+        }
+
+        try
+        {
+            JObject loadedResource = _loadedResources[resource];
+
+            JToken? token = loadedResource.SelectToken(jsonPath);
+            if (token == null)
+            {
+                return Result<T>.Ok(defaultValue);
+            }
+
+            var obj = token.ToObject<T>();
+            return obj is null ? Result<T>.Ok(defaultValue) : Result<T>.Ok(obj);
+        }
+        catch (Exception ex)
+        {
+            return Result<T>.Fail("An exception occurred when loading resource data")
+                .WithException(ex);
+        }
+    }
+
+    public Result SetValue<T>(ResourceKey resource, string jsonPath, T newValue)
+        where T : notnull
+    {
+        var loadResult = AcquireResourceData(resource);
+        if (loadResult.IsFailure)
+        {
+            return Result.Fail($"Failed to load resource data: {resource}")
+                .WithErrors(loadResult);
+        }
+
+        try
+        {
+            JObject loadedResource = _loadedResources[resource];
+
+            JToken? token = loadedResource.SelectToken(jsonPath);
+            if (token != null)
+            {
+                token.Replace(JToken.FromObject(newValue));
+            }
+            else
+            {
+                // Add new property if path does not exist
+                loadedResource.SelectToken(jsonPath)?.Parent?.Add(newValue);
+            }
+
+            // Mark the resource as modified
+            _modifiedResources.Add(resource);
+
+            NotifyChanges(resource, jsonPath);
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"Failed to set value: '{resource}', '{jsonPath}'")
+                .WithException(ex);
+        }
+
+        return Result.Ok();
+    }
+
+    public void RegisterNotifier(ResourceKey resourceKey, object recipient, Action<ResourceKey, string> callback)
+    {
+        var recipientCallbacks = _notifiers.GetOrAdd(resourceKey, new ConcurrentDictionary<object, Action<ResourceKey, string>>());
+        recipientCallbacks[recipient] = callback;
+    }
+
+    public void UnregisterNotifier(ResourceKey resourceKey, object recipient)
+    {
+        if (_notifiers.TryGetValue(resourceKey, out var recipientCallbacks))
+        {
+            recipientCallbacks.TryRemove(recipient, out _);
+
+            // Clean up if no more recipients are listening for this resource key
+            if (recipientCallbacks.IsEmpty)
+            {
+                _notifiers.TryRemove(resourceKey, out _);
+            }
+        }
+    }
+
+    public Result RemapResourceKey(ResourceKey oldResource, ResourceKey newResource)
+    {
+        try
+        {
+            // Update the loaded resources
+            if (_loadedResources.ContainsKey(oldResource))
+            {
+                _loadedResources[newResource] = _loadedResources[oldResource];
+                _loadedResources.TryRemove(oldResource, out _);
+            }
+
+            // Update the modified resources list
+            if (_modifiedResources.Contains(oldResource))
+            {
+                _modifiedResources.Add(newResource);
+                _modifiedResources.TryTake(out oldResource);
+            }
+
+            // Update the notifiers
+            if (_notifiers.ContainsKey(oldResource))
+            {
+                _notifiers[newResource] = _notifiers[oldResource];
+                _notifiers.TryRemove(oldResource, out _);
+            }
+
+            // Rename the backing JSON file
+            string oldFilePath = GetFullPath(oldResource);
+            string newFilePath = GetFullPath(newResource);
+            if (File.Exists(oldFilePath))
+            {
+                File.Move(oldFilePath, newFilePath);
+            }
+
+            return Result.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"Failed to remap resource: '{oldResource}' to '{newResource}'")
+                .WithException(ex);
+        }
+    }
+
+    public async Task<Result> SavePendingAsync()
+    {
+        foreach (var resourceKey in _modifiedResources)
+        {
+            if (_loadedResources.ContainsKey(resourceKey))
+            {
+                try
+                {
+                    string fullPath = GetFullPath(resourceKey);
+                    string jsonContent = _loadedResources[resourceKey].ToString(Formatting.Indented);
+
+                    using (var writer = new StreamWriter(fullPath))
+                    {
+                        await writer.WriteAsync(jsonContent);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    return Result.Fail($"An exception occurred when saving resource '{resourceKey}'")
+                        .WithException(ex);
+                }
+            }
+        }
+
+        // Clear the modified resources list
+        _modifiedResources.Clear();
+
+        return Result.Ok();
+    }
+
+    private void NotifyChanges(ResourceKey resource, string jsonPath)
+    {
+        if (_notifiers.ContainsKey(resource))
+        {
+            foreach (var recipientCallback in _notifiers[resource])
+            {
+                recipientCallback.Value.Invoke(resource, jsonPath);
+            }
+        }
+    }
+
+    private string GetFullPath(ResourceKey resource)
+    {
+        // Todo: Map this to the file path in the CelData folder
+        return resource;
+    }
+}

--- a/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceDataService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.ResourceData/Services/ResourceDataService.cs
@@ -73,14 +73,14 @@ public class ResourceDataService : IResourceDataService
     }
 
     /// <summary>
-    /// Registers a callback that gets triggered when a property in the resource is modified.
+    /// Registers a notifier that gets triggered when a property in the resource is modified.
     /// </summary>
-    public void RegisterNotifier(ResourceKey resourceKey, object recipient, Action<ResourceKey, string> callback)
+    public void RegisterNotifier(ResourceKey resourceKey, object recipient, ResourcePropertyChangedNotifier notifier)
     {
         var loadResult = AcquireResourceData(resourceKey);
         if (loadResult.IsSuccess)
         {
-            _resourceDataCache[resourceKey].RegisterNotifier(recipient, callback);
+            _resourceDataCache[resourceKey].RegisterNotifier(recipient, notifier);
         }
     }
 

--- a/Celbridge/Modules/Workspace/Celbridge.Workspace/Module.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Workspace/Module.cs
@@ -20,6 +20,7 @@ public class Extension : IModule
         Documents.ServiceConfiguration.ConfigureServices(config);
         Explorer.ServiceConfiguration.ConfigureServices(config);
         Inspector.ServiceConfiguration.ConfigureServices(config);
+        ResourceData.ServiceConfiguration.ConfigureServices(config);
         Scripting.ServiceConfiguration.ConfigureServices(config);
         Status.ServiceConfiguration.ConfigureServices(config);
 

--- a/Celbridge/Modules/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
@@ -5,6 +5,7 @@ using Celbridge.Explorer;
 using Celbridge.Extensions;
 using Celbridge.Inspector;
 using Celbridge.Projects;
+using Celbridge.ResourceData;
 using Celbridge.Scripting;
 using Celbridge.Settings;
 using Celbridge.Status;
@@ -28,6 +29,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
     public IExplorerService ExplorerService { get; }
     public IStatusService StatusService { get; }
     public IDataTransferService DataTransferService { get; }
+    public IResourceDataService ResourceDataService { get; }
 
     private bool _workspaceStateIsDirty;
 
@@ -52,6 +54,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
         ExplorerService = serviceProvider.GetRequiredService<IExplorerService>();
         StatusService = serviceProvider.GetRequiredService<IStatusService>();
         DataTransferService = serviceProvider.GetRequiredService<IDataTransferService>();
+        ResourceDataService = serviceProvider.GetRequiredService<IResourceDataService>();
 
         //
         // Let the workspace settings service know where to find the workspace settings database


### PR DESCRIPTION
Meta data is store as properties in a .json file in the CelData folder.
Added a Resource Data Service to manage reading and writing to Resource Data.
Clients can register to observe changes to Resource Data properties on a specific resource.
Markdown inspector uses Resource Data to allow user to select between Editor, Preview and Both display modes.