### PR TITLE
Add component namespaces

### DIFF
--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Empty.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Empty.json
@@ -9,7 +9,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "Empty#1"
+      "const": "Component.Empty#1"
     },
     "comment": {
       "type": "string"

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Empty.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Empty.json
@@ -9,7 +9,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "Component.Empty#1"
+      "const": ".Empty#1"
     },
     "comment": {
       "type": "string"

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Line.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Line.json
@@ -3,7 +3,6 @@
   "additionalProperties": false,
 
   "attributes": {
-    "tags": [ "Screenplay" ],
     "allowMultipleComponents": true
   },
 

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Line.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Line.json
@@ -10,7 +10,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "Line#1"
+      "const": "Screenplay.Line#1"
     },
     "dialogueKey": {
       "type": "string"

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Markdown.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Markdown.json
@@ -9,7 +9,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "Markdown#1"
+      "const": "Markdown.Markdown#1"
     },
     "editorMode": {
       "type": "string",

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Markdown.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Markdown.json
@@ -2,9 +2,7 @@
   "type": "object",
   "additionalProperties": false,
 
-  "attributes": {
-    "tags": [ "Markdown" ]
-  },
+  "attributes": {},
 
   "properties": {
     "_componentType": {

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Scene.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Scene.json
@@ -9,7 +9,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "Scene#1"
+      "const": "Screenplay.Scene#1"
     },
     "sceneTitle": {
       "type": "string"

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Scene.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/Scene.json
@@ -2,9 +2,7 @@
   "type": "object",
   "additionalProperties": false,
 
-  "attributes": {
-    "tags": [ "Screenplay" ]
-  },
+  "attributes": {},
 
   "properties": {
     "_componentType": {

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/ScreenplayActivity.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/ScreenplayActivity.json
@@ -10,7 +10,7 @@
   "properties": {
     "_componentType": {
       "type": "string",
-      "const": "ScreenplayActivity#1"
+      "const": "Screenplay.ScreenplayActivity#1"
     }
   },
 

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/ScreenplayActivity.json
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Assets/Components/ScreenplayActivity.json
@@ -3,7 +3,6 @@
   "additionalProperties": false,
 
   "attributes": {
-    "tags": [ "Screenplay" ],
     "isActivityComponent": true
   },
 

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -4,7 +4,7 @@ namespace Celbridge.Screenplay.Components;
 
 public class LineEditor : ComponentEditorBase
 {
-    public const string ComponentType = "Line";
+    public const string ComponentType = "Screenplay.Line";
     public const string Character = "/character";
     public const string SourceText = "/sourceText";
 

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
@@ -4,7 +4,7 @@ namespace Celbridge.Screenplay.Components;
 
 public class SceneEditor : ComponentEditorBase
 {
-    public const string ComponentType = "Scene";
+    public const string ComponentType = "Screenplay.Scene";
     public const string SceneTitle = "/sceneTitle";
     public const string SceneDescription = "/sceneDescription";
 

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -13,7 +13,7 @@ namespace Celbridge.Screenplay.Services;
 
 public class ScreenplayActivity : IActivity
 {
-    private const string EmptyComponentType = "Component.Empty";
+    private const string EmptyComponentType = ".Empty";
 
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ScreenplayActivity> _logger;

--- a/Celbridge/Modules/Activities/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Activities/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -13,6 +13,8 @@ namespace Celbridge.Screenplay.Services;
 
 public class ScreenplayActivity : IActivity
 {
+    private const string EmptyComponentType = "Component.Empty";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ScreenplayActivity> _logger;
     private readonly ICommandService _commandService;
@@ -96,7 +98,7 @@ public class ScreenplayActivity : IActivity
 
             var schema = component.Schema;
 
-            if (schema.ComponentType == "Empty")
+            if (schema.ComponentType == EmptyComponentType)
             {
                 // Ignore empty components
                 continue;

--- a/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
@@ -10,6 +10,8 @@ namespace Celbridge.Activities.Services;
 
 public class ActivityDispatcher
 {
+    private const string EmptyComponentType = "Component.Empty";
+
     private readonly ILogger<ActivityDispatcher> _logger;
     private readonly IMessengerService _messengerService;
     private readonly IEntityService _entityService;
@@ -149,7 +151,7 @@ public class ActivityDispatcher
                 // Todo: Remove this once the Empty component handles displaying the comment property
                 foreach (var component in components)
                 {
-                    if (component.Schema.ComponentType == "Empty")
+                    if (component.Schema.ComponentType == EmptyComponentType)
                     {
                         AnnotateEmptyComponent(component);
                     }

--- a/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Activities/Services/ActivityDispatcher.cs
@@ -10,7 +10,7 @@ namespace Celbridge.Activities.Services;
 
 public class ActivityDispatcher
 {
-    private const string EmptyComponentType = "Component.Empty";
+    private const string EmptyComponentType = ".Empty";
 
     private readonly ILogger<ActivityDispatcher> _logger;
     private readonly IMessengerService _messengerService;

--- a/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
@@ -12,6 +12,8 @@ namespace Celbridge.Documents.ViewModels;
 
 public partial class TextEditorDocumentViewModel : ObservableObject
 {
+    private const string MarkdownComponentType = "Markdown.Markdown";
+
     private readonly ILogger<TextEditorDocumentViewModel> _logger;
     private readonly IMessengerService _messengerService;
     private readonly IDocumentsService _documentsService;
@@ -87,7 +89,7 @@ public partial class TextEditorDocumentViewModel : ObservableObject
     private void OnComponentChangedMessage(object recipient, ComponentChangedMessage message)
     {
         if (message.ComponentKey.Resource == _fileResource &&
-            message.ComponentType == "Markdown" &&
+            message.ComponentType == MarkdownComponentType &&
             message.PropertyPath == MarkdownComponentConstants.EditorMode)
         {
             UpdateEditorMode();
@@ -100,7 +102,7 @@ public partial class TextEditorDocumentViewModel : ObservableObject
         {
             EditorMode editorMode;
 
-            var getComponentResult = _entityService.GetComponentOfType(_fileResource, "Markdown");
+            var getComponentResult = _entityService.GetComponentOfType(_fileResource, MarkdownComponentType);
             if (getComponentResult.IsSuccess)
             {
                 // Get the editor mode from the markdown component.

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Models/ComponentConfig.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Models/ComponentConfig.cs
@@ -109,6 +109,17 @@ public class ComponentConfig
                 }
             }
 
+            // Add the component namespace as a tag for convenience
+            var dotIndex = componentType.LastIndexOf('.');
+            if (dotIndex > 0)
+            {
+                var componentNamespace = componentType.Substring(0, dotIndex);
+                if (!string.IsNullOrEmpty(componentNamespace))
+                {
+                    componentTags.Add(componentNamespace);
+                }
+            }
+
             // Get the component properties
 
             var componentProperties = new List<ComponentPropertyInfo>();

--- a/Celbridge/Modules/Workspace/Celbridge.Entities/Services/ComponentConfigRegistry.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Entities/Services/ComponentConfigRegistry.cs
@@ -57,22 +57,24 @@ public class ComponentConfigRegistry
                     return Result.Fail($"Component editor name does not end with 'Editor': '{editorKey}'");
                 }
 
-                // Remove trailing "Editor" from editor key to form the component type
-                var componentType = editorKey[..^6];
+                var configComponentType = config.ComponentType;
 
-                if (componentType != config.ComponentType)
+                // Sanity check that the component type matches the editor type
+                // This doesn't account for component namespaces, that would require an attribute on the editor class.
+                var editorComponentType = editorKey[..^6];
+                if (!configComponentType.EndsWith($".{editorComponentType}"))
                 {
                     return Result.Fail($"Component type does not match type defined in schema: '{editorKey}'");
                 }
 
-                if (_componentConfigs.ContainsKey(componentType))
+                if (_componentConfigs.ContainsKey(configComponentType))
                 {
-                    return Result.Fail($"Component config already exists: '{componentType}'");
+                    return Result.Fail($"Component config already exists: '{configComponentType}'");
                 }
 
                 // Register the config
 
-                _componentConfigs[componentType] = config;
+                _componentConfigs[configComponentType] = config;
             }
 
             return Result.Ok();

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -15,6 +15,8 @@ namespace Celbridge.Inspector.ViewModels;
 
 public partial class ComponentListViewModel : InspectorViewModel
 {
+    private const string EmptyComponentType = "Component.Empty";
+
     private readonly ILogger<MarkdownInspectorViewModel> _logger;
     private readonly IMessengerService _messengerService;
     private readonly ICommandService _commandService;
@@ -144,7 +146,7 @@ public partial class ComponentListViewModel : InspectorViewModel
         var executeResult = await _commandService.ExecuteAsync<IAddComponentCommand>(command => 
         {
             command.ComponentKey = new ComponentKey(Resource, addIndex);
-            command.ComponentType = "Empty";
+            command.ComponentType = EmptyComponentType;
         });
 
         if (executeResult.IsFailure)
@@ -373,9 +375,18 @@ public partial class ComponentListViewModel : InspectorViewModel
             }
             var componentType = getTypeResult.Value;
 
-            if (componentType == "Empty")
+            if (componentType == EmptyComponentType)
             {
                 componentType = string.Empty;
+            }
+            else
+            {
+                // Remove the namespace part of the component type
+                var dotIndex = componentType.LastIndexOf('.');
+                if (dotIndex >= 0)
+                {
+                    componentType = componentType.Substring(dotIndex + 1);
+                }
             }
 
             var componentItem = new ComponentItem

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -15,7 +15,7 @@ namespace Celbridge.Inspector.ViewModels;
 
 public partial class ComponentListViewModel : InspectorViewModel
 {
-    private const string EmptyComponentType = "Component.Empty";
+    private const string EmptyComponentType = ".Empty";
 
     private readonly ILogger<MarkdownInspectorViewModel> _logger;
     private readonly IMessengerService _messengerService;

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentTypeEditorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/ComponentTypeEditorViewModel.cs
@@ -85,11 +85,14 @@ public partial class ComponentTypeEditorViewModel : ObservableObject
         {
             // Add component types that start with the input text first.
             // These should appear at the top of the list.
-            foreach (var name in componentTypes)
+            foreach (var componentType in componentTypes)
             {
-                if (name.StartsWith(inputText, StringComparison.InvariantCultureIgnoreCase))
+                var dotIndex = componentType.IndexOf('.');
+                var unqualifiedComponentType = componentType.Substring(dotIndex);
+
+                if (unqualifiedComponentType.StartsWith(inputText, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    filteredList.Add(name);
+                    filteredList.Add(componentType);
                 }
             }
 
@@ -99,11 +102,14 @@ public partial class ComponentTypeEditorViewModel : ObservableObject
             // Todo: Remove any component types that don't allow multiples of the same type (if there's already an instance)
 
             // Now add any remaining component types that contain the input text
-            foreach (var name in componentTypes)
+            foreach (var componentType in componentTypes)
             {
-                if (name.Contains(inputText, StringComparison.InvariantCultureIgnoreCase))
+                var dotIndex = componentType.IndexOf('.');
+                var unqualifiedComponentType = componentType.Substring(dotIndex);
+
+                if (unqualifiedComponentType.Contains(inputText, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    filteredList.Add(name);
+                    filteredList.Add(componentType);
                 }
             }
         }

--- a/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
+++ b/Celbridge/Modules/Workspace/Celbridge.Inspector/ViewModels/MarkdownInspectorViewModel.cs
@@ -12,7 +12,7 @@ namespace Celbridge.Inspector.ViewModels;
 
 public partial class MarkdownInspectorViewModel : InspectorViewModel
 {
-    private const string MarkdownComponent = "Markdown";
+    private const string MarkdownComponentType = "Markdown.Markdown";
 
     private readonly ILogger<MarkdownInspectorViewModel> _logger;
     private readonly IMessengerService _messengerService;
@@ -49,7 +49,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     private void OnComponentChangedMessage(object recipient, ComponentChangedMessage message)
     {
         if (message.ComponentKey.Resource == Resource &&
-            message.ComponentType == MarkdownComponent &&
+            message.ComponentType == MarkdownComponentType &&
             message.PropertyPath == MarkdownComponentConstants.EditorMode)
         {
             UpdateButtonState();
@@ -96,7 +96,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
     private void SetEditorMode(EditorMode editorMode)
     {
         // Get the component
-        var getComponentResult = _entityService.GetComponentOfType(Resource, MarkdownComponent);
+        var getComponentResult = _entityService.GetComponentOfType(Resource, MarkdownComponentType);
         if (getComponentResult.IsFailure)
         {
             _logger.LogError(getComponentResult.Error);
@@ -117,7 +117,7 @@ public partial class MarkdownInspectorViewModel : InspectorViewModel
         try
         {
             // Get the component
-            var getComponentResult = _entityService.GetComponentOfType(Resource, MarkdownComponent);
+            var getComponentResult = _entityService.GetComponentOfType(Resource, MarkdownComponentType);
             if (getComponentResult.IsFailure)
             {
                 _logger.LogError(getComponentResult.Error);


### PR DESCRIPTION
All component types are now defined in a namespace, to help avoid naming conflicts in future.
The namespace is automatically added as an entity tag for convenient filtering.