### PR TITLE
Add CopyComponent command

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/ICopyComponentCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/ICopyComponentCommand.cs
@@ -1,0 +1,24 @@
+using Celbridge.Commands;
+
+namespace Celbridge.Entities;
+
+/// <summary>
+/// Command to copy an entity component from a source index to a destination index.
+/// </summary>
+public interface ICopyComponentCommand : IExecutableCommand
+{
+    /// <summary>
+    /// The resource associated with the entity data to be modified.
+    /// </summary>
+    ResourceKey Resource { get; set; }
+
+    /// <summary>
+    /// The source index of the component to copy.
+    /// </summary>
+    int SourceComponentIndex { get; set; }
+
+    /// <summary>
+    /// The destination index of the component to copy.
+    /// </summary>
+    int DestComponentIndex { get; set; }
+}

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
@@ -47,6 +47,11 @@ public interface IEntityService
     Result RemoveComponent(ResourceKey resource, int componentIndex);
 
     /// <summary>
+    /// Copy an entity component from a source index to a destination index.
+    /// </summary>
+    Result CopyComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex);
+
+    /// <summary>
     /// Returns the indices of the entity components of the specified type.
     /// </summary>
     Result<List<int>> GetComponentsOfType(ResourceKey resourceKey, string componentType);
@@ -77,7 +82,7 @@ public interface IEntityService
     /// propertyPath is a JSON Pointer (RFC 6901).
     /// Fails if the property cannot be found.
     /// </summary>
-    Result<string> GetPropertyAsJSON(ResourceKey resource, int componentIndex, string propertyPath);
+    Result<string> GetPropertyAsJson(ResourceKey resource, int componentIndex, string propertyPath);
 
     /// <summary>
     /// Replaces the value of an existing entity property for a component.

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Celbridge.Entities.csproj
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Celbridge.Entities.csproj
@@ -27,11 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="ComponentConfig\Prototypes\VoiceLine.json" />
-    <None Remove="ComponentConfig\Schemas\VoiceLine.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />
     <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="JsonPointer.Net" />

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
@@ -1,0 +1,48 @@
+using Celbridge.Commands;
+using Celbridge.Core;
+using Celbridge.Workspace;
+
+namespace Celbridge.Entities.Commands;
+
+public class CopyComponentCommand : CommandBase, ICopyComponentCommand
+{
+    private readonly IWorkspaceWrapper _workspaceWrapper;
+
+    public ResourceKey Resource { get; set; }
+    public int SourceComponentIndex { get; set; }
+    public int DestComponentIndex { get; set; }
+
+    public CopyComponentCommand(
+        IWorkspaceWrapper workspaceWrapper)
+    {
+        _workspaceWrapper = workspaceWrapper;
+    }
+
+    public override async Task<Result> ExecuteAsync()
+    {
+        var entityService = _workspaceWrapper.WorkspaceService.EntityService;
+
+        var copyResult = entityService.CopyComponent(Resource, SourceComponentIndex, DestComponentIndex);
+        if (copyResult.IsFailure)
+        {
+            return Result.Fail($"Failed to move entity component form index '{SourceComponentIndex}' to index '{DestComponentIndex}': '{Resource}'.")
+                .WithErrors(copyResult);
+        }
+
+        await Task.CompletedTask;
+
+        return copyResult;
+    }
+
+    public static void CopyComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
+    {
+        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+
+        commandService.Execute<ICopyComponentCommand>(command =>
+        {
+            command.Resource = resource;
+            command.SourceComponentIndex = sourceComponentIndex;
+            command.DestComponentIndex = destComponentIndex;
+        });
+    }
+}

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/PrintPropertyCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/PrintPropertyCommand.cs
@@ -26,7 +26,7 @@ public class PrintPropertyCommand : CommandBase, IPrintPropertyCommand
     {
         var entityService = _workspaceWrapper.WorkspaceService.EntityService;
 
-        var getResult = entityService.GetPropertyAsJSON(Resource, ComponentIndex, PropertyPath);
+        var getResult = entityService.GetPropertyAsJson(Resource, ComponentIndex, PropertyPath);
         if (getResult.IsFailure)
         {
             return Result.Fail().WithErrors(getResult);

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Prototypes/Invalid.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Prototypes/Invalid.json
@@ -1,0 +1,4 @@
+{
+  "_componentType": "Invalid",
+  "_componentVersion": 1
+}

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Schemas/Invalid.json
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/ComponentConfig/Schemas/Invalid.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "_componentType": {
+      "type": "string",
+      "const": "Invalid"
+    },
+    "_componentVersion": {
+      "type": "integer",
+      "const": 1
+    }
+  },
+  "required": [
+    "_componentType",
+    "_componentVersion"
+  ],
+  "additionalProperties": false,
+  "allowMultipleComponents": true
+}

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -56,29 +56,27 @@ public class EntityData
         }
     }
 
-    public Result<string> GetPropertyAsJSON(JsonPointer propertyPointer)
+    public Result<JsonNode> GetPropertyAsJsonNode(JsonPointer propertyPointer)
     {
         try
         {
             if (!propertyPointer.TryEvaluate(EntityJsonObject, out var valueNode))
             {
-                return Result<string>.Fail($"Property was not found at: '{propertyPointer}'");
+                return Result<JsonNode>.Fail($"Property was not found at: '{propertyPointer}'");
             }
 
             if (valueNode is null)
             {
                 // The property was found but it is a JSON null value.
-                // We treat this as an error for Entity Data.
-                return Result<string>.Fail($"Property is a JSON null value: '{propertyPointer}'");
+                // Null property values are not supported for Entity Data.
+                return Result<JsonNode>.Fail($"Property is a JSON null value: '{propertyPointer}'");
             }
 
-            var valueJSON = valueNode.ToJsonString();
-
-            return Result<string>.Ok(valueJSON);
+            return Result<JsonNode>.Ok(valueNode);
         }
         catch (Exception ex)
         {
-            return Result<string>.Fail($"An exception occurred when getting entity property '{propertyPointer}'")
+            return Result<JsonNode>.Fail($"An exception occurred when getting entity property '{propertyPointer}'")
                 .WithException(ex);
         }
     }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/ServiceConfiguration.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/ServiceConfiguration.cs
@@ -25,5 +25,6 @@ public static class ServiceConfiguration
         config.AddTransient<IPrintPropertyCommand, PrintPropertyCommand>();
         config.AddTransient<IAddComponentCommand, AddComponentCommand>();
         config.AddTransient<IRemoveComponentCommand, RemoveComponentCommand>();
+        config.AddTransient<ICopyComponentCommand, CopyComponentCommand>();
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityUtils.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityUtils.cs
@@ -270,16 +270,8 @@ public static class EntityUtils
                     break;
                 }
 
-            case OperationType.Move:
-                reverseOperation = PatchOperation.Move(operation.Path, operation.From);
-                break;
-
-            case OperationType.Copy:
-                reverseOperation = PatchOperation.Remove(operation.Path);
-                break;
-
             default:
-                return Result<PatchOperation>.Fail("Unsupported patch operation");
+                return Result<PatchOperation>.Fail($"Patch operation is not supported: {operation.Op}");
         }
 
         return Result<PatchOperation>.Ok(reverseOperation);


### PR DESCRIPTION
Copy component from a source index to a destination index.
Added checks to forbid the use of some JsonPatch operation types (copy, move, test) as they make undo/redo logic too complicated. Instead, we build operations like CopyComponent and MoveComponet out of the existing AddComponent and RemoveComponent primitives.