### PR TITLE
Track associated activity in the entity properties

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Activities/IActivity.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Activities/IActivity.cs
@@ -17,13 +17,17 @@ public interface IActivity
     Task<Result> DeactivateAsync();
 
     /// <summary>
-    /// Updates an entity that is relevant to this activity.
+    /// Returns true if the activity supports the resource.
     /// </summary>
-    Task<Result> UpdateEntityAsync(ResourceKey resource);
+    bool SupportsResource(ResourceKey resource);
 
     /// <summary>
-    /// Initializes a newly created entity, if the resource is relevant to this activity.
-    /// Returns true if the entity was initialized, false otherwise.
+    /// Initializes a newly created resource that is supported by this activity.
     /// </summary>
-    bool TryInitializeEntity(ResourceKey resource);
+    Task<Result> InitializeResourceAsync(ResourceKey resource);
+
+    /// <summary>
+    /// Updates a resource that is supported by this activity..
+    /// </summary>
+    Task<Result> UpdateResourceAsync(ResourceKey resource);
 }

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Entities/IEntityService.cs
@@ -150,7 +150,18 @@ public interface IEntityService
     bool HasTag(ResourceKey resource, string tag);
 
     /// <summary>
-    /// Return the list of all available component types.
+    /// Returns the list of all available component types.
     /// </summary>
     List<string> GetAllComponentTypes();
+
+    /// <summary>
+    /// Returns the activity property for the entity.
+    /// </summary>
+    Result<string> GetActivity(ResourceKey resource);
+
+    /// <summary>
+    /// Sets the activity property for the entity.
+    /// This will trigger an entity save if the activity is different from the current value.
+    /// </summary>
+    Result SetActivity(ResourceKey resource, string activity);
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
@@ -6,8 +6,6 @@ using Celbridge.Messaging;
 using Celbridge.Workspace;
 using CommunityToolkit.Diagnostics;
 
-using Path = System.IO.Path;
-
 namespace Celbridge.Activities.Services;
 
 public class ActivityDispatcher
@@ -18,7 +16,8 @@ public class ActivityDispatcher
 
     private ActivityRegistry? _activityRegistry;
 
-    private HashSet<ResourceKey> _pendingEntityUpdates = new();
+    private List<ResourceKey> _pendingInits = new();
+    private List<ResourceKey> _pendingUpdates = new();
 
     public ActivityDispatcher(
         ILogger<ActivityDispatcher> logger,
@@ -35,51 +34,33 @@ public class ActivityDispatcher
     {
         _activityRegistry = activityRegistry;
 
-        _messengerService.Register<EntityCreatedMessage>(this, OnEntityCreatedMessage);
+        _messengerService.Register<EntityCreatedMessage>(this, (s, e) => OnInitMessage(e.Resource));
 
-        _messengerService.Register<SelectedResourceChangedMessage>(this, (s, e) => HandleMessage(e.Resource));
-        _messengerService.Register<ComponentChangedMessage>(this, (s, e) => HandleMessage(e.Resource));
-        _messengerService.Register<PopulatedComponentListMessage>(this, (s, e) => HandleMessage(e.Resource));
-
-        void HandleMessage(ResourceKey resource)
+        void OnInitMessage(ResourceKey resource)
         {
             if (!resource.IsEmpty)
             {
-                _pendingEntityUpdates.Add(resource);
+                // Make a note of the new entity for initialization
+                _pendingInits.AddDistinct(resource);
+            }
+        }
+
+        _messengerService.Register<SelectedResourceChangedMessage>(this, (s, e) => OnUpdateMessage(e.Resource));
+        _messengerService.Register<ComponentChangedMessage>(this, (s, e) => OnUpdateMessage(e.Resource));
+        _messengerService.Register<PopulatedComponentListMessage>(this, (s, e) => OnUpdateMessage(e.Resource));
+
+        void OnUpdateMessage(ResourceKey resource)
+        {
+            if (!resource.IsEmpty)
+            {
+                // Make a note of the entity for updating
+                _pendingUpdates.AddDistinct(resource);
             }
         }
 
         await Task.CompletedTask;
 
         return Result.Ok();
-    }
-
-    private void OnEntityCreatedMessage(object recipient, EntityCreatedMessage message)
-    {
-        Guard.IsNotNull(_activityRegistry);
-
-        var resource = message.Resource;
-
-        var fileExtension = Path.GetExtension(resource.ToString());
-        var hasExtension = !string.IsNullOrEmpty(fileExtension);
-
-        if (hasExtension)
-        {
-            // Try each activity in alphabetic order for deterministic results
-            var keys = _activityRegistry.Activities.Keys.ToList();
-            keys.Sort();
-
-            foreach (var key in keys)
-            {
-                // Attempt to initialize the entity with this activity
-                var activity = _activityRegistry.Activities[key];
-                if (activity.TryInitializeEntity(resource))
-                {
-                    // First activity to initialize the entity wins
-                    break;
-                }
-            }
-        }
     }
 
     public void Uninitialize()
@@ -91,147 +72,193 @@ public class ActivityDispatcher
     {
         Guard.IsNotNull(_activityRegistry);
 
-        foreach (var fileResource in _pendingEntityUpdates)
+        var initsResult = await PerformPendingInits();
+        var updatesResult = await PerformPendingUpdates();
+
+        if (initsResult.IsFailure)
         {
-            // Get the component list for this entity
-            var getComponentsResult = _entityService.GetComponents(fileResource);
-            if (getComponentsResult.IsFailure)
+            return initsResult;
+        }
+
+        if (updatesResult.IsFailure)
+        {
+            return updatesResult;
+        }
+
+        return Result.Ok();
+    }
+
+    private async Task<Result> PerformPendingInits()
+    {
+        // Perform pending inits
+        var pendingInits = _pendingInits.ToList();
+        _pendingInits.Clear();
+
+        bool failed = false;
+        foreach (var fileResource in pendingInits)
+        {
+            try
             {
-                return Result.Fail($"Failed to get components for entity: '{fileResource}'")
-                    .WithErrors(getComponentsResult);
-            }
-            var components = getComponentsResult.Value;
-
-            var unprocessedComponents = new List<int>();
-
-            // Annotate empty components
-
-            for (int i = 0; i < components.Count; i++)
-            {
-                var component = components[i];
-
-                if (component.Schema.ComponentType != "Empty")
+                var initResult = await InitializeResource(fileResource);
+                if (initResult.IsFailure)
                 {
-                    unprocessedComponents.Add(i);
+                    failed = true;
+                    _logger.LogError(initResult.Error);
                     continue;
                 }
-
-                AnnotateEmptyComponent(component);
             }
-
-            // Check that the entity has a Primary Component
-
-            bool hasPrimaryComponent = _entityService.HasTag(fileResource, "PrimaryComponent");
-            if (!hasPrimaryComponent)
+            catch (Exception ex)
             {
-                // Move onto next modified file resource
-                continue;
-            }
-
-            // Check that there is at least one component.
-            // There must be if the PrimaryComponent tag is present.
-
-            var getCountResult = _entityService.GetComponentCount(fileResource);
-            if (getCountResult.IsFailure)
-            {
-                return Result.Fail($"Failed to get component count for entity: '{fileResource}'");
-            }
-            var componentCount = getCountResult.Value;
-
-            if (componentCount == 0)
-            {
-                return Result.Fail($"Component count is zero for entity: '{fileResource}'");
-            }
-
-            // Get the schema for the Primary Component
-
-            IComponentProxy? primaryComponent = null;
-
-            bool syntaxError = false;
-
-            foreach (var componentIndex in unprocessedComponents)
-            {
-                var component = components[componentIndex];
-
-                if (component.Schema.ComponentType == "Empty")
-                {
-                    // Ignore empty components at top of Entity
-                    continue;
-                }
-
-                if (component.Schema.HasTag("PrimaryComponent"))
-                {
-                    if (primaryComponent is not null)
-                    {
-                        // Todo: Annotate the component with an error message
-                        // Multiple Primary Components detected
-                        continue;
-                    }
-
-                    // Found the Primary Component
-                    primaryComponent = component;
-                }
-                else
-                {
-                    if (primaryComponent is null)
-                    {
-                        component.SetAnnotation(
-                            ComponentStatus.Error, 
-                            "Invalid component position", 
-                            "This component must be placed after the Primary Component");
-                        syntaxError = true;
-
-                        continue;
-                    }
-                }
-            }
-        
-            if (primaryComponent is null)
-            {
-                syntaxError = true;
-                continue;
-            }
-
-            if (syntaxError) 
-            {
-                // Todo: Annotate all components with an error message
-                // Invalid component
-                // No Primary Component defined
-
-                continue;
-            }
-
-            // Get the activity name for this Primary Component
-
-            var activityName = primaryComponent.Schema.GetStringAttribute("activityName");
-            if (string.IsNullOrEmpty(activityName))
-            {
-                return Result.Fail($"Activity name is empty for Primary Component on resource: {fileResource}");
-            }
-
-            if (!_activityRegistry.Activities.TryGetValue(activityName, out var activity))
-            {
-                // Todo: Annotate the component with an error message
-                continue;
-            }
-
-            // Todo: Check that the Primary Component is allowed for this resource type
-
-            // Use the activity to annotate all components in the entity
-
-            var updateResult = await activity.UpdateEntityAsync(fileResource);
-            if (updateResult.IsFailure)
-            {
-                return Result.Fail($"Failed to update resource: '{fileResource}'")
-                    .WithErrors(updateResult);
+                failed = true;
+                _logger.LogError(ex.ToString());
             }
         }
 
-        _pendingEntityUpdates.Clear();
-
-        await Task.CompletedTask;
+        if (failed)
+        {
+            return Result.Fail($"Failed to perform pending inits");
+        }
 
         return Result.Ok();
+    }
+
+    private async Task<Result> PerformPendingUpdates()
+    {
+        Guard.IsNotNull(_activityRegistry);
+
+        bool failed = false;
+
+        var pendingUpdates = _pendingUpdates.ToList();
+        _pendingUpdates.Clear();
+
+        foreach (var fileResource in pendingUpdates)
+        {
+            try
+            {
+                // Get the component list for this entity
+                var getComponentsResult = _entityService.GetComponents(fileResource);
+                if (getComponentsResult.IsFailure)
+                {
+                    failed = true;
+                    _logger.LogError(getComponentsResult.Error);
+                    continue;
+                }
+                var components = getComponentsResult.Value;
+
+                // Update annotations for empty components
+                // Todo: Remove this once the Empty component handles displaying the comment property
+                foreach (var component in components)
+                {
+                    if (component.Schema.ComponentType == "Empty")
+                    {
+                        AnnotateEmptyComponent(component);
+                    }
+                }
+
+                // Ensure the resource is associated with the correct activity
+                string activityName = UpdateAssociatedActivity(fileResource);
+
+                if (string.IsNullOrEmpty(activityName))
+                {
+                    // No activity supports this resource, early out.
+                    continue;
+                }
+
+                // Use the associated activity to update the resource
+
+                var activity = _activityRegistry.Activities[activityName];
+
+                var updateResult = await activity.UpdateResourceAsync(fileResource);
+                if (updateResult.IsFailure)
+                {
+                    failed = true;
+                    _logger.LogError(updateResult.Error);
+                    continue;
+                }
+            }
+            catch (Exception ex)
+            {
+                failed = true;
+                _logger.LogError(ex.ToString());
+            }
+        }
+
+        if (failed)
+        {
+            return Result.Fail($"Failed to perform pending updates");
+        }
+
+        return Result.Ok();
+    }
+
+    private async Task<Result> InitializeResource(ResourceKey resource)
+    {
+        Guard.IsNotNull(_activityRegistry);
+
+        // Search for an activity that supports this resource.
+        // Try each activity in alphabetic order for deterministic results.
+
+        var activityNames = _activityRegistry.ActivityNames;
+        foreach (var activityName in activityNames)
+        {
+            var activity = _activityRegistry.Activities[activityName];
+
+            if (activity.SupportsResource(resource))
+            {
+                // Initialize the resource with this activity
+                var initializeResult = await activity.InitializeResourceAsync(resource);
+                if (initializeResult.IsFailure)
+                {
+                    return Result.Fail($"Failed to initialize resource '{resource}' with activity '{activityName}'");
+                }
+
+                // Associate this activity with the entity
+                _entityService.SetActivity(resource, activityName);
+                break;
+            }
+        }
+
+        // If no activity supports the resource then no initialization is necessary
+
+        return Result.Ok();
+    }
+
+    private string UpdateAssociatedActivity(ResourceKey resource)
+    {
+        Guard.IsNotNull(_activityRegistry);
+
+        // Check if the current associated  is still valid
+        var getActivityResult = _entityService.GetActivity(resource);
+        if (getActivityResult.IsSuccess)
+        {
+            var currentActivity = getActivityResult.Value;
+            if (!string.IsNullOrEmpty(currentActivity) ||
+                _activityRegistry.Activities.ContainsKey(currentActivity))
+            {
+                // Activity is valid, early out.
+                return currentActivity;
+            }
+        }
+
+        // Search for an activity that supports this resource.
+
+        string newActivityName = string.Empty; // Default to no activity
+        var activityNames = _activityRegistry.ActivityNames;
+        foreach (var activityName in activityNames)
+        {
+            var activity = _activityRegistry.Activities[activityName];
+
+            if (activity.SupportsResource(resource))
+            {
+                newActivityName = activityName;    
+                break;
+            }
+        }
+
+        // Associate the updated activity with the resource
+        _entityService.SetActivity(resource, newActivityName);
+
+        return newActivityName;
     }
 
     private void AnnotateEmptyComponent(IComponentProxy component)

--- a/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
@@ -43,7 +43,10 @@ public class ActivityDispatcher
 
         void HandleMessage(ResourceKey resource)
         {
-            _pendingEntityUpdates.Add(resource);
+            if (!resource.IsEmpty)
+            {
+                _pendingEntityUpdates.Add(resource);
+            }
         }
 
         await Task.CompletedTask;

--- a/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityService.cs
@@ -68,6 +68,7 @@ public class ActivityService : IActivityService, IDisposable
                 // Dispose managed objects here
 
                 _activityRegistry?.Uninitialize();
+                _activityDispatcher?.Uninitialize();
             }
 
             _disposed = true;

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/EntityData.cs
@@ -26,6 +26,22 @@ public class EntityData
         return new EntityData(jsonObject, entitySchema, tags);
     }
 
+    public string GetActivity()
+    {
+        string activity = string.Empty;
+        if (EntityJsonObject.ContainsKey("_activity"))
+        {
+            activity = EntityJsonObject["_activity"]!.ToString();
+        }
+
+        return activity;
+    }
+
+    public void SetActivity(string activity)
+    {
+        EntityJsonObject["_activity"] = activity;
+    }
+
     public Result<T> GetProperty<T>(JsonPointer propertyPointer)
         where T : notnull
     {

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
@@ -56,35 +56,6 @@ public class EntityRegistry
         return Result.Ok();
     }
 
-    private Result<JsonSchema> CreateEntitySchema()
-    {
-        try
-        {
-            // Build and cache the entity schema
-            var builder = new JsonSchemaBuilder()
-                .Type(SchemaValueType.Object)
-                .Properties(
-                    ("_entityVersion", new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Integer)
-                        .Const(1)
-                    ),
-                    ("_components", new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Array)
-                    )
-                )
-                .Required("_entityVersion", "_components");
-
-            var entitySchema = builder.Build();
-
-            return Result<JsonSchema>.Ok(entitySchema);
-        }
-        catch (Exception ex)
-        {
-            return Result<JsonSchema>.Fail("An exception occurred when creating entity schema")
-                .WithException(ex);
-        }
-    }
-
     public string GetEntityDataPath(ResourceKey resource)
     {
         var entityDataPath = Path.Combine(GetEntitiesFolderPath(), resource) + ".json";
@@ -349,7 +320,7 @@ public class EntityRegistry
             if (entityData is null)
             {
                 // We were unable to load an existing entity data, so we need to create a new one
-                var createResult = CreateEntityData(resource);
+                var createResult = EntityUtils.CreateEntityData(resource, _configRegistry, _entitySchema);
                 if (createResult.IsSuccess)
                 {
                     entityData = createResult.Value;
@@ -412,40 +383,43 @@ public class EntityRegistry
         return Result<List<int>>.Ok(componentIndices);
     }
 
+    private Result<JsonSchema> CreateEntitySchema()
+    {
+        try
+        {
+            // Build and cache the entity schema
+            var builder = new JsonSchemaBuilder()
+                .Type(SchemaValueType.Object)
+                .Properties(
+                    ("_entityVersion", new JsonSchemaBuilder()
+                        .Type(SchemaValueType.Integer)
+                        .Const(1)
+                    ),
+                    ("_components", new JsonSchemaBuilder()
+                        .Type(SchemaValueType.Array)
+                    ),
+                    ("_activity", new JsonSchemaBuilder()
+                        .Type(SchemaValueType.String)
+                    )
+                )
+                .Required("_entityVersion", "_components", "_activity");
+
+            var entitySchema = builder.Build();
+
+            return Result<JsonSchema>.Ok(entitySchema);
+        }
+        catch (Exception ex)
+        {
+            return Result<JsonSchema>.Fail("An exception occurred when creating entity schema")
+                .WithException(ex);
+        }
+    }
+
+
     private string GetEntitiesFolderPath()
     {
         var projectDataFolderPath = _projectService.CurrentProject!.ProjectDataFolderPath;
         var path = Path.Combine(projectDataFolderPath, FileNameConstants.EntitiesFolder);
         return path;
-    }
-
-    private Result<EntityData> CreateEntityData(ResourceKey resource)
-    {
-        Guard.IsNotNull(_configRegistry);
-        Guard.IsNotNull(_entitySchema);
-
-        var entityJsonObject = new JsonObject
-        {
-            ["_entityVersion"] = 1,
-            ["_components"] = new JsonArray()
-        };
-
-        var evaluateResult = _entitySchema.Evaluate(entityJsonObject);
-        if (!evaluateResult.IsValid)
-        {
-            return Result<EntityData>.Fail($"Failed to create entity data. Schema validation error: {resource}");
-        }
-
-        var getTagsResult = EntityUtils.GetAllComponentTags(entityJsonObject, _configRegistry);
-        if (getTagsResult.IsFailure)
-        {
-            return Result<EntityData>.Fail($"Failed to get component tags for entity data: {resource}")
-                .WithErrors(getTagsResult);
-        }
-        var tags = getTagsResult.Value;
-
-        var entityData = EntityData.Create(entityJsonObject, _entitySchema, tags);
-
-        return Result<EntityData>.Ok(entityData);
     }
 }

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
@@ -8,7 +8,6 @@ using Json.Schema;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 using Path = System.IO.Path;
 

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/EntityService.cs
@@ -26,8 +26,6 @@ public class EntityService : IEntityService, IDisposable
     private ComponentProxyService _componentProxyService;
     private EntityRegistry _entityRegistry;
 
-    private JsonSchema? _entitySchema;
-
     private static long _undoGroupId;
 
     public static JsonSerializerOptions SerializerOptions { get; } = new()
@@ -61,23 +59,6 @@ public class EntityService : IEntityService, IDisposable
     {
         try
         {
-            // Build and cache the entity schema
-            var builder = new JsonSchemaBuilder()
-                .Type(SchemaValueType.Object)
-                .Properties(
-                    ("_entityVersion", new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Integer)
-                        .Const(1)
-                    ),
-                    ("_components", new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Array)
-                    )
-                )
-                .Required("_entityVersion", "_components");
-
-            _entitySchema = builder.Build();
-            Guard.IsNotNull(_entitySchema);
-
             // Initialize the component proxy service
             var initProxyResult = _componentProxyService.Initialize();
             if (initProxyResult.IsFailure)
@@ -93,7 +74,7 @@ public class EntityService : IEntityService, IDisposable
                     .WithErrors(initConfigResult);
             }
 
-            var initEntitiesResult = _entityRegistry.Initialize(_entitySchema, _configRegistry);
+            var initEntitiesResult = _entityRegistry.Initialize(_configRegistry);
             if (initEntitiesResult.IsFailure)
             {
                 return Result.Fail("Failed to initialize entity registry")


### PR DESCRIPTION
Activities can now be queried to see if they support a resource type. If a supporting activity is found for a resource, then it is stored in the entity properties. The assigned activity is then used to update the resource going forward. Later on, if multiple activities support the same resource type, we will allow the user to select which activity should be used per resource. 
