### PR TITLE
Make component property changes simpler and more robust

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
@@ -92,13 +92,13 @@ public interface IEntityService
     Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue) where T : notnull;
 
     /// <summary>
-    /// Undo the most recent property change for a resource.
+    /// Undo the most recent entity change for a resource.
     /// </summary>
-    Result<bool> UndoProperty(ResourceKey resource);
+    Result<bool> UndoEntity(ResourceKey resource);
 
     /// <summary>
-    /// Redo the most recently undone property change for a resource.
+    /// Redo the most recently undone entity change for a resource.
     /// </summary>
-    Result<bool> RedoProperty(ResourceKey resource);
+    Result<bool> RedoEntity(ResourceKey resource);
 }
 

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
@@ -80,16 +80,18 @@ public interface IEntityService
     Result<string> GetPropertyAsJSON(ResourceKey resource, int componentIndex, string propertyPath);
 
     /// <summary>
-    /// Sets the value of an entity property for a component.
+    /// Replaces the value of an existing entity property for a component.
+    /// If insert is true then the value is inserted at the specified key/index, rather than replacing the existing entry.
     /// propertyPath is a JSON Pointer (RFC 6901).
     /// </summary>
-    Result SetProperty<T>(ResourceKey resource, int componentIndex, string propertyPath, T newValue) where T : notnull;
+    Result SetProperty<T>(ResourceKey resource, int componentIndex, string propertyPath, T newValue, bool insert = false) where T : notnull;
 
     /// <summary>
-    /// Sets the value of a property from the first component of the specified type.
+    /// Replaces the value of an existing property from the first component of the specified type.
+    /// If insert is true then the value is inserted at the specified key/index, rather than replacing the existing entry.
     /// propertyPath is a JSON Pointer (RFC 6901).
     /// </summary>
-    Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue) where T : notnull;
+    Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue, bool insert = false) where T : notnull;
 
     /// <summary>
     /// Undo the most recent entity change for a resource.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IRedoEntityCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IRedoEntityCommand.cs
@@ -3,9 +3,9 @@ using Celbridge.Commands;
 namespace Celbridge.Entities;
 
 /// <summary>
-/// Command to undo the most recent property change for a resource.
+/// Command to redo the most recent entity change for a resource.
 /// </summary>
-public interface IUndoPropertyCommand : IExecutableCommand
+public interface IRedoEntityCommand : IExecutableCommand
 {
     /// <summary>
     /// The resource associated with the Entity Data to be modified.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/ISetPropertyCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/ISetPropertyCommand.cs
@@ -27,4 +27,10 @@ public interface ISetPropertyCommand : IExecutableCommand
     /// The JSON formatted value to set the property to.
     /// </summary>
     string JsonValue { get; set; }
+
+    /// <summary>
+    /// Specifies whether to insert a new value rather than replacing the existing value at the specified key/index.
+    /// This is primarily used to insert new values into arrays, shifting the existing values to the right.
+    /// </summary>
+    bool Insert { get; set; }
 }

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IUndoEntityCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IUndoEntityCommand.cs
@@ -3,9 +3,9 @@ using Celbridge.Commands;
 namespace Celbridge.Entities;
 
 /// <summary>
-/// Command to redo the most recent property change for a resource.
+/// Command to undo the most recent entity change for a resource.
 /// </summary>
-public interface IRedoPropertyCommand : IExecutableCommand
+public interface IUndoEntityCommand : IExecutableCommand
 {
     /// <summary>
     /// The resource associated with the Entity Data to be modified.

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
@@ -4,13 +4,13 @@ using Celbridge.Workspace;
 
 namespace Celbridge.Entities.Commands;
 
-public class UndoPropertyCommand : CommandBase, IUndoPropertyCommand
+public class RedoEntityCommand : CommandBase, IRedoEntityCommand
 {
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey Resource { get; set; }
 
-    public UndoPropertyCommand(
+    public RedoEntityCommand(
         IWorkspaceWrapper workspaceWrapper)
     {
         _workspaceWrapper = workspaceWrapper;
@@ -20,7 +20,7 @@ public class UndoPropertyCommand : CommandBase, IUndoPropertyCommand
     {
         var entityService = _workspaceWrapper.WorkspaceService.EntityService;
 
-        var applyResult = entityService.UndoProperty(Resource);
+        var applyResult = entityService.RedoEntity(Resource);
 
         await Task.CompletedTask;
 
@@ -31,10 +31,10 @@ public class UndoPropertyCommand : CommandBase, IUndoPropertyCommand
     // Static methods for scripting support.
     //
 
-    public static void UndoProperty(ResourceKey resource)
+    public static void RedoEntity(ResourceKey resource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IUndoPropertyCommand>(command =>
+        commandService.Execute<IRedoEntityCommand>(command =>
         {
             command.Resource = resource;
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
@@ -12,6 +12,7 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     public int ComponentIndex { get; set; }
     public string PropertyPath { get; set; } = string.Empty;
     public string JsonValue { get; set; } = string.Empty;
+    public bool Insert { get; set; }
 
     public SetPropertyCommand(
         IWorkspaceWrapper workspaceWrapper)
@@ -23,7 +24,7 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     {
         var entityService = _workspaceWrapper.WorkspaceService.EntityService;
 
-        var applyResult = entityService.SetProperty(Resource, ComponentIndex, PropertyPath, JsonValue);
+        var applyResult = entityService.SetProperty(Resource, ComponentIndex, PropertyPath, JsonValue, Insert);
 
         await Task.CompletedTask;
 
@@ -34,6 +35,10 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     // Static methods for scripting support.
     //
 
+    /// <summary>
+    /// Replaces an existing component property value at the specified path.
+    /// If the property value does not exist, the operation fails.
+    /// </summary>
     public static void SetProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
@@ -43,6 +48,24 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
             command.ComponentIndex = componentIndex;
             command.PropertyPath = propertyPath;
             command.JsonValue = jsonValue;
+            command.Insert = false;
+        });
+    }
+
+    /// <summary>
+    /// Inserts a new component property value at the specified path.
+    /// If the property value already exists, it is replaced.
+    /// </summary>
+    public static void InsertProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
+    {
+        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        commandService.Execute<ISetPropertyCommand>(command =>
+        {
+            command.Resource = resource;
+            command.ComponentIndex = componentIndex;
+            command.PropertyPath = propertyPath;
+            command.JsonValue = jsonValue;
+            command.Insert = true;
         });
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
@@ -4,13 +4,13 @@ using Celbridge.Workspace;
 
 namespace Celbridge.Entities.Commands;
 
-public class RedoPropertyCommand : CommandBase, IRedoPropertyCommand
+public class UndoEntityCommand : CommandBase, IUndoEntityCommand
 {
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey Resource { get; set; }
 
-    public RedoPropertyCommand(
+    public UndoEntityCommand(
         IWorkspaceWrapper workspaceWrapper)
     {
         _workspaceWrapper = workspaceWrapper;
@@ -20,7 +20,7 @@ public class RedoPropertyCommand : CommandBase, IRedoPropertyCommand
     {
         var entityService = _workspaceWrapper.WorkspaceService.EntityService;
 
-        var applyResult = entityService.RedoProperty(Resource);
+        var applyResult = entityService.UndoEntity(Resource);
 
         await Task.CompletedTask;
 
@@ -31,10 +31,10 @@ public class RedoPropertyCommand : CommandBase, IRedoPropertyCommand
     // Static methods for scripting support.
     //
 
-    public static void RedoProperty(ResourceKey resource)
+    public static void UndoEntity(ResourceKey resource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IRedoPropertyCommand>(command =>
+        commandService.Execute<IUndoEntityCommand>(command =>
         {
             command.Resource = resource;
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -84,20 +84,20 @@ public class EntityData
         }
     }
 
-    public Result<string> GetPropertyAsJSON(JsonPointer jsonPointer)
+    public Result<string> GetPropertyAsJSON(JsonPointer propertyPointer)
     {
         try
         {
-            if (!jsonPointer.TryEvaluate(JsonObject, out var valueNode))
+            if (!propertyPointer.TryEvaluate(JsonObject, out var valueNode))
             {
-                return Result<string>.Fail($"Property was not found at: '{jsonPointer}'");
+                return Result<string>.Fail($"Property was not found at: '{propertyPointer}'");
             }
 
             if (valueNode is null)
             {
                 // The property was found but it is a JSON null value.
                 // We treat this as an error for Entity Data.
-                return Result<string>.Fail($"Property is a JSON null value: '{jsonPointer}'");
+                return Result<string>.Fail($"Property is a JSON null value: '{propertyPointer}'");
             }
 
             var valueJSON = valueNode.ToJsonString();
@@ -106,7 +106,7 @@ public class EntityData
         }
         catch (Exception ex)
         {
-            return Result<string>.Fail($"An exception occurred when getting entity property '{jsonPointer}'")
+            return Result<string>.Fail($"An exception occurred when getting entity property '{propertyPointer}'")
                 .WithException(ex);
         }
     }
@@ -132,7 +132,7 @@ public class EntityData
             if (JsonNode.DeepEquals(JsonObject, patchedJsonObject))
             {
                 // The patch was valid, but did not result in any changes.
-                // This is indicated by returning a null reverse patch and change message.
+                // This is indicated by returning null reverse patch and change message values.
                 var emptyPatchSummary = new PatchSummary(operation, null, null);
                 return Result<PatchSummary>.Ok(emptyPatchSummary);
             }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -1,10 +1,10 @@
+using Celbridge.Entities.Services;
 using CommunityToolkit.Diagnostics;
 using Json.Patch;
 using Json.Pointer;
+using Json.Schema;
 using System.Text.Json.Nodes;
 using System.Text.Json;
-using Celbridge.Entities.Services;
-using Json.Schema;
 
 namespace Celbridge.Entities.Models;
 
@@ -24,28 +24,6 @@ public class EntityData
         return new EntityData(jsonObject, entitySchema);
     }
 
-    public EntityData DeepClone()
-    {
-        var jsonClone = JsonObject.DeepClone() as JsonObject;
-        Guard.IsNotNull(jsonClone);
-
-        return new EntityData(jsonClone, EntitySchema);
-    }
-
-    public Result<string> GetComponentType(int componentIndex)
-    {
-        var propertyPath = $"/_components/{componentIndex}/_componentType";
-
-        var getPropertyResult = GetProperty<string>(propertyPath);
-        if (getPropertyResult.IsFailure)
-        {
-            return Result<string>.Fail("Failed to get component type")
-                .WithErrors(getPropertyResult);
-        }
-
-        return Result<string>.Ok(getPropertyResult.Value);
-    }
-
     public Result<List<int>> GetComponentsOfType(string componentType)
     {
         if (JsonObject["_components"] is not JsonArray components)
@@ -56,88 +34,70 @@ public class EntityData
         var indices = new List<int>();
         for (int i = 0; i < components.Count; i++)
         {
-            JsonNode? componentNode = components[i];
-            if (componentNode is not JsonObject componentObject)
+            var propertyPath = JsonPointer.Create("_components", i, "_componentType");
+
+            var getPropertyResult = GetProperty<string>(propertyPath);
+            if (getPropertyResult.IsFailure)
             {
                 continue;
             }
+            var componentTypeValue = getPropertyResult.Value;
 
-            if (componentObject["_componentType"] is not JsonValue componentTypeNode ||
-                componentTypeNode.GetValueKind() != JsonValueKind.String)
+            if (componentTypeValue == componentType)
             {
-                continue;
+                indices.Add(i);
             }
-
-            var componentTypeValue = componentTypeNode.GetValue<string>();
-            if (componentTypeValue != componentType)
-            {
-                continue;
-            }
-
-            indices.Add(i);
         }
 
         return Result<List<int>>.Ok(indices);
     }
 
-    public Result<T> GetProperty<T>(string propertyPath)
+    public Result<T> GetProperty<T>(JsonPointer propertyPointer)
         where T : notnull
     {
         try
         {
-            var jsonPointer = JsonPointer.Parse(propertyPath);
-            if (jsonPointer is null)
+            if (!propertyPointer.TryEvaluate(JsonObject, out var valueNode))
             {
-                return Result<T>.Fail($"Invalid JSON pointer '{propertyPath}'");
-            }
-
-            if (!jsonPointer.TryEvaluate(JsonObject, out var valueNode))
-            {
-                return Result<T>.Fail($"Property was not found at: '{propertyPath}'");
+                return Result<T>.Fail($"Property was not found at: '{propertyPointer}'");
             }
 
             if (valueNode is null)
             {
                 // The property was found but it is a JSON null value.
                 // We treat this as an error for Entity Data.
-                return Result<T>.Fail($"Property is a JSON null value: '{propertyPath}'");
+                return Result<T>.Fail($"Property is a JSON null value: '{propertyPointer}'");
             }
 
             var value = valueNode.Deserialize<T>(EntityService.SerializerOptions);
             if (value is null)
             {
-                return Result<T>.Fail($"Failed to deserialize property at '{propertyPath}' to type '{nameof(T)}'");
+                return Result<T>.Fail($"Failed to deserialize property at '{propertyPointer}' to type '{nameof(T)}'");
             }
             
             return Result<T>.Ok(value);
         }
         catch (Exception ex)
         {
-            return Result<T>.Fail($"An exception occurred when getting entity property '{propertyPath}'")
+            return Result<T>.Fail($"An exception occurred when getting entity property '{propertyPointer}'")
                 .WithException(ex);
         }
     }
 
-    public Result<string> GetPropertyAsJSON(string propertyPath)
+    public Result<string> GetPropertyAsJSON(JsonPointer jsonPointer)
     {
         try
         {
-            var jsonPointer = JsonPointer.Parse(propertyPath);
-            if (jsonPointer is null)
-            {
-                return Result<string>.Fail($"Invalid JSON pointer '{propertyPath}'");
-            }
-
             if (!jsonPointer.TryEvaluate(JsonObject, out var valueNode))
             {
-                return Result<string>.Fail($"Property was not found at: '{propertyPath}'");
+                return Result<string>.Fail($"Property was not found at: '{jsonPointer}'");
             }
 
             if (valueNode is null)
             {
                 // The property was found but it is a JSON null value.
                 // We treat this as an error for Entity Data.
-                return Result<string>.Fail($"Property is a JSON null value: '{propertyPath}'");
+                return Result<string>.Fail($"Property is a JSON null value: '{jsonPointer}'");
             }
 
             var valueJSON = valueNode.ToJsonString();
@@ -146,24 +106,19 @@ public class EntityData
         }
         catch (Exception ex)
         {
-            return Result<string>.Fail($"An exception occurred when getting entity property '{propertyPath}'")
+            return Result<string>.Fail($"An exception occurred when getting entity property '{jsonPointer}'")
                 .WithException(ex);
         }
     }
 
-    public Result<PatchSummary> ApplyPatch(ResourceKey resource, string patchJson, ComponentSchemaRegistry schemaRegistry)
+    public Result<PatchSummary> ApplyPatchOperation(ResourceKey resource, PatchOperation operation, ComponentSchemaRegistry schemaRegistry)
     {
         try
         {
-            var patch = JsonSerializer.Deserialize<JsonPatch>(patchJson);
-            if (patch is null)
-            {
-                return Result<PatchSummary>.Fail("Failed to deserialize JSON patch");
-            }
-
             // Generate the patched version of the entity.
             // We perform a number of checks on this patched entity before we use it to replace the existing entity.
 
+            var patch = new JsonPatch(operation);
             var patchResult = patch.Apply(JsonObject);
             if (!patchResult.IsSuccess)
             {
@@ -177,12 +132,9 @@ public class EntityData
             if (JsonNode.DeepEquals(JsonObject, patchedJsonObject))
             {
                 // The patch was valid, but did not result in any changes.
-                // This is indicated by returning an empty reverse patch and change list.
-                var emptyAppliedPatch = new PatchSummary(
-                    patchJson,
-                    string.Empty,
-                    new List<ComponentChangedMessage>());
-                return Result<PatchSummary>.Ok(emptyAppliedPatch);
+                // This is indicated by returning a null reverse patch and change message.
+                var emptyPatchSummary = new PatchSummary(operation, null, null);
+                return Result<PatchSummary>.Ok(emptyPatchSummary);
             }
 
             // Check if the patched JSON is still valid for the entity schema
@@ -193,40 +145,63 @@ public class EntityData
                 return Result<PatchSummary>.Fail($"Failed to apply JSON patch to entity data. Schema validation error.");
             }
 
-            // Generate the reverse patch so we can undo the changes later if needed.
-            var reversePatch = patchedJsonObject.CreatePatch(JsonObject);
-            var reversePatchJson = JsonSerializer.Serialize(reversePatch);
+            // Make reverse patch and component changed message
+            PatchOperation reverseOperation;
+            switch (operation.Op)
+            {
+                case OperationType.Add:
+                    reverseOperation = PatchOperation.Remove(operation.Path);
+                    break;
 
-            // Make a note of each component change that the patch makes to the entity data.
+                case OperationType.Remove:
+                    {
+                        if (!operation.Path.TryEvaluate(JsonObject, out var existingValue))
+                        {
+                            return Result<PatchSummary>.Fail($"Component does not exist at path: '{operation.Path}'");
+                        }
+                        reverseOperation = PatchOperation.Add(operation.Path, existingValue);
+                        break;
+                    }
 
-            var getResult = GetChangesForPatch(resource, patch);
+                case OperationType.Replace:
+                    {
+                        if (!operation.Path.TryEvaluate(JsonObject, out var existingValue))
+                        {
+                            return Result<PatchSummary>.Fail($"Component does not exist at path: '{operation.Path}'");
+                        }
+                        reverseOperation = PatchOperation.Replace(operation.Path, existingValue);
+                        break;
+                    }
+
+                case OperationType.Move:
+                    reverseOperation = PatchOperation.Move(operation.Path, operation.From);
+                    break;
+
+                case OperationType.Copy:
+                    reverseOperation = PatchOperation.Remove(operation.Path);
+                    break;
+
+                default:
+                    return Result<PatchSummary>.Fail("Unsupported patch operation");
+            }
+
+            // Make a note of the component change that the patch applied to the entity data.
+            var getResult = GetChangeForPatchOperation(resource, operation);
             if (getResult.IsFailure)
             {
                 return Result<PatchSummary>.Fail($"Failed to extract component changes from entity patch")
                     .WithErrors(getResult);
             }
-            var componentChanges = getResult.Value;
+            var componentChange = getResult.Value;
 
-            // Check that each component that was modified by the patch is still valid against its schema
+            // Check that the component that was modified by the operation is still valid against its schema.
+            // Removed component operations don't require validation.
 
-            var validatedComponents = new HashSet<int>();
-            foreach (var componentChange in componentChanges)
+            bool isRemoveComponentOperation = operation.Path.Count == 2 && operation.Op == OperationType.Remove;
+            if (!isRemoveComponentOperation)
             {
-                if (componentChange.PropertyPath == "/" &&
-                    componentChange.Operation == "remove")
-                {
-                    // Removed components don't require validation
-                    continue;
-                }
-
                 var componentIndex = componentChange.ComponentIndex;
                 var componentType = componentChange.ComponentType;
-
-                if (validatedComponents.Contains(componentIndex))
-                {
-                    // This component has already been validated
-                    continue;
-                }
 
                 var getSchemaResult = schemaRegistry.GetSchemaForComponentType(componentType);
                 if (getSchemaResult.IsFailure)
@@ -253,14 +228,12 @@ public class EntityData
                     return Result<PatchSummary>.Fail($"Component at index {componentIndex} is not valid against its schema")
                         .WithErrors(validateResult);
                 }
-
-                validatedComponents.Add(componentIndex);
             }
 
-            // The patched entity has passed validation, so we can now update the entity.
+            // The patched component has passed validation, so we can now update the entity.
             JsonObject = patchedJsonObject;
 
-            var patchSummary = new PatchSummary(patchJson, reversePatchJson, componentChanges);
+            var patchSummary = new PatchSummary(operation, reverseOperation, componentChange);
             return Result<PatchSummary>.Ok(patchSummary);
         }
         catch (Exception ex)
@@ -270,117 +243,77 @@ public class EntityData
         }
     }
 
-    private Result<List<ComponentChangedMessage>> GetChangesForPatch(ResourceKey resource, JsonPatch patch)
+    private Result<ComponentChangedMessage> GetChangeForPatchOperation(ResourceKey resource, PatchOperation operation)
     {
         try
         {
-            List<ComponentChangedMessage> componentChanges = new();
+            var jsonPointer = operation.Path;
 
-            foreach (var op in patch.Operations)
+            // Check if the JSON pointer is a component property path
+            if (jsonPointer.Count < 2 ||
+                jsonPointer[0] != "_components")
             {
-                var jsonPointer = op.Path;
-                var path = jsonPointer.ToString();
-
-                // Check if the JSON pointer is a component property path
-                var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                if (segments is null ||
-                    segments.Length < 2 ||
-                    segments[0] != "_components")
-                {
-                    throw new InvalidOperationException($"Component patch operation does not start with /_components");
-                }
-
-                // Extract the component index from the path
-                var indexSegment = segments[1];
-                if (!int.TryParse(indexSegment, out var componentIndex))
-                {
-                    throw new InvalidOperationException($"Component patch operation does not specify a component index");
-                }
-
-                var componentType = string.Empty;
-                if (op.Op == OperationType.Add &&
-                    segments.Length == 2)
-                {
-                    // This is an add component operation, so extract the type of the component that will be
-                    // added by the patch...
-
-                    var addedComponent = op.Value as JsonObject;
-                    if (addedComponent is null)
-                    {
-                        throw new InvalidOperationException($"Added component is not a JsonObject");
-                    }
-
-                    var addedComponentTypeNode = addedComponent["_componentType"];
-                    if (addedComponentTypeNode is null)
-                    {
-                        throw new InvalidOperationException($"Added component does not have a '_componentType' property");
-                    }
-
-                    componentType = addedComponentTypeNode.GetValue<string>();
-                }
-                else
-                {
-                    // ...in all other cases, use the component type of the existing component.
-
-                    var components = JsonObject["_components"] as JsonArray;
-                    if (components is null ||
-                        componentIndex >= components.Count)
-                    {
-                        throw new InvalidOperationException($"Entity data does not contain '_components' array");
-                    }
-
-                    var componentObject = components[componentIndex] as JsonObject;
-                    if (componentObject is null)
-                    {
-                        throw new InvalidOperationException($"'_components' array does not contain a JsonObject at index: {componentIndex}");
-                    }
-
-                    var componentTypeNode = componentObject["_componentType"];
-                    if (componentTypeNode is null)
-                    {
-                        throw new InvalidOperationException($"Component at index {componentIndex} does not contain a '_componentType' property");
-                    }
-
-                    componentType = componentTypeNode.ToString();
-                }
-
-                if (string.IsNullOrEmpty(componentType))
-                {
-                    throw new InvalidOperationException($"Added component's type is empty");
-                }
-
-                // Report the operation type as a string
-                var operation = op.Op.ToString().ToLower();
-
-                // Construct the component relative property path 
-                string propertyPath;
-                if (segments.Length == 2)
-                {
-                    // This is a component add, remove, etc. operation, so the property path is the root of the component
-                    propertyPath = "/";
-                }
-                else
-                {
-                    // This is a component property change operation, so the property path is the component relative path
-                    propertyPath = "/" + string.Join("/", segments.Skip(2));
-                
-                    if (operation == "add" || operation == "replace")
-                    {
-                        // We report 'add' and 'replace' property operations as a 'set' operation, because the distinction is not
-                        // important to clients listening for property changes.
-                        operation = "set";
-                    }
-                }
-
-                var componentChange = new ComponentChangedMessage(resource, componentType, componentIndex, propertyPath, operation);
-                componentChanges.Add(componentChange);
+                throw new InvalidOperationException($"Component patch operation does not start with /_components");
             }
 
-            return Result<List<ComponentChangedMessage>>.Ok(componentChanges);
+            // Extract the component index from the path
+            var indexSegment = jsonPointer[1];
+            if (!int.TryParse(indexSegment, out var componentIndex))
+            {
+                throw new InvalidOperationException($"Component patch operation does not specify a component index");
+            }
+
+            var componentType = string.Empty;
+            if (operation.Op == OperationType.Add &&
+                jsonPointer.Count == 2)
+            {
+                // This is an add component operation, so extract the type of the component that will be
+                // added by the patch...
+
+                var addedComponent = operation.Value as JsonObject;
+                if (addedComponent is null)
+                {
+                    throw new InvalidOperationException($"Added component is not a JsonObject");
+                }
+
+                var addedComponentTypeNode = addedComponent["_componentType"];
+                if (addedComponentTypeNode is null)
+                {
+                    throw new InvalidOperationException($"Added component does not have a '_componentType' property");
+                }
+
+                componentType = addedComponentTypeNode.GetValue<string>();
+            }
+            else
+            {
+                // ...in all other cases, use the component type of the existing entity component.
+
+                var componentTypePointer = jsonPointer[..2].Combine("_componentType");
+                if (!componentTypePointer.TryEvaluate(JsonObject, out var componentTypeNode) ||
+                    componentTypeNode is null)
+                {
+                    throw new InvalidOperationException($"Component at index {componentIndex} does not contain a '_componentType' property");
+                }
+
+                componentType = componentTypeNode.GetValue<string>();
+            }
+
+            if (string.IsNullOrEmpty(componentType))
+            {
+                throw new InvalidOperationException($"Invalid component type");
+            }
+
+            string propertyPath = jsonPointer.Count == 2 ? "/" : jsonPointer[2..].ToString();
+            var operationName = operation.Op.ToString().ToLower();
+
+            // Create a message for the component change
+            var message = new ComponentChangedMessage(resource, componentType, componentIndex, propertyPath, operationName);
+
+            return Result<ComponentChangedMessage>.Ok(message);
         }
         catch (Exception ex)
         {
-            return Result<List<ComponentChangedMessage>>.Fail("An exception occurred when extracting component changes from patch")
+            return Result<ComponentChangedMessage>.Fail("An exception occurred when extracting changes from a component patch operation")
                 .WithException(ex);
         }
     }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/PatchContext.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/PatchContext.cs
@@ -1,0 +1,22 @@
+namespace Celbridge.Entities.Models;
+
+/// <summary>
+/// Describes the context in which a patch is applied.
+/// </summary>
+public enum PatchContext
+{
+    /// <summary>
+    /// Modifying an entity.
+    /// </summary>
+    Modify,
+
+    /// <summary>
+    /// Undoing a previously applied modification.
+    /// </summary>
+    Undo,
+
+    /// <summary>
+    /// Redoing a previously undone modification.
+    /// </summary>
+    Redo
+}

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/PatchSummary.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/PatchSummary.cs
@@ -1,7 +1,9 @@
+using Json.Patch;
+
 namespace Celbridge.Entities.Models;
 
 /// <summary>
-/// Describes the changes applied by an entity data patch.
-/// Includes the original JSON patch, a reverse JSON patch that undoes the changes, and a list of changes.
+/// Describes the changes applied by an entity patch operation.
+/// Includes the original patch operation, a reverse operation that undoes the changes, and a message object describing the change.
 /// </summary>
-public record PatchSummary(string Patch, string ReversePatch, List<ComponentChangedMessage> ComponentChangedMessages);
+public record PatchSummary(PatchOperation Operation, PatchOperation? ReverseOperation, ComponentChangedMessage? ComponentChangedMessage);

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/ServiceConfiguration.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/ServiceConfiguration.cs
@@ -20,8 +20,8 @@ public static class ServiceConfiguration
         // Register commands
         //
         config.AddTransient<ISetPropertyCommand, SetPropertyCommand>();
-        config.AddTransient<IUndoPropertyCommand, UndoPropertyCommand>();
-        config.AddTransient<IRedoPropertyCommand, RedoPropertyCommand>();
+        config.AddTransient<IUndoEntityCommand, UndoEntityCommand>();
+        config.AddTransient<IRedoEntityCommand, RedoEntityCommand>();
         config.AddTransient<IPrintPropertyCommand, PrintPropertyCommand>();
         config.AddTransient<IAddComponentCommand, AddComponentCommand>();
         config.AddTransient<IRemoveComponentCommand, RemoveComponentCommand>();

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
@@ -1,37 +1,18 @@
 using Celbridge.Core;
+using Celbridge.Entities.Models;
 using Celbridge.Explorer;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Projects;
 using Celbridge.Workspace;
 using CommunityToolkit.Diagnostics;
+using Json.Patch;
+using Json.Pointer;
 using Json.Schema;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Celbridge.Entities.Services;
-
-/// <summary>
-/// Describes the context in which a patch is applied.
-/// </summary>
-public enum PatchContext
-{
-    /// <summary>
-    /// Modifying an entity.
-    /// </summary>
-    Modify,
-
-    /// <summary>
-    /// Undoing a previously applied modification.
-    /// </summary>
-    Undo,
-
-    /// <summary>
-    /// Redoing a previously undone modification.
-    /// </summary>
-    Redo
-}
 
 public class EntityService : IEntityService, IDisposable
 {
@@ -155,7 +136,6 @@ public class EntityService : IEntityService, IDisposable
         return _entityRegistry.CopyEntityDataFile(sourceResource, destResource);
     }
 
-    private record AddComponentOperation(string op, string path, JsonObject value);
     public Result AddComponent(ResourceKey resource, string componentType, int componentIndex)
     {
         // Acquire the entity for the specified resource
@@ -167,7 +147,6 @@ public class EntityService : IEntityService, IDisposable
                 .WithErrors(acquireResult);
         }
         var entity = acquireResult.Value;
-        Guard.IsNotNull(entity);
 
         // Acquire the schema for the specified componentType
 
@@ -179,7 +158,7 @@ public class EntityService : IEntityService, IDisposable
         }
         var componentSchema = componentSchemaResult.Value;
 
-        // Create an instance of the prototype in the Entity Data
+        // Acquire the prototype for the specified componentType
 
         var getPrototypeResult = _prototypeRegistry.GetPrototype(componentType);
         if (getPrototypeResult.IsFailure)
@@ -189,11 +168,12 @@ public class EntityService : IEntityService, IDisposable
         }
         var prototype = getPrototypeResult.Value;
 
-        var operation = new AddComponentOperation("add", $"/_components/{componentIndex}", prototype.JsonObject);
-        var jsonPatch = JsonSerializer.Serialize(operation, SerializerOptions);
-        jsonPatch = $"[{jsonPatch}]";
+        // Apply a patch operation to add the component to the entity
 
-        var applyResult = ApplyPatch(resource, jsonPatch);
+        var componentPointer = JsonPointer.Create("_components", componentIndex);
+        var patchOperation = PatchOperation.Add(componentPointer, prototype.JsonObject);
+
+        var applyResult = ApplyPatchOperation(entity, patchOperation);
         if (applyResult.IsFailure)
         {
             return Result.Fail($"Failed to apply patch to add component to entity: {resource}")
@@ -203,7 +183,6 @@ public class EntityService : IEntityService, IDisposable
         return Result.Ok();
     }
 
-    private record RemoveComponentOperation(string op, string path);
     public Result RemoveComponent(ResourceKey resource, int componentIndex)
     {
         // Acquire the entity for the specified resource
@@ -215,14 +194,13 @@ public class EntityService : IEntityService, IDisposable
                 .WithErrors(acquireResult);
         }
         var entity = acquireResult.Value;
-        Guard.IsNotNull(entity);
 
         // Apply a patch to remove the component at the specified index
-        var operation = new RemoveComponentOperation("remove", $"/_components/{componentIndex}");
-        var jsonPatch = JsonSerializer.Serialize(operation, SerializerOptions);
-        jsonPatch = $"[{jsonPatch}]";
+        
+        var componentPointer = JsonPointer.Create("_components", componentIndex);
+        var patchOperation = PatchOperation.Remove(componentPointer);
 
-        var applyResult = ApplyPatch(resource, jsonPatch);
+        var applyResult = ApplyPatchOperation(entity, patchOperation);
         if (applyResult.IsFailure)
         {
             return Result.Fail($"Failed to apply patch to remove entity component at index '{componentIndex}' for resource: {resource}")
@@ -284,12 +262,12 @@ public class EntityService : IEntityService, IDisposable
         var entity = acquireResult.Value;
         Guard.IsNotNull(entity);
 
-        var componentPropertyPath = GetComponentPropertyPath(componentIndex, propertyPath);
+        var propertyPointer = GetPropertyPointer(componentIndex, propertyPath);
 
-        var getResult = entity.EntityData.GetProperty<T>(componentPropertyPath);
+        var getResult = entity.EntityData.GetProperty<T>(propertyPointer);
         if (getResult.IsFailure)
         {
-            return Result<T>.Fail($"Failed to get entity property '{propertyPath}' for resource '{resource}'")
+            return Result<T>.Fail($"Failed to get component property '{propertyPath}' for resource '{resource}'")
                 .WithErrors(getResult);
         }
 
@@ -308,9 +286,9 @@ public class EntityService : IEntityService, IDisposable
         var entity = acquireResult.Value;
         Guard.IsNotNull(entity);
 
-        var componentPropertyPath = GetComponentPropertyPath(componentIndex, propertyPath);
+        var propertyPointer = GetPropertyPointer(componentIndex, propertyPath);
 
-        var getResult = entity.EntityData.GetPropertyAsJSON(componentPropertyPath);
+        var getResult = entity.EntityData.GetPropertyAsJSON(propertyPointer);
         if (getResult.IsFailure)
         {
             return Result<string>.Fail($"Failed to get entity property '{propertyPath}' for resource '{resource}'")
@@ -320,17 +298,33 @@ public class EntityService : IEntityService, IDisposable
         return getResult;
     }
 
-    private record SetPropertyOperation(string op, string path, object value);
-    public Result SetProperty<T>(ResourceKey resource, int componentIndex, string propertyPath, T newValue) where T : notnull
+    public Result SetProperty<T>(ResourceKey resource, int componentIndex, string propertyPath, T newValue, bool insert) where T : notnull
     {
-        string componentPropertyPath = GetComponentPropertyPath(componentIndex, propertyPath);
+        var acquireResult = _entityRegistry.AcquireEntity(resource);
+        if (acquireResult.IsFailure)
+        {
+            return Result.Fail($"Failed to acquire entity: {resource}")
+                .WithErrors(acquireResult);
+        }
+        var entity = acquireResult.Value;
+        Guard.IsNotNull(entity);
 
-        // Set the property by applying a JSON patch
-        var operation = new SetPropertyOperation("add", componentPropertyPath, newValue);
-        var jsonPatch = JsonSerializer.Serialize(operation, SerializerOptions);
-        jsonPatch = $"[{jsonPatch}]";
+        // Construct a patch operation to set the property
 
-        var applyResult = ApplyPatch(resource, jsonPatch);
+        var propertyPointer = GetPropertyPointer(componentIndex, propertyPath);
+        var jsonValue = JsonSerializer.SerializeToNode(newValue, SerializerOptions);
+
+        PatchOperation operation;
+        if (insert)
+        {
+            operation = PatchOperation.Add(propertyPointer, jsonValue);
+        }
+        else
+        {
+            operation = PatchOperation.Replace(propertyPointer, jsonValue);
+        }
+
+        var applyResult = ApplyPatchOperation(entity, operation);
         if (applyResult.IsFailure)
         {
             return Result.Fail($"Failed to apply entity patch for resource: {resource}");
@@ -339,14 +333,14 @@ public class EntityService : IEntityService, IDisposable
         return Result.Ok();
     }
 
-    public Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue) where T : notnull
+    public Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue, bool insert) where T : notnull
     {
-        var geComponentsResult = GetComponentsOfType(resource, componentType);
-        if (geComponentsResult.IsFailure)
+        var getComponentsResult = GetComponentsOfType(resource, componentType);
+        if (getComponentsResult.IsFailure)
         {
-            return geComponentsResult;
+            return getComponentsResult;
         }
-        var componentIndices = geComponentsResult.Value;
+        var componentIndices = getComponentsResult.Value;
 
         if (componentIndices.Count < 1)
         {
@@ -354,7 +348,7 @@ public class EntityService : IEntityService, IDisposable
         }
         var componentIndex = componentIndices[0];
 
-        return SetProperty(resource, componentIndex, propertyPath, newValue);
+        return SetProperty(resource, componentIndex, propertyPath, newValue, insert);
     }
 
     public Result<bool> UndoEntity(ResourceKey resource)
@@ -376,10 +370,10 @@ public class EntityService : IEntityService, IDisposable
 
         // Pop the next patch summary from the Undo stack and apply it to the entity
         var patchSummary = entity.UndoStack.Pop();
-        var reversePatch = patchSummary.ReversePatch;
-        Guard.IsNotNull(reversePatch);
+        var reversePatchOperation = patchSummary.ReverseOperation;
+        Guard.IsNotNull(reversePatchOperation);
 
-        var applyResult = ApplyPatch(resource, reversePatch, PatchContext.Undo);
+        var applyResult = ApplyPatchOperation(entity, reversePatchOperation, PatchContext.Undo);
         if (applyResult.IsFailure)
         {
             return Result<bool>.Fail($"Failed to apply undo patch to resource: {resource}");
@@ -408,10 +402,10 @@ public class EntityService : IEntityService, IDisposable
 
         // Pop the next patch summary from the Redo stack and apply it to the entity
         var patchSummary = entity.RedoStack.Pop();
-        var reversePatch = patchSummary.ReversePatch;
-        Guard.IsNotNull(reversePatch);
+        var reverseOperation = patchSummary.ReverseOperation;
+        Guard.IsNotNull(reverseOperation);
 
-        var applyResult = ApplyPatch(resource, reversePatch, PatchContext.Redo);
+        var applyResult = ApplyPatchOperation(entity, reverseOperation, PatchContext.Redo);
         if (applyResult.IsFailure)
         {
             return Result<bool>.Fail($"Failed to apply redo patch to resource: {resource}");
@@ -421,9 +415,11 @@ public class EntityService : IEntityService, IDisposable
         return Result<bool>.Ok(true);
     }
 
-    private static string GetComponentPropertyPath(int componentIndex, string propertyPath)
+    private static JsonPointer GetPropertyPointer(int componentIndex, string propertyPath)
     {
-        return $"/_components/{componentIndex}{propertyPath}";
+        var trimmedPath = propertyPath.TrimStart('/');
+        var jsonPointer = JsonPointer.Create("_components", componentIndex, trimmedPath);
+        return jsonPointer;
     }
 
     private void OnResourceRegistryUpdatedMessage(object recipient, ResourceRegistryUpdatedMessage message)
@@ -431,53 +427,23 @@ public class EntityService : IEntityService, IDisposable
         _entityRegistry.CleanupEntities();
     }
 
-    private Result ApplyPatch(ResourceKey resource, string patch, PatchContext context = PatchContext.Modify)
+    private Result ApplyPatchOperation(Entity entity, PatchOperation patchOperation, PatchContext context = PatchContext.Modify)
     {
-        var acquireResult = _entityRegistry.AcquireEntity(resource);
-        if (acquireResult.IsFailure)
-        {
-            return Result.Fail($"Failed to acquire entity: {resource}")
-                .WithErrors(acquireResult);
-        }
-        var entity = acquireResult.Value;
-        Guard.IsNotNull(entity);
-
-        var applyResult = entity.EntityData.ApplyPatch(resource, patch, _schemaRegistry);
+        var applyResult = entity.ApplyPatchOperation(patchOperation, _schemaRegistry, context);
         if (applyResult.IsFailure)
         {
-            return Result.Fail($"Failed to apply patch to entity for resource: '{resource}'")
+            return Result.Fail($"Failed to apply entity patch for resource: '{entity.Resource}'")
                 .WithErrors(applyResult);
         }
         var patchSummary = applyResult.Value;
 
-        if (patchSummary.ComponentChangedMessages.Count > 0)
+        if (patchSummary.ComponentChangedMessage is not null)
         {
-            // Add the patch summary to the requested stack to support undo/redo
-            switch (context)
-            {
-                case PatchContext.Modify:
-                    // Execute: Add patch summary to the Undo stack and clear the Redo stack.
-                    entity.UndoStack.Push(patchSummary);
-                    entity.RedoStack.Clear();
-                    break;
-                case PatchContext.Undo:
-                    // Undo: Add patch summary to the Redo stack.
-                    entity.RedoStack.Push(patchSummary);
-                    break;
-                case PatchContext.Redo:
-                    // Undo: Add patch summary to the Undo stack.
-                    entity.UndoStack.Push(patchSummary);
-                    break;
-            }
-
             // Mark the entity as needing to be saved
-            _entityRegistry.MarkModifiedEntity(resource);
+            _entityRegistry.MarkModifiedEntity(entity.Resource);
 
-            // Notify listeners of the component changes resulting from applying the patch
-            foreach (var message in patchSummary.ComponentChangedMessages)
-            {
-                _messengerService.Send(message);
-            }
+            // Notify listeners about the component changes
+            _messengerService.Send(patchSummary.ComponentChangedMessage);
         }
 
         return Result.Ok();

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
@@ -357,7 +357,7 @@ public class EntityService : IEntityService, IDisposable
         return SetProperty(resource, componentIndex, propertyPath, newValue);
     }
 
-    public Result<bool> UndoProperty(ResourceKey resource)
+    public Result<bool> UndoEntity(ResourceKey resource)
     {
         var acquireResult = _entityRegistry.AcquireEntity(resource);
         if (acquireResult.IsFailure)
@@ -389,7 +389,7 @@ public class EntityService : IEntityService, IDisposable
         return Result<bool>.Ok(true);
     }
 
-    public Result<bool> RedoProperty(ResourceKey resource)
+    public Result<bool> RedoEntity(ResourceKey resource)
     {
         var acquireResult = _entityRegistry.AcquireEntity(resource);
         if (acquireResult.IsFailure)

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
@@ -95,13 +95,10 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
 
     private void SetEditorMode(EditorMode editorMode)
     {
-        try
+        var setResult = _entityService.SetProperty(Resource, MarkdownComponent, MarkdownComponentConstants.EditorMode, editorMode);
+        if (setResult.IsFailure)
         {
-            _entityService.SetProperty(Resource, MarkdownComponent, MarkdownComponentConstants.EditorMode, editorMode);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex.Message);
+            _logger.LogError(setResult.Error);
         }
     }
 


### PR DESCRIPTION
All entity data patches now contain a single operation.
Reverse operations are defined explicitly instead of diffing JsonObjects (unreliable for some operations).
Use JsonPointer for all Json path logic.
Fix remove component undo operation.
Support inserting values in arrays and objects at specific key/index.

