### PR TITLE
Update component list in inspector via workspace update tick

### DIFF
--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandMessages.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Commands/CommandMessages.cs
@@ -1,6 +1,12 @@
-﻿namespace Celbridge.Commands;
+namespace Celbridge.Commands;
 
 /// <summary>
-/// Message sent when a command is about to execute.
+/// A message sent when a command is about to execute.
 /// </summary>
-public record CommandExecutingMessage(IExecutableCommand Command, CommandExecutionMode ExecutionMode, float ElapsedTime);
+public record ExecuteCommandStartedMessage(IExecutableCommand Command, CommandExecutionMode ExecutionMode, float ElapsedTime);
+
+/// <summary>
+/// A message sent when a command has finished executing.
+/// </summary>
+public record ExecuteCommandEndedMessage(IExecutableCommand Command, CommandExecutionMode ExecutionMode, float ElapsedTime);
+

--- a/Celbridge/CoreServices/Celbridge.BaseLibrary/Inspector/IInspectorService.cs
+++ b/Celbridge/CoreServices/Celbridge.BaseLibrary/Inspector/IInspectorService.cs
@@ -37,4 +37,9 @@ public interface IInspectorService
     /// A service for creating field UI elements for editing component values.
     /// </summary>
     IFieldFactory FieldFactory { get; }
+
+    /// <summary>
+    /// Updates the inspector service.
+    /// </summary>
+    Task<Result> UpdateAsync();
 }

--- a/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
+++ b/Celbridge/CoreServices/Celbridge.Commands/Services/CommandService.cs
@@ -269,14 +269,14 @@ public class CommandService : ICommandService
                 try
                 {
                     // Notify listeners that the command is about to execute
-                    var message = new CommandExecutingMessage(command, executionMode, (float)_stopwatch.Elapsed.TotalSeconds);
-                    _messengerService.Send(message);
+                    var startedMessage = new ExecuteCommandStartedMessage(command, executionMode, (float)_stopwatch.Elapsed.TotalSeconds);
+                    _messengerService.Send(startedMessage);
 
                     var scopeName = $"{executionMode} {command.GetType().Name}";
                     using (_logger.BeginScope(scopeName))
                     {
                         // Log the command execution at the debug level
-                        string logEntry = _logSerializer.SerializeObject(message, false);
+                        string logEntry = _logSerializer.SerializeObject(startedMessage, false);
                         _logger.LogDebug(logEntry);
 
                         if (executionMode == CommandExecutionMode.Undo)
@@ -339,6 +339,9 @@ public class CommandService : ICommandService
                         {
                             _workspaceWrapper.WorkspaceService.SetWorkspaceStateIsDirty();
                         }
+
+                        var endedMessage = new ExecuteCommandEndedMessage(command, executionMode, (float)_stopwatch.Elapsed.TotalSeconds);
+                        _messengerService.Send(endedMessage);
                     }
                 }
                 catch (Exception ex)

--- a/Celbridge/CoreServices/Celbridge.Logging/Services/ExecuteCommandStartedMessageJsonConverter.cs
+++ b/Celbridge/CoreServices/Celbridge.Logging/Services/ExecuteCommandStartedMessageJsonConverter.cs
@@ -4,16 +4,16 @@ using Newtonsoft.Json.Linq;
 
 namespace Celbridge.Logging.Services;
 
-public class CommandExecutingMessageJsonConverter : JsonConverter<CommandExecutingMessage>
+public class ExecuteCommandStartedMessageJsonConverter : JsonConverter<ExecuteCommandStartedMessage>
 {
     public bool _ignoreCommandProperties { get; set; } = false;
 
-    public CommandExecutingMessageJsonConverter(bool ignoreCommandProperties)
+    public ExecuteCommandStartedMessageJsonConverter(bool ignoreCommandProperties)
     {
         _ignoreCommandProperties = ignoreCommandProperties;
     }
 
-    public override void WriteJson(JsonWriter writer, CommandExecutingMessage? message, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, ExecuteCommandStartedMessage? message, JsonSerializer serializer)
     {
         Guard.IsNotNull(message);
 
@@ -37,7 +37,7 @@ public class CommandExecutingMessageJsonConverter : JsonConverter<CommandExecuti
         outputJO.WriteTo(writer);
     }
 
-    public override CommandExecutingMessage ReadJson(JsonReader reader, Type objectType, CommandExecutingMessage? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    public override ExecuteCommandStartedMessage ReadJson(JsonReader reader, Type objectType, ExecuteCommandStartedMessage? existingValue, bool hasExistingValue, JsonSerializer serializer)
     {
         throw new NotImplementedException();
     }

--- a/Celbridge/CoreServices/Celbridge.Logging/Services/LogSerializer.cs
+++ b/Celbridge/CoreServices/Celbridge.Logging/Services/LogSerializer.cs
@@ -30,7 +30,7 @@ public class LogSerializer : ILogSerializer
             Formatting = Formatting.None
         };
 
-        settings.Converters.Add(new CommandExecutingMessageJsonConverter(ignoreCommandProperties));
+        settings.Converters.Add(new ExecuteCommandStartedMessageJsonConverter(ignoreCommandProperties));
         settings.Converters.Add(new StringEnumConverter());
         settings.Converters.Add(new EntityIdConverter());
         settings.Converters.Add(new ResourceKeyConverter());

--- a/Celbridge/CoreServices/Celbridge.Telemetry/Services/TelemetryService.cs
+++ b/Celbridge/CoreServices/Celbridge.Telemetry/Services/TelemetryService.cs
@@ -28,7 +28,7 @@ public class TelemetryService : ITelemetryService
     {
         try
         {
-            _messengerService.Register<CommandExecutingMessage>(this, OnExecutedCommandMessage);
+            _messengerService.Register<ExecuteCommandStartedMessage>(this, OnExecutedCommandMessage);
 
             //create the Countly init object
             CountlyConfig cc = new CountlyConfig();
@@ -81,7 +81,7 @@ public class TelemetryService : ITelemetryService
         await Countly.RecordEvent(eventName, 1, segmentation);
     }
 
-    private void OnExecutedCommandMessage(object recipient, CommandExecutingMessage message)
+    private void OnExecutedCommandMessage(object recipient, ExecuteCommandStartedMessage message)
     {
         var segmentation = new Segmentation();
         segmentation.Add("CommandName", message.Command.GetType().Name);

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/Services/InspectorService.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/Services/InspectorService.cs
@@ -6,6 +6,11 @@ using Celbridge.Workspace;
 
 namespace Celbridge.Inspector.Services;
 
+/// <summary>
+/// Message sent when the workspace requests the inspector to update.
+/// </summary>
+public record UpdateInspectorMessage();
+
 public class InspectorService : IInspectorService, IDisposable
 {
     private readonly ILogger<InspectorService> _logger;
@@ -56,6 +61,17 @@ public class InspectorService : IInspectorService, IDisposable
 
         InspectorFactory = _serviceProvider.GetRequiredService<IInspectorFactory>();
         FieldFactory = _serviceProvider.GetRequiredService<IFieldFactory>();
+    }
+
+    public async Task<Result> UpdateAsync()
+    {
+        await Task.CompletedTask;
+
+        // Notify the inspector panel elements to update
+        var message = new UpdateInspectorMessage();
+        _messengerService.Send(message);
+
+        return Result.Ok();
     }
 
     private void OnWorkspaceWillPopulatePanelsMessage(object recipient, WorkspaceWillPopulatePanelsMessage message)


### PR DESCRIPTION
Fixes an issue where the component list was being repopulated multiple times when the selected entities component structure changed. The new scheme sets a flag when a change notification is received and then repopulates the list as part of the workspace update tick.