### PR TITLE
Multiple component validation checks

### DIFF
--- a/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Schemas/VoiceLine.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Schemas/VoiceLine.json
@@ -26,5 +26,6 @@
     "speakingTo",
     "line"
   ],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allowMultipleComponents": true
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/ComponentSchema.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/ComponentSchema.cs
@@ -9,13 +9,15 @@ public class ComponentSchema
 {
     public string ComponentType { get; }
     public int ComponentVersion { get; }
+    public bool AllowMultipleComponents { get; }
 
     private readonly JsonSchema _jsonSchema;
 
-    private ComponentSchema(string componentType, int componentVersion, JsonSchema jsonSchema)
+    private ComponentSchema(string componentType, int componentVersion, bool allowMultipleComponents, JsonSchema jsonSchema)
     {
         ComponentType = componentType;
         ComponentVersion = componentVersion;
+        AllowMultipleComponents = allowMultipleComponents;
         _jsonSchema = jsonSchema;
     }
 
@@ -32,6 +34,7 @@ public class ComponentSchema
             }
 
             // Get component type
+
             var componentTypePointer = JsonPointer.Parse("/properties/_componentType/const");
             var componentTypeElement = componentTypePointer.Evaluate(root);
 
@@ -48,6 +51,7 @@ public class ComponentSchema
             }
 
             // Get component version 
+            
             var componentVersionPointer = JsonPointer.Parse("/properties/_componentVersion/const");
             var componentVersionElement = componentVersionPointer.Evaluate(root);
 
@@ -56,17 +60,25 @@ public class ComponentSchema
             {
                 return Result<ComponentSchema>.Fail("Component version element is not valid");
             }
-
             var componentVersion = componentVersionElement.Value.GetInt32();
 
+            // Get allowMultipleComponents
+
+            bool allowMultipleComponents = false;
+            if (root.TryGetProperty("allowMultipleComponents", out JsonElement allowMultipleElement))
+            {
+                allowMultipleComponents = allowMultipleElement.GetBoolean();
+            }
+
             // Create the JsonSchema object
+
             var jsonSchema = JsonSchema.FromText(schemaJson);
             if (jsonSchema is null)
             {
                 return Result<ComponentSchema>.Fail($"Failed to parse schema for component type: '{componentType}'");
             }
 
-            var schema = new ComponentSchema(componentType, componentVersion, jsonSchema);
+            var schema = new ComponentSchema(componentType, componentVersion, allowMultipleComponents, jsonSchema);
 
             return Result<ComponentSchema>.Ok(schema);
         }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -10,12 +10,12 @@ namespace Celbridge.Entities.Models;
 
 public class EntityData
 {
-    public JsonObject JsonObject { get; private set; }
+    public JsonObject EntityJsonObject { get; private set; }
     public JsonSchema EntitySchema { get; }
 
     private EntityData(JsonObject jsonObject, JsonSchema entitySchema)
     {
-        JsonObject = jsonObject;
+        EntityJsonObject = jsonObject;
         EntitySchema = entitySchema;
     }
 
@@ -24,40 +24,12 @@ public class EntityData
         return new EntityData(jsonObject, entitySchema);
     }
 
-    public Result<List<int>> GetComponentsOfType(string componentType)
-    {
-        if (JsonObject["_components"] is not JsonArray components)
-        {
-            return Result<List<int>>.Fail("Entity data does not contain any components");
-        }
-
-        var indices = new List<int>();
-        for (int i = 0; i < components.Count; i++)
-        {
-            var propertyPath = JsonPointer.Create("_components", i, "_componentType");
-
-            var getPropertyResult = GetProperty<string>(propertyPath);
-            if (getPropertyResult.IsFailure)
-            {
-                continue;
-            }
-            var componentTypeValue = getPropertyResult.Value;
-
-            if (componentTypeValue == componentType)
-            {
-                indices.Add(i);
-            }
-        }
-
-        return Result<List<int>>.Ok(indices);
-    }
-
     public Result<T> GetProperty<T>(JsonPointer propertyPointer)
         where T : notnull
     {
         try
         {
-            if (!propertyPointer.TryEvaluate(JsonObject, out var valueNode))
+            if (!propertyPointer.TryEvaluate(EntityJsonObject, out var valueNode))
             {
                 return Result<T>.Fail($"Property was not found at: '{propertyPointer}'");
             }
@@ -88,7 +60,7 @@ public class EntityData
     {
         try
         {
-            if (!propertyPointer.TryEvaluate(JsonObject, out var valueNode))
+            if (!propertyPointer.TryEvaluate(EntityJsonObject, out var valueNode))
             {
                 return Result<string>.Fail($"Property was not found at: '{propertyPointer}'");
             }
@@ -119,7 +91,7 @@ public class EntityData
             // We perform a number of checks on this patched entity before we use it to replace the existing entity.
 
             var patch = new JsonPatch(operation);
-            var patchResult = patch.Apply(JsonObject);
+            var patchResult = patch.Apply(EntityJsonObject);
             if (!patchResult.IsSuccess)
             {
                 return Result<PatchSummary>.Fail($"Failed to apply JSON patch to entity data: {patchResult.Error}");
@@ -129,7 +101,7 @@ public class EntityData
             Guard.IsNotNull(patchedJsonObject);
 
             // Check if the JSON object has actually changed as a result of applying the patch
-            if (JsonNode.DeepEquals(JsonObject, patchedJsonObject))
+            if (JsonNode.DeepEquals(EntityJsonObject, patchedJsonObject))
             {
                 // The patch was valid, but did not result in any changes.
                 // This is indicated by returning null reverse patch and change message values.
@@ -158,7 +130,7 @@ public class EntityData
             bool isAddComponentOperation = operation.Path.Count == 2 && operation.Op == OperationType.Add;
             if (isAddComponentOperation)
             {
-                var checkMultipleResult = CheckMultipleComponentConstraint(componentChange, schemaRegistry);
+                var checkMultipleResult = EntityUtils.CheckMultipleComponents(patchedJsonObject, componentChange.ComponentType, schemaRegistry);
                 if (checkMultipleResult.IsFailure)
                 {
                     return Result<PatchSummary>.Fail($"Component type does not allow multiple components: '{componentChange.ComponentType}'")
@@ -167,15 +139,20 @@ public class EntityData
             }
 
             // Check that the component that was modified by the operation is still valid against its schema.
-            // Removed component operations don't require validation.
+            // The remove component operation doesn't require validation.
             bool isRemoveComponentOperation = operation.Path.Count == 2 && operation.Op == OperationType.Remove;
             if (!isRemoveComponentOperation)
             {
-                var checkSchemaResult = CheckComponentSchemeConstraint(componentChange, schemaRegistry, patchedJsonObject);
+                var checkSchemaResult = EntityUtils.CheckComponentSchema(patchedJsonObject, componentChange.ComponentIndex, schemaRegistry);
+                if (checkSchemaResult.IsFailure)
+                {
+                    return Result<PatchSummary>.Fail($"Failed to validate component at index '{componentChange.ComponentIndex}' against schema for component type '{componentChange.ComponentType}'")
+                        .WithErrors(checkSchemaResult);
+                }
             }
 
             // Make reverse patch operation for undo
-            var createReverseResult = CreateReversePatchOperation(operation);
+            var createReverseResult = EntityUtils.CreateReversePatchOperation(EntityJsonObject, operation);
             if (createReverseResult.IsFailure)
             {
                 return Result<PatchSummary>.Fail($"Failed to create reverse patch operation")
@@ -184,7 +161,7 @@ public class EntityData
             var reverseOperation = createReverseResult.Value;
 
             // The patched component has passed validation, so we can now update the entity.
-            JsonObject = patchedJsonObject;
+            EntityJsonObject = patchedJsonObject;
 
             var patchSummary = new PatchSummary(operation, reverseOperation, componentChange);
             return Result<PatchSummary>.Ok(patchSummary);
@@ -242,7 +219,7 @@ public class EntityData
                 // ...in all other cases, use the component type of the existing entity component.
 
                 var componentTypePointer = jsonPointer[..2].Combine("_componentType");
-                if (!componentTypePointer.TryEvaluate(JsonObject, out var componentTypeNode) ||
+                if (!componentTypePointer.TryEvaluate(EntityJsonObject, out var componentTypeNode) ||
                     componentTypeNode is null)
                 {
                     throw new InvalidOperationException($"Component at index {componentIndex} does not contain a '_componentType' property");
@@ -269,115 +246,5 @@ public class EntityData
             return Result<ComponentChangedMessage>.Fail("An exception occurred when extracting changes from a component patch operation")
                 .WithException(ex);
         }
-    }
-
-    private Result CheckMultipleComponentConstraint(ComponentChangedMessage componentChange, ComponentSchemaRegistry schemaRegistry)
-    {
-        var addedComponentType = componentChange.ComponentType;
-        var getSchemaResult = schemaRegistry.GetSchemaForComponentType(addedComponentType);
-        if (getSchemaResult.IsFailure)
-        {
-            return Result<PatchSummary>.Fail($"Failed to get schema for component type '{addedComponentType}'")
-                .WithErrors(getSchemaResult);
-        }
-        var schema = getSchemaResult.Value;
-
-        var allowMultiple = schema.AllowMultipleComponents;
-        if (!allowMultiple)
-        {
-            // Check if the existing entity already contains a component of the same type
-            var getComponentsResult = GetComponentsOfType(addedComponentType);
-            if (getComponentsResult.IsFailure)
-            {
-                return Result<PatchSummary>.Fail($"Failed to get components of type '{addedComponentType}'")
-                    .WithErrors(getComponentsResult);
-            }
-            var componentCount = getComponentsResult.Value.Count;
-
-            if (componentCount > 0)
-            {
-                return Result<PatchSummary>.Fail($"Component type '{addedComponentType}' does not allow multiple components");
-            }
-        }
-
-        return Result.Ok();
-    }
-
-    private Result CheckComponentSchemeConstraint(ComponentChangedMessage componentChange, ComponentSchemaRegistry schemaRegistry, JsonObject patchedJsonObject)
-    {
-        var componentIndex = componentChange.ComponentIndex;
-        var componentType = componentChange.ComponentType;
-
-        var getSchemaResult = schemaRegistry.GetSchemaForComponentType(componentType);
-        if (getSchemaResult.IsFailure)
-        {
-            return Result<PatchSummary>.Fail($"Failed to get schema for component type '{componentType}'")
-                .WithErrors(getSchemaResult);
-        }
-        var componentSchema = getSchemaResult.Value;
-
-        var jsonPointer = JsonPointer.Parse($"/_components/{componentIndex}");
-        if (!jsonPointer.TryEvaluate(patchedJsonObject, out var componentNode))
-        {
-            return Result<PatchSummary>.Fail($"Failed to get component at index: {componentIndex}");
-        }
-
-        if (componentNode is not JsonObject componentObject)
-        {
-            return Result<PatchSummary>.Fail($"Component at index {componentIndex} is not a JSON object");
-        }
-
-        var validateResult = componentSchema.ValidateJsonObject(componentObject);
-        if (validateResult.IsFailure)
-        {
-            return Result<PatchSummary>.Fail($"Component at index {componentIndex} is not valid against its schema")
-                .WithErrors(validateResult);
-        }
-
-        return Result.Ok();
-    }
-
-    private Result<PatchOperation> CreateReversePatchOperation(PatchOperation operation)
-    {
-        PatchOperation reverseOperation;
-        switch (operation.Op)
-        {
-            case OperationType.Add:
-                reverseOperation = PatchOperation.Remove(operation.Path);
-                break;
-
-            case OperationType.Remove:
-                {
-                    if (!operation.Path.TryEvaluate(JsonObject, out var existingValue))
-                    {
-                        return Result<PatchOperation>.Fail($"Component does not exist at path: '{operation.Path}'");
-                    }
-                    reverseOperation = PatchOperation.Add(operation.Path, existingValue);
-                    break;
-                }
-
-            case OperationType.Replace:
-                {
-                    if (!operation.Path.TryEvaluate(JsonObject, out var existingValue))
-                    {
-                        return Result<PatchOperation>.Fail($"Component does not exist at path: '{operation.Path}'");
-                    }
-                    reverseOperation = PatchOperation.Replace(operation.Path, existingValue);
-                    break;
-                }
-
-            case OperationType.Move:
-                reverseOperation = PatchOperation.Move(operation.Path, operation.From);
-                break;
-
-            case OperationType.Copy:
-                reverseOperation = PatchOperation.Remove(operation.Path);
-                break;
-
-            default:
-                return Result<PatchOperation>.Fail("Unsupported patch operation");
-        }
-
-        return Result<PatchOperation>.Ok(reverseOperation);
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityUtils.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityUtils.cs
@@ -1,0 +1,287 @@
+using Celbridge.Entities.Models;
+using Json.Patch;
+using Json.Pointer;
+using Json.Schema;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+
+namespace Celbridge.Entities.Services;
+
+public static class EntityUtils
+{
+    /// <summary>
+    /// Loads and validates an EntityData object from a json file.
+    /// </summary>
+    public static Result<EntityData> LoadEntityDataFile(string entityDataPath, JsonSchema entitySchema, ComponentSchemaRegistry schemaRegistry)
+    {
+        // Load the EntityData json
+        var jsonObject = JsonNode.Parse(File.ReadAllText(entityDataPath)) as JsonObject;
+        if (jsonObject is null)
+        {
+            return Result<EntityData>.Fail($"Failed to parse entity data from file: '{entityDataPath}'");
+        }
+
+        // Todo: Attempt to repair/migrate the data instead of just failing
+
+        // Validate the loaded data against the entity schema
+        var evaluateResult = entitySchema.Evaluate(jsonObject);
+        if (!evaluateResult.IsValid)
+        {
+            return Result<EntityData>.Fail($"Entity data failed schema validation: '{entityDataPath}'");
+        }
+
+        var checkSchemasResult = CheckComponentSchemas(jsonObject, schemaRegistry);
+        if (checkSchemasResult.IsFailure)
+        {
+            return Result<EntityData>.Fail($"Failed to validate component schemas for entity: '{entityDataPath}'")
+                .WithErrors(checkSchemasResult);
+        }
+
+        var checkMultipleResult = CheckMultipleComponents(jsonObject, schemaRegistry);
+        if (checkMultipleResult.IsFailure)
+        {
+            return Result<EntityData>.Fail($"Entity data contains invalid multiple components: '{entityDataPath}'")
+                .WithErrors(checkMultipleResult);
+        }
+
+        // We've passed validation so now we can create and return the EntityData object
+        var entityData = EntityData.Create(jsonObject, entitySchema);
+
+        return Result<EntityData>.Ok(entityData);
+    }
+
+    /// <summary>
+    /// Returns a list of indices of components of the specified type in the entity data.
+    /// </summary>
+    public static Result<List<int>> GetComponentsOfType(JsonObject entityData, string componentType)
+    {
+        if (entityData["_components"] is not JsonArray components)
+        {
+            return Result<List<int>>.Fail("Entity data does not contain any components");
+        }
+
+        var indices = new List<int>();
+        for (int i = 0; i < components.Count; i++)
+        {
+            var propertyPath = JsonPointer.Create("_components", i, "_componentType");
+            if (!propertyPath.TryEvaluate(entityData, out var componentTypeNode) ||
+                componentTypeNode is null ||
+                componentTypeNode.GetValueKind() != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var componentTypeValue = componentTypeNode.GetValue<string>();
+            if (componentTypeValue == componentType)
+            {
+                indices.Add(i);
+            }
+        }
+
+        return Result<List<int>>.Ok(indices);
+    }
+
+    /// <summary>
+    /// Checks if the entity data contains multiple components of the same type where the component schema does not allow it.
+    /// </summary>
+    public static Result CheckMultipleComponents(JsonObject entityData, ComponentSchemaRegistry schemaRegistry)
+    {
+        if (entityData["_components"] is not JsonArray components)
+        {
+            return Result.Fail("Entity data does not contain a '_components' property.");
+        }
+
+        var checkedComponentTypes = new HashSet<string>();
+
+        for (int i = 0; i < components.Count; i++)
+        {
+            var componentTypePointer = JsonPointer.Parse($"/_components/{i}/_componentType");
+
+            if (!componentTypePointer.TryEvaluate(entityData, out var componentTypeNode) ||
+                componentTypeNode is null ||
+                componentTypeNode.GetValueKind() != JsonValueKind.String)
+            {
+                return Result.Fail($"Failed to get component type for component at index {i}.");
+            }
+
+            var componentType = componentTypeNode.GetValue<string>();
+
+            if (checkedComponentTypes.Contains(componentType))
+            {
+                // We've already checked this component type
+                continue;
+            }
+
+            var checkResult = CheckMultipleComponents(entityData, componentType, schemaRegistry);
+            if (checkResult.IsFailure)
+            {
+                return Result.Fail($"Duplicate component check failed for component type '{componentType}'.")
+                    .WithErrors(checkResult);
+            }
+
+            checkedComponentTypes.Add(componentType);
+        }
+
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Checks if the entity data contains multiple instance of any component type where the schema does not allow it.
+    /// </summary>
+    public static Result CheckMultipleComponents(JsonObject entityData, string componentType, ComponentSchemaRegistry schemaRegistry)
+    {
+        var getSchemaResult = schemaRegistry.GetSchemaForComponentType(componentType);
+        if (getSchemaResult.IsFailure)
+        {
+            return Result.Fail($"Failed to get schema for component type '{componentType}'")
+                .WithErrors(getSchemaResult);
+        }
+        var schema = getSchemaResult.Value;
+
+        var allowMultiple = schema.AllowMultipleComponents;
+        if (!allowMultiple)
+        {
+            // Check if the existing entity already contains a component of the same type
+            var getComponentsResult = GetComponentsOfType(entityData, componentType);
+            if (getComponentsResult.IsFailure)
+            {
+                return Result.Fail($"Failed to get components of type '{componentType}'")
+                    .WithErrors(getComponentsResult);
+            }
+            var componentCount = getComponentsResult.Value.Count;
+
+            if (componentCount > 1)
+            {
+                return Result.Fail($"Component type '{componentType}' does not allow multiple components");
+            }
+        }
+
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Checks if a specific component in the entity data is valid against its respective schema.
+    /// </summary>
+    public static Result CheckComponentSchema(JsonObject entityData, int componentIndex, ComponentSchemaRegistry schemaRegistry)
+    {
+        // Get the component at specified index
+
+        var componentPointer = JsonPointer.Parse($"/_components/{componentIndex}");
+        if (!componentPointer.TryEvaluate(entityData, out var componentNode))
+        {
+            return Result.Fail($"Failed to get component at index: {componentIndex}");
+        }
+
+        if (componentNode is not JsonObject componentObject)
+        {
+            return Result.Fail($"Component at index {componentIndex} is not a JSON object");
+        }
+
+        // Get the component type
+
+        var componentTypePointer = JsonPointer.Parse($"/_componentType");
+        if (!componentTypePointer.TryEvaluate(componentObject, out var componentTypeNode) ||
+            componentTypeNode is null ||
+            componentTypeNode.GetValueKind() != JsonValueKind.String)
+        {
+            return Result.Fail($"Failed to get component type for component at index: {componentIndex}");
+        }
+        var componentType = componentTypeNode.GetValue<string>();
+
+        // Get the schema for the component type
+
+        var getSchemaResult = schemaRegistry.GetSchemaForComponentType(componentType);
+        if (getSchemaResult.IsFailure)
+        {
+            return Result.Fail($"Failed to get schema for component type '{componentType}'")
+                .WithErrors(getSchemaResult);
+        }
+        var componentSchema = getSchemaResult.Value;
+
+        // Validate the component against its schema
+
+        var validateResult = componentSchema.ValidateJsonObject(componentObject);
+        if (validateResult.IsFailure)
+        {
+            return Result.Fail($"Component at index {componentIndex} is not valid against its schema")
+                .WithErrors(validateResult);
+        }
+
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Checks if all components in the entity data are valid against their respective schemas.
+    /// </summary>
+    public static Result CheckComponentSchemas(JsonObject entityData, ComponentSchemaRegistry schemaRegistry)
+    {
+        var componentsPointer = JsonPointer.Parse("/_components");
+
+        if (!componentsPointer.TryEvaluate(entityData, out var componentsNode) ||
+            componentsNode is not JsonArray componentsArray ||
+            componentsArray is null)
+        {
+            return Result.Fail("Failed to get components array");
+        }
+
+        // Validate each component in the entity against its corresponding schema
+        for (int i = 0; i < componentsArray.Count; i++)
+        {
+            var checkSchemaResult = CheckComponentSchema(entityData, i, schemaRegistry);
+            if (checkSchemaResult.IsFailure)
+            {
+                return Result.Fail($"Component at index {i} is not valid against its schema")
+                    .WithErrors(checkSchemaResult);
+            }
+        }
+
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Creates a reverse patch operation (to support undo) for the specified patch operation.
+    /// </summary>
+    public static Result<PatchOperation> CreateReversePatchOperation(JsonObject entityData, PatchOperation operation)
+    {
+        PatchOperation reverseOperation;
+        switch (operation.Op)
+        {
+            case OperationType.Add:
+                reverseOperation = PatchOperation.Remove(operation.Path);
+                break;
+
+            case OperationType.Remove:
+                {
+                    if (!operation.Path.TryEvaluate(entityData, out var existingValue))
+                    {
+                        return Result<PatchOperation>.Fail($"Component does not exist at path: '{operation.Path}'");
+                    }
+                    reverseOperation = PatchOperation.Add(operation.Path, existingValue);
+                    break;
+                }
+
+            case OperationType.Replace:
+                {
+                    if (!operation.Path.TryEvaluate(entityData, out var existingValue))
+                    {
+                        return Result<PatchOperation>.Fail($"Component does not exist at path: '{operation.Path}'");
+                    }
+                    reverseOperation = PatchOperation.Replace(operation.Path, existingValue);
+                    break;
+                }
+
+            case OperationType.Move:
+                reverseOperation = PatchOperation.Move(operation.Path, operation.From);
+                break;
+
+            case OperationType.Copy:
+                reverseOperation = PatchOperation.Remove(operation.Path);
+                break;
+
+            default:
+                return Result<PatchOperation>.Fail("Unsupported patch operation");
+        }
+
+        return Result<PatchOperation>.Ok(reverseOperation);
+    }
+}


### PR DESCRIPTION
Component schema must define 'allowMultipleComponents: true' to allow multiple instances of the same component type.
Fail to load entity data file with invalid multiple components.
Fail to add a component that would break multiple component constraint.
Refactored several utility methods to live in EntityUtils.cs