### PR TITLE
Fix bug when duplicating a component

### DIFF
--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
@@ -15,4 +15,13 @@ public partial class ComponentItem : ObservableObject
 
     [ObservableProperty]
     private string _componentDescription = string.Empty;
+
+    public ComponentItem DeepClone()
+    {
+        return new ComponentItem
+        {
+            ComponentType = ComponentType,
+            ComponentDescription = ComponentDescription
+        };
+    }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -221,7 +221,9 @@ public partial class ComponentListViewModel : InspectorViewModel
 
         // Update the list view
         var item = ComponentItems[sourceIndex];
-        ComponentItems.Insert(destIndex, item);
+        var clone = item.DeepClone();
+
+        ComponentItems.Insert(destIndex, clone);
 
         // Supress the refresh
         _supressRefreshCount = 1;


### PR DESCRIPTION
After duplicating a component, editing the new component also updated the old component's description in the component list. This was due to the same ComponentItem object being inserted multiple times in the ComponentItems observable collection.