### PR TITLE
Perform entity operations using command

### DIFF
--- a/Celbridge/Celbridge.Tests/CommandTests.cs
+++ b/Celbridge/Celbridge.Tests/CommandTests.cs
@@ -114,7 +114,7 @@ public class CommandTests
         //
 
         // The undo stack is currently empty
-        _commandService.IsUndoStackEmpty().Should().BeTrue();
+        _commandService.GetUndoCount().Should().Be(0);
 
         var testCommand = new TestCommand();
         _commandService.EnqueueCommand(testCommand);
@@ -132,7 +132,7 @@ public class CommandTests
         testCommand.ExecuteComplete.Should().BeTrue();
 
         // Undo stack should contain one item
-        _commandService.IsUndoStackEmpty().Should().BeFalse();
+        _commandService.GetUndoCount().Should().Be(1);
 
         //
         // Undo the command
@@ -142,9 +142,7 @@ public class CommandTests
         
         var undoResult = _commandService.Undo();
         undoResult.IsSuccess.Should().BeTrue();
-        undoResult.Value.Should().BeTrue();
-
-        _commandService.IsUndoStackEmpty().Should().BeTrue();
+        _commandService.GetUndoCount().Should().Be(0);
 
         // Wait for undo to complete
         for (int i = 0; i < 10; i++)
@@ -162,11 +160,10 @@ public class CommandTests
         // Redo the command
         //
 
-        _commandService.IsRedoStackEmpty().Should().BeFalse();
+        _commandService.GetRedoCount().Should().Be(1);
 
         var redoResult = _commandService.Redo();
         redoResult.IsSuccess.Should().BeTrue();
-        redoResult.Value.Should().BeTrue();
 
         // Wait for redo to complete
         for (int i = 0; i < 10; i++)
@@ -178,7 +175,7 @@ public class CommandTests
             await Task.Delay(50);
         }
 
-        _commandService.IsUndoStackEmpty().Should().BeFalse();
-        _commandService.IsRedoStackEmpty().Should().BeTrue();
+        _commandService.GetUndoCount().Should().Be(1);
+        _commandService.GetRedoCount().Should().Be(0);
     }
 }

--- a/Celbridge/Celbridge.Tests/CommandTests.cs
+++ b/Celbridge/Celbridge.Tests/CommandTests.cs
@@ -61,6 +61,7 @@ public class CommandTests
         services.AddSingleton<IMessengerService, MessengerService>();
         services.AddSingleton<ICommandService, CommandService>();
         services.AddSingleton<IWorkspaceWrapper, WorkspaceWrapper>();
+        services.AddTransient<TestCommand>();
 
         _serviceProvider = services.BuildServiceProvider();
         _commandService = _serviceProvider.GetRequiredService<ICommandService>();
@@ -88,8 +89,12 @@ public class CommandTests
     {
         Guard.IsNotNull(_commandService);
 
-        var testCommand = new TestCommand();
-        _commandService.EnqueueCommand(testCommand);
+        TestCommand? testCommand = null;
+        _commandService.Execute<TestCommand>(command =>
+        {
+            testCommand = command;
+        });
+        Guard.IsNotNull(testCommand);
 
         // Wait for command to execute
         for (int i = 0; i < 10; i++)
@@ -116,8 +121,12 @@ public class CommandTests
         // The undo stack is currently empty
         _commandService.GetUndoCount().Should().Be(0);
 
-        var testCommand = new TestCommand();
-        _commandService.EnqueueCommand(testCommand);
+        TestCommand? testCommand = null;
+        _commandService.Execute<TestCommand>(command =>
+        {
+            testCommand = command;
+        });
+        Guard.IsNotNull(testCommand);
 
         // Wait for command to execute
         for (int i = 0; i < 10; i++)

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandBase.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandBase.cs
@@ -27,7 +27,8 @@ public abstract class CommandBase : IExecutableCommand
     public string ExecutionSource { get; set; } = string.Empty;
 
     /// <summary>
-    /// A callback action called when the command is executed.
+    /// Called when the command is executed.
+    /// This is used internally by the ExecuteAsync() method and should not be used directly.
     /// </summary>
     public Action<Result>? OnExecute { get; set; } = null;
 

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandBase.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandBase.cs
@@ -27,6 +27,11 @@ public abstract class CommandBase : IExecutableCommand
     public string ExecutionSource { get; set; } = string.Empty;
 
     /// <summary>
+    /// A callback action called when the command is executed.
+    /// </summary>
+    public Action<Result>? OnExecute { get; set; } = null;
+
+    /// <summary>
     /// Execute the command.
     /// </summary>
     public abstract Task<Result> ExecuteAsync();

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -20,7 +20,7 @@ public interface ICommandService
     /// Create, configure and immediately execute a command.
     /// Note that immediately executed commands do not support command flags or undo/redo.
     /// </summary>
-    Task<Result> ExecuteNow<T>(
+    Task<Result> ExecuteImmediate<T>(
         Action<T>? configure = null,
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -8,7 +8,9 @@ namespace Celbridge.Commands;
 public interface ICommandService
 {
     /// <summary>
-    /// Create, configure and enqueue a command.
+    /// Enqueues a command for later execution.
+    /// Enqueued commands are executed in sequential order.
+    /// Succeeds if the command was enqueued successfully.
     /// </summary>
     Result Execute<T> (
         Action<T>? configure = null,
@@ -17,8 +19,9 @@ public interface ICommandService
     ) where T : IExecutableCommand;
 
     /// <summary>
-    /// Create, configure and immediately execute a command.
-    /// Note that immediately executed commands do not support command flags or undo/redo.
+    /// Executes a command immediately without enqueuing it.
+    /// When you use this method, bear in mind that an enqueued command could execute at the same time.
+    /// Command flags have no effect when you use this method.
     /// </summary>
     Task<Result> ExecuteImmediate<T>(
         Action<T>? configure = null,
@@ -27,9 +30,8 @@ public interface ICommandService
     ) where T : IExecutableCommand;
 
     /// <summary>
-    /// Create, configure and asynchronously execute a command.
-    /// The call completes when the command has been executed.
-    /// This method does not support executing undoable commands.
+    /// Enqueue a command for execution, and then wait for it to execute.
+    /// Returns the command execution result.
     /// </summary>
     Task<Result> ExecuteAsync<T>(
         Action<T>? configure = null,

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -64,17 +64,6 @@ public interface ICommandService
         [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand;
 
     /// <summary>
-    /// Create a new command via the dependency injection system.
-    /// </summary>
-    T CreateCommand<T>() where T : IExecutableCommand;
-
-    /// <summary>
-    /// Add the command to the queue.
-    /// It will be executed when it reaches the front of the queue.
-    /// </summary>
-    Result EnqueueCommand(IExecutableCommand command);
-
-    /// <summary>
     /// Returns true if a command of the given type is in the queue.
     /// </summary>
     bool ContainsCommandsOfType<T>() where T : notnull;

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -85,26 +85,22 @@ public interface ICommandService
     void RemoveCommandsOfType<T>() where T : notnull;
 
     /// <summary>
-    /// Returns true if the undo stack is empty.
+    /// Returns the number of available undo operations.
     /// </summary>
-    bool IsUndoStackEmpty();
+    int GetUndoCount();
 
     /// <summary>
-    /// Returns true if the redo stack is empty.
+    /// Returns the number of available redo operations.
     /// </summary>
-    bool IsRedoStackEmpty();
+    int GetRedoCount();
 
     /// <summary>
     /// Attempt to pop the most recent undo command from the undo stack and execute it.
-    /// The call will succeed whether an undo is performed or not (e.g. if the undo stack is empty).
-    /// The boolean return value indicates whether an undo operation was actually performed.
     /// </summary>
-    Result<bool> Undo();
+    Result Undo();
 
     /// <summary>
     /// Attempts to pop the most recently undone command from the redo stack and execute it.
-    /// The call will succeed whether a redo is performed or not (e.g. if the redo stack is empty).
-    /// The boolean return value indicates whether a redo operation was actually performed.
     /// </summary>
-    Result<bool> Redo();
+    Result Redo();
 }

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -9,6 +9,7 @@ public interface ICommandService
 {
     /// <summary>
     /// Create and enqueue a command that does not require configuration.
+    /// May be used to execute commands with CommandFlags.Undoable enabled.
     /// </summary>
     Result Execute<T>(
         [CallerFilePath] string filePath = "",
@@ -23,6 +24,15 @@ public interface ICommandService
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0
     ) where T : IExecutableCommand;
+
+    /// <summary>
+    /// Create and asynchronously execute a command that does not require configuration.
+    /// The call completes when the command has been executed.
+    /// This method does not support executing undoable commands.
+    /// </summary>
+    Task<Result> ExecuteAsync<T>(
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand;
 
     /// <summary>
     /// Create, configure and enqueue a command.
@@ -42,6 +52,16 @@ public interface ICommandService
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0
     ) where T : IExecutableCommand;
+
+    /// <summary>
+    /// Create, configure and asynchronously execute a command.
+    /// The call completes when the command has been executed.
+    /// This method does not support executing undoable commands.
+    /// </summary>
+    Task<Result> ExecuteAsync<T>(
+        Action<T> configure,
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand;
 
     /// <summary>
     /// Create a new command via the dependency injection system.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/ICommandService.cs
@@ -8,37 +8,10 @@ namespace Celbridge.Commands;
 public interface ICommandService
 {
     /// <summary>
-    /// Create and enqueue a command that does not require configuration.
-    /// May be used to execute commands with CommandFlags.Undoable enabled.
-    /// </summary>
-    Result Execute<T>(
-        [CallerFilePath] string filePath = "",
-        [CallerLineNumber] int lineNumber = 0
-    ) where T : IExecutableCommand;
-
-    /// <summary>
-    /// Create and immediately execute a command that does not require configuration.
-    /// Note that immediately executed commands do not support command flags or undo/redo.
-    /// </summary>
-    Task<Result> ExecuteNow<T>(
-        [CallerFilePath] string filePath = "",
-        [CallerLineNumber] int lineNumber = 0
-    ) where T : IExecutableCommand;
-
-    /// <summary>
-    /// Create and asynchronously execute a command that does not require configuration.
-    /// The call completes when the command has been executed.
-    /// This method does not support executing undoable commands.
-    /// </summary>
-    Task<Result> ExecuteAsync<T>(
-        [CallerFilePath] string filePath = "",
-        [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand;
-
-    /// <summary>
     /// Create, configure and enqueue a command.
     /// </summary>
     Result Execute<T> (
-        Action<T> configure,
+        Action<T>? configure = null,
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0
     ) where T : IExecutableCommand;
@@ -48,7 +21,7 @@ public interface ICommandService
     /// Note that immediately executed commands do not support command flags or undo/redo.
     /// </summary>
     Task<Result> ExecuteNow<T>(
-        Action<T> configure,
+        Action<T>? configure = null,
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0
     ) where T : IExecutableCommand;
@@ -59,7 +32,7 @@ public interface ICommandService
     /// This method does not support executing undoable commands.
     /// </summary>
     Task<Result> ExecuteAsync<T>(
-        Action<T> configure,
+        Action<T>? configure = null,
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand;
 

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/IExecutableCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/IExecutableCommand.cs
@@ -28,7 +28,7 @@ public interface IExecutableCommand
 
     /// <summary>
     /// Called when the command is executed.
-    /// Used internally by the ExecuteAsync() method.
+    /// This is used internally by the ExecuteAsync() method and should not be used directly.
     /// </summary>
     Action<Result>? OnExecute { get; set; }
 

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/IExecutableCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/IExecutableCommand.cs
@@ -27,6 +27,12 @@ public interface IExecutableCommand
     string ExecutionSource { get; set; }
 
     /// <summary>
+    /// Called when the command is executed.
+    /// Used internally by the ExecuteAsync() method.
+    /// </summary>
+    Action<Result>? OnExecute { get; set; }
+
+    /// <summary>
     /// Execute the command.
     /// </summary>
     Task<Result> ExecuteAsync();

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
@@ -124,16 +124,24 @@ public interface IEntityService
     Result SetProperty<T>(ResourceKey resource, string componentType, string propertyPath, T newValue, bool insert = false) where T : notnull;
 
     /// <summary>
-    /// Attempt to undo the most recent entity change for a resource.
-    /// Returns false if there was no operation on the undo stack to undo.
+    /// Returns the number of available undo operations for an entity.
     /// </summary>
-    Result<bool> UndoEntity(ResourceKey resource);
+    int GetUndoCount(ResourceKey resource);
 
     /// <summary>
-    /// Attempt to redo the most recently undone entity change for a resource.
-    /// Returns false if there was no operation on the redo stack to redo.
+    /// Undo the most recent entity change for a resource.
     /// </summary>
-    Result<bool> RedoEntity(ResourceKey resource);
+    Result UndoEntity(ResourceKey resource);
+
+    /// <summary>
+    /// Returns the number of available redo operations for an entity.
+    /// </summary>
+    int GetRedoCount(ResourceKey resource);
+
+    /// <summary>
+    /// Redo the most recently undone entity change for a resource.
+    /// </summary>
+    Result RedoEntity(ResourceKey resource);
 
     /// <summary>
     /// Returns true if any component in the entity has the specified tag.

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/UserInterface/IUndoService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/UserInterface/IUndoService.cs
@@ -6,14 +6,12 @@ namespace Celbridge.UserInterface;
 public interface IUndoService
 {
     /// <summary>
-    /// Attempt to undo the last operation.
-    /// Returns false if there was no operation on the undo stack to undo.
+    /// Undo the last operation.
     /// </summary>
-    Result<bool> Undo();
+    Result Undo();
 
     /// <summary>
-    /// Attempt to redo the most recently undone operation.
-    /// Returns false if there was no operation on the redo stack to redo.
+    /// Redo the most recently undone operation.
     /// </summary>
-    Result<bool> Redo();
+    Result Redo();
 }

--- a/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
@@ -368,7 +368,6 @@ public class CommandService : ICommandService
                             //
 
                             var undoResult = await command.UndoAsync();
-                            await Task.Delay(1); // Workaround for a bug in the colored console logger
 
                             if (undoResult.IsSuccess)
                             {
@@ -387,7 +386,6 @@ public class CommandService : ICommandService
                             //
 
                             var executeResult = await command.ExecuteAsync();
-                            await Task.Delay(1); // Workaround for a bug in the colored console logger
 
                             if (executeResult.IsSuccess)
                             {

--- a/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
@@ -58,7 +58,7 @@ public class CommandService : ICommandService
         return EnqueueCommand(command, CommandExecutionMode.Execute);
     }
 
-    public async Task<Result> ExecuteNow<T>(
+    public async Task<Result> ExecuteImmediate<T>(
         Action<T>? configure = null,
         [CallerFilePath] string filePath = "",
         [CallerLineNumber] int lineNumber = 0) where T : IExecutableCommand

--- a/Celbridge/CoreServices/Celbridge.Logging/Services/CommandSerializerContractResolver.cs
+++ b/Celbridge/CoreServices/Celbridge.Logging/Services/CommandSerializerContractResolver.cs
@@ -31,6 +31,7 @@ public class CommandSerializerContractResolver : DefaultContractResolver
                 case nameof(IExecutableCommand.UndoGroupId):
                 case nameof(IExecutableCommand.CommandFlags):
                 case nameof(IExecutableCommand.ExecutionSource):
+                case nameof(IExecutableCommand.OnExecute):
                     shouldSerialize = false;
                     break;
             }

--- a/Celbridge/CoreServices/Celbridge.Projects/Commands/CreateProjectCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Commands/CreateProjectCommand.cs
@@ -34,7 +34,7 @@ public class CreateProjectCommand : CommandBase, ICreateProjectCommand
 
         // Close any open project.
         // This will fail if there's no project currently open, but we can just ignore that.
-        await _commandService.ExecuteNow<IUnloadProjectCommand>();
+        await _commandService.ExecuteImmediate<IUnloadProjectCommand>();
 
         // Create the new project
         var createResult = await _projectService.CreateProjectAsync(Config);

--- a/Celbridge/CoreServices/Celbridge.Projects/Commands/LoadProjectCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Commands/LoadProjectCommand.cs
@@ -56,7 +56,7 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
 
         // Close any loaded project.
         // This will fail if there's no project currently open, but we can just ignore that.
-        await _commandService.ExecuteNow<IUnloadProjectCommand>();
+        await _commandService.ExecuteImmediate<IUnloadProjectCommand>();
 
         // Load the project
         var loadResult = await LoadProjectAsync(ProjectFilePath);

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -286,8 +286,8 @@ public class DocumentsService : IDocumentsService, IDisposable
             }
 
             // Execute a command to load the document
-            // Use ExecuteNow() to ensure the command is executed while the workspace is still loading.
-            var openResult = await _commandService.ExecuteNow<IOpenDocumentCommand>(command =>
+            // Use ExecuteImmediate() to ensure the command is executed while the workspace is still loading.
+            var openResult = await _commandService.ExecuteImmediate<IOpenDocumentCommand>(command =>
             {
                 command.FileResource = fileResource;
             });
@@ -311,8 +311,8 @@ public class DocumentsService : IDocumentsService, IDisposable
         }
 
         // Execute a command to select the previously selected document
-        // Use ExecuteNow() to ensure the command is executed while the workspace is still loading.
-        var selectResult = await _commandService.ExecuteNow<ISelectDocumentCommand>(command =>
+        // Use ExecuteImmediate() to ensure the command is executed while the workspace is still loading.
+        var selectResult = await _commandService.ExecuteImmediate<ISelectDocumentCommand>(command =>
         {
             command.FileResource = new ResourceKey(selectedDocument);
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/AddComponentCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/AddComponentCommand.cs
@@ -34,15 +34,21 @@ public class AddComponentCommand : CommandBase, IAddComponentCommand
         return addResult;
     }
 
-    public static void AddComponent(ResourceKey resource, string componentType, int insertAtIndex)
+    //
+    // Static methods for scripting support.
+    //
+
+    public static async Task<Result> AddComponent(ResourceKey resource, string componentType, int insertAtIndex)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
 
-        commandService.Execute<IAddComponentCommand>(command =>
+        var result = await commandService.ExecuteAsync<IAddComponentCommand>(command =>
         {
             command.Resource = resource;
             command.ComponentType = componentType;
             command.ComponentIndex = insertAtIndex;
         });
+
+        return result;
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
@@ -34,11 +34,15 @@ public class CopyComponentCommand : CommandBase, ICopyComponentCommand
         return copyResult;
     }
 
-    public static void CopyComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
+    //
+    // Static methods for scripting support.
+    //
+
+    public static async Task<Result> CopyComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
 
-        commandService.Execute<ICopyComponentCommand>(command =>
+        return await commandService.ExecuteAsync<ICopyComponentCommand>(command =>
         {
             command.Resource = resource;
             command.SourceComponentIndex = sourceComponentIndex;

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/MoveComponentCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/MoveComponentCommand.cs
@@ -34,11 +34,15 @@ public class MoveComponentCommand : CommandBase, IMoveComponentCommand
         return copyResult;
     }
 
-    public static void MoveComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
+    //
+    // Static methods for scripting support.
+    //
+
+    public static async Task<Result> MoveComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
 
-        commandService.Execute<IMoveComponentCommand>(command =>
+        return await commandService.ExecuteAsync<IMoveComponentCommand>(command =>
         {
             command.Resource = resource;
             command.SourceComponentIndex = sourceComponentIndex;

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
@@ -31,10 +31,10 @@ public class RedoEntityCommand : CommandBase, IRedoEntityCommand
     // Static methods for scripting support.
     //
 
-    public static void RedoEntity(ResourceKey resource)
+    public static async Task<Result> RedoEntity(ResourceKey resource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IRedoEntityCommand>(command =>
+        return await commandService.ExecuteAsync<IRedoEntityCommand>(command =>
         {
             command.Resource = resource;
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RemoveComponentCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/RemoveComponentCommand.cs
@@ -33,11 +33,15 @@ public class RemoveComponentCommand : CommandBase, IRemoveComponentCommand
         return removeResult;
     }
 
-    public static void RemoveComponent(ResourceKey resource, int componentIndex)
+    //
+    // Static methods for scripting support.
+    //
+
+    public static async Task<Result> RemoveComponent(ResourceKey resource, int componentIndex)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
 
-        commandService.Execute<IRemoveComponentCommand>(command =>
+        return await commandService.ExecuteAsync<IRemoveComponentCommand>(command =>
         {
             command.Resource = resource;
             command.ComponentIndex = componentIndex;

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
@@ -39,10 +39,10 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     /// Replaces an existing component property value at the specified path.
     /// If the property value does not exist, the operation fails.
     /// </summary>
-    public static void SetProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
+    public static async Task<Result> SetProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<ISetPropertyCommand>(command =>
+        return await commandService.ExecuteAsync<ISetPropertyCommand>(command =>
         {
             command.Resource = resource;
             command.ComponentIndex = componentIndex;
@@ -56,10 +56,10 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     /// Inserts a new component property value at the specified path.
     /// If the property value already exists, it is replaced.
     /// </summary>
-    public static void InsertProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
+    public static async Task<Result> InsertProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<ISetPropertyCommand>(command =>
+        return await commandService.ExecuteAsync<ISetPropertyCommand>(command =>
         {
             command.Resource = resource;
             command.ComponentIndex = componentIndex;

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
@@ -31,10 +31,10 @@ public class UndoEntityCommand : CommandBase, IUndoEntityCommand
     // Static methods for scripting support.
     //
 
-    public static void UndoEntity(ResourceKey resource)
+    public static async Task<Result> UndoEntity(ResourceKey resource)
     {
         var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IUndoEntityCommand>(command =>
+        return await commandService.ExecuteAsync<IUndoEntityCommand>(command =>
         {
             command.Resource = resource;
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Explorer/Services/ExplorerService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Explorer/Services/ExplorerService.cs
@@ -320,8 +320,8 @@ public class ExplorerService : IExplorerService, IDisposable
             return;
         }
 
-        // Use ExecuteNow() to ensure the command is executed while the workspace is still loading.
-        var selectResult = await _commandService.ExecuteNow<ISelectResourceCommand>(command =>
+        // Use ExecuteImmediate() to ensure the command is executed while the workspace is still loading.
+        var selectResult = await _commandService.ExecuteImmediate<ISelectResourceCommand>(command =>
         {
             command.Resource = resource;
         });

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/StringFieldViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/StringFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Celbridge.Commands;
 using Celbridge.Entities;
 using Celbridge.Logging;
 using Celbridge.Messaging;
@@ -13,6 +14,7 @@ public partial class StringFieldViewModel : ObservableObject
 {
     private ILogger<StringFieldViewModel> _logger;
     private IMessengerService _messengerService;
+    private ICommandService _commandService;
     private IEntityService _entityService;
 
     public ResourceKey Resource { get; private set; }
@@ -33,10 +35,12 @@ public partial class StringFieldViewModel : ObservableObject
     public StringFieldViewModel(
         ILogger<StringFieldViewModel> logger,
         IMessengerService messengerService,
+        ICommandService commandService,
         IWorkspaceWrapper workspaceWrapper)
     {
         _logger = logger;
         _messengerService = messengerService;
+        _commandService = commandService;
         _entityService = workspaceWrapper.WorkspaceService.EntityService;
     }
 
@@ -114,7 +118,13 @@ public partial class StringFieldViewModel : ObservableObject
 
     private void WriteProperty()
     {
-        _entityService.SetProperty(Resource, ComponentIndex, PropertyName, ValueText);
+        _commandService.Execute<ISetPropertyCommand>(command =>
+        {
+            command.Resource = Resource;
+            command.ComponentIndex = ComponentIndex;
+            command.PropertyPath = PropertyName;
+            command.JsonValue = ValueText;
+        });
     }
 
     public void OnViewUnloaded()


### PR DESCRIPTION
Execute commands to implement all entity operations (e.g. add/remove components, set property, etc.). The helps to ensure that operations are performed sequentially, reducing the scope for concurrent execution bugs.

To support this, the new CommandService.ExecuteAsync() method allows the client to enqueue a command and wait for it to execute, returning the execution result.

I've also refactored the command & entity undo/redo APIs to be consistent with each other and easier to use.

