### PR TITLE
Refactor EditorMode entity property to use an enum value

### DIFF
--- a/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -378,4 +378,16 @@
   <data name="WebInspector_AddressPlaceholder" xml:space="preserve">
     <value>Enter web address</value>
   </data>
+  <data name="InspectorPanel_ShowEditorAndPreviewTooltip" xml:space="preserve">
+    <value>Show editor and preview </value>
+  </data>
+  <data name="InspectorPanel_ShowEditorTooltip" xml:space="preserve">
+    <value>Show editor only</value>
+  </data>
+  <data name="InspectorPanel_ShowPreviewTooltip" xml:space="preserve">
+    <value>Show preview only</value>
+  </data>
+  <data name="InspectorPanel_OpenDocumentTooltip" xml:space="preserve">
+    <value>Open document</value>
+  </data>
 </root>

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Documents/EditorMode.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Documents/EditorMode.cs
@@ -1,0 +1,22 @@
+namespace Celbridge.Documents;
+
+/// <summary>
+/// Supported editor display modes.
+/// </summary>
+public enum EditorMode
+{
+    /// <summary>
+    /// Display editor panel only.
+    /// </summary>
+    Editor,
+
+    /// <summary>
+    /// Display preview panel only.
+    /// </summary>
+    Preview,
+
+    /// <summary>
+    /// Display both editor and preview panels in a split view.
+    /// </summary>
+    EditorAndPreview
+}

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/TextEditorEntityConstants.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/TextEditorEntityConstants.cs
@@ -7,12 +7,7 @@ namespace Celbridge.Entities;
 public static class TextEditorEntityConstants
 {
     /// <summary>
-    /// ShowEditor property path.
+    /// Editor mode property path.
     /// </summary>
-    public const string ShowEditor = "/ShowEditor";
-
-    /// <summary>
-    /// ShowPreview property path.
-    /// </summary>
-    public const string ShowPreview = "/ShowPreview";
+    public const string EditorMode = "/editorMode";
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
@@ -42,7 +42,7 @@ public partial class TextEditorDocumentViewModel : ObservableObject
 
         _fileResource = fileResource;
 
-        UpdatePanelVisibility();
+        UpdateEditorMode();
     }
 
     public Result<PreviewProvider> GetPreviewProvider()
@@ -73,19 +73,20 @@ public partial class TextEditorDocumentViewModel : ObservableObject
             return;
         }
 
-        if (paths.Contains(TextEditorEntityConstants.ShowEditor) ||
-            paths.Contains(TextEditorEntityConstants.ShowPreview))
+        if (paths.Contains(TextEditorEntityConstants.EditorMode))
         {
-            UpdatePanelVisibility();
+            UpdateEditorMode();
         }
     }
 
-    private void UpdatePanelVisibility()
+    private void UpdateEditorMode()
     {
         try
         {
-            ShowEditor = _entityService.GetProperty(_fileResource, TextEditorEntityConstants.ShowEditor, true);
-            ShowPreview = _entityService.GetProperty(_fileResource, TextEditorEntityConstants.ShowPreview, true);
+            var editorMode = _entityService.GetProperty(_fileResource, TextEditorEntityConstants.EditorMode, EditorMode.Editor);
+
+            ShowEditor = (editorMode == EditorMode.Editor || editorMode == EditorMode.EditorAndPreview);
+            ShowPreview = (editorMode == EditorMode.Preview || editorMode == EditorMode.EditorAndPreview);
         }
         catch (Exception ex)
         {

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Prototypes/Markdown.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Prototypes/Markdown.json
@@ -1,4 +1,5 @@
 {
   "_entityType": "Markdown",
-  "_entityVersion": 1
+  "_entityVersion": 1,
+  "editorMode": "EditorAndPreview"
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/File.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/File.json
@@ -13,5 +13,6 @@
   "required": [
     "_entityType",
     "_entityVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/Folder.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/Folder.json
@@ -13,5 +13,6 @@
   "required": [
     "_entityType",
     "_entityVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/Markdown.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/EntityConfig/Schemas/Markdown.json
@@ -8,10 +8,16 @@
     "_entityVersion": {
       "type": "integer",
       "const": 1
+    },
+    "editorMode": {
+      "type": "string",
+      "enum": [ "Editor", "Preview", "EditorAndPreview" ]
     }
   },
   "required": [
     "_entityType",
-    "_entityVersion"
-  ]
+    "_entityVersion",
+    "editorMode"
+  ],
+  "additionalProperties": false
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -1,8 +1,10 @@
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using Json.Patch;
 using CommunityToolkit.Diagnostics;
+using Json.Patch;
 using Json.Pointer;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using Celbridge.Entities.Services;
 
 namespace Celbridge.Entities.Models;
 
@@ -53,7 +55,7 @@ public class EntityData
                 return Result<T>.Fail($"Property is a JSON null value: '{propertyPath}'");
             }
 
-            var value = valueNode.Deserialize<T>();
+            var value = valueNode.Deserialize<T>(EntityService.SerializerOptions);
             if (value is null)
             {
                 return Result<T>.Fail($"Failed to deserialize property at '{propertyPath}' to type '{nameof(T)}'");

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
@@ -5,7 +5,6 @@ using Celbridge.Explorer;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Workspace;
-using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -20,13 +19,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     private readonly IEntityService _entityService;
 
     [ObservableProperty]
-    private bool _showEditorEnabled;
-
-    [ObservableProperty]
-    private bool _showBothEnabled;
-
-    [ObservableProperty]
-    private bool _showPreviewEnabled;
+    private EditorMode _editorMode;
 
     // Code gen requires a parameterless constructor
     public MarkdownInspectorViewModel()
@@ -55,8 +48,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     {
         if (message.Resource == Resource)            
         {
-            if (message.PropertyPaths.Contains(TextEditorEntityConstants.ShowEditor) ||
-                message.PropertyPaths.Contains(TextEditorEntityConstants.ShowPreview))
+            if (message.PropertyPaths.Contains(TextEditorEntityConstants.EditorMode))
             {
                 UpdateButtonState();
             }
@@ -85,31 +77,26 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     public IRelayCommand ShowEditorCommand => new RelayCommand(ShowEditor_Executed);
     private void ShowEditor_Executed()
     {
-        SetPanelVisibility(true, false);
+        SetEditorMode(EditorMode.Editor);
     }
 
     public IRelayCommand ShowPreviewCommand => new RelayCommand(ShowPreview_Executed);
     private void ShowPreview_Executed()
     {
-        SetPanelVisibility(false, true);
+        SetEditorMode(EditorMode.Preview);
     }
 
     public IRelayCommand ShowBothCommand => new RelayCommand(ShowEditorAndPreview_Executed);
     private void ShowEditorAndPreview_Executed()
     {
-        SetPanelVisibility(true, true);
+        SetEditorMode(EditorMode.EditorAndPreview);
     }
 
-    private void SetPanelVisibility(bool showEditor, bool showPreview)
+    private void SetEditorMode(EditorMode editorMode)
     {
-        Guard.IsTrue(showEditor || showPreview);
-
         try
         {
-            _entityService.SetProperty(Resource, TextEditorEntityConstants.ShowEditor, showEditor);
-            _entityService.SetProperty(Resource, TextEditorEntityConstants.ShowPreview, showPreview);
-
-            UpdateButtonState();
+            _entityService.SetProperty(Resource, TextEditorEntityConstants.EditorMode, editorMode);
         }
         catch (Exception ex)
         {
@@ -121,13 +108,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     {
         try
         {
-            bool showingEditor = _entityService.GetProperty(Resource, TextEditorEntityConstants.ShowEditor, true);
-            bool showingPreview = _entityService.GetProperty(Resource, TextEditorEntityConstants.ShowPreview, true);
-            bool showingBoth = showingEditor && showingPreview;
-
-            ShowEditorEnabled = !showingEditor || (showingBoth);
-            ShowPreviewEnabled = !showingPreview || (showingBoth);
-            ShowBothEnabled = !showingBoth;
+            EditorMode = _entityService.GetProperty(Resource, TextEditorEntityConstants.EditorMode, EditorMode.Editor);
         }
         catch (Exception ex)
         {

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
@@ -1,3 +1,4 @@
+using Celbridge.Documents;
 using Celbridge.Inspector.ViewModels;
 using CommunityToolkit.Diagnostics;
 using Microsoft.Extensions.Localization;
@@ -12,6 +13,10 @@ public partial class MarkdownInspector : UserControl, IInspector
     public MarkdownInspectorViewModel ViewModel => (DataContext as MarkdownInspectorViewModel)!;
 
     private LocalizedString StartURLString => _stringLocalizer.GetString("WebInspector_StartURL");
+    private LocalizedString OpenDocumentTooltipString => _stringLocalizer.GetString("InspectorPanel_OpenDocumentTooltip");
+    private LocalizedString ShowEditorTooltipString => _stringLocalizer.GetString("InspectorPanel_ShowEditorTooltip");
+    private LocalizedString ShowPreviewTooltipString => _stringLocalizer.GetString("InspectorPanel_ShowPreviewTooltip");
+    private LocalizedString ShowEditorAndPreviewTooltipString => _stringLocalizer.GetString("InspectorPanel_ShowEditorAndPreviewTooltip");
 
     public ResourceKey Resource 
     {
@@ -58,7 +63,7 @@ public partial class MarkdownInspector : UserControl, IInspector
                                             .Margin(2, 2, 8, 0)
                                             .HorizontalAlignment(HorizontalAlignment.Center)
                                             .Command(() => vm.OpenDocumentCommand)
-                                            .ToolTipService(null, null, "Open document")
+                                            .ToolTipService(null, null, OpenDocumentTooltipString)
                                             .Content
                                             (
                                                 new SymbolIcon()
@@ -72,9 +77,10 @@ public partial class MarkdownInspector : UserControl, IInspector
                                                 new Button()
                                                     .Margin(2)
                                                     .Command(() => vm.ShowEditorCommand)
-                                                    .IsEnabled(x => x.Binding(() => vm.ShowEditorEnabled)
-                                                        .Mode(BindingMode.OneWay))
-                                                    .ToolTipService(null, null, "Show editor panel only")
+                                                    .IsEnabled(x => x.Binding(() => vm.EditorMode)
+                                                        .Mode(BindingMode.OneWay)
+                                                        .Convert(editMode => editMode != EditorMode.Editor))
+                                                    .ToolTipService(null, null, ShowEditorTooltipString)
                                                     .Content
                                                     (
                                                         new SymbolIcon()
@@ -83,9 +89,10 @@ public partial class MarkdownInspector : UserControl, IInspector
                                                 new Button()
                                                     .Margin(2)
                                                     .Command(() => vm.ShowBothCommand)
-                                                    .IsEnabled(x => x.Binding(() => vm.ShowBothEnabled)
-                                                        .Mode(BindingMode.OneWay))
-                                                    .ToolTipService(null, null, "Show both editor and preview panels")
+                                                    .IsEnabled(x => x.Binding(() => vm.EditorMode)
+                                                        .Mode(BindingMode.OneWay)
+                                                        .Convert(editMode => editMode != EditorMode.EditorAndPreview))
+                                                    .ToolTipService(null, null, ShowEditorAndPreviewTooltipString)
                                                     .Content
                                                     (
                                                         new SymbolIcon()
@@ -94,9 +101,10 @@ public partial class MarkdownInspector : UserControl, IInspector
                                                 new Button()
                                                     .Margin(2)
                                                     .Command(() => vm.ShowPreviewCommand)
-                                                    .IsEnabled(x => x.Binding(() => vm.ShowPreviewEnabled)
-                                                        .Mode(BindingMode.OneWay))
-                                                    .ToolTipService(null, null, "Show preview panel only")
+                                                    .IsEnabled(x => x.Binding(() => vm.EditorMode)
+                                                        .Mode(BindingMode.OneWay)
+                                                        .Convert(editMode => editMode != EditorMode.Preview))
+                                                    .ToolTipService(null, null, ShowPreviewTooltipString)
                                                     .Content
                                                     (
                                                         new SymbolIcon()


### PR DESCRIPTION
Use a single enum property instead of 2 separate boolean properties to store the editor display mode.
Change entity schemas to disallow additional properties.
Use customized serialization options for serializing entity data to support enum serialization and camel case property names.
Change Markdown inspector tooltips to use localized strings. 