### PR TITLE
Remove all Uno Feature flags except Hosting from module projects

### DIFF
--- a/Celbridge/Modules/Celbridge.Core/Celbridge.Core.csproj
+++ b/Celbridge/Modules/Celbridge.Core/Celbridge.Core.csproj
@@ -9,15 +9,7 @@
     <Nullable>enable</Nullable>
 
     <UnoFeatures>
-      CSharpMarkup;
-      Lottie;
       Hosting;
-      Toolkit;
-      Logging;
-      Mvvm;
-      Configuration;
-      Localization;
-      ThemeService;
     </UnoFeatures>
 
   </PropertyGroup>

--- a/Celbridge/Modules/Celbridge.Markdown/Celbridge.Markdown.csproj
+++ b/Celbridge/Modules/Celbridge.Markdown/Celbridge.Markdown.csproj
@@ -9,15 +9,7 @@
     <Nullable>enable</Nullable>
 
     <UnoFeatures>
-      CSharpMarkup;
-      Lottie;
       Hosting;
-      Toolkit;
-      Logging;
-      Mvvm;
-      Configuration;
-      Localization;
-      ThemeService;
     </UnoFeatures>
 
   </PropertyGroup>

--- a/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
+++ b/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
@@ -9,15 +9,7 @@
     <Nullable>enable</Nullable>
 
     <UnoFeatures>
-      CSharpMarkup;
-      Lottie;
       Hosting;
-      Toolkit;
-      Logging;
-      Mvvm;
-      Configuration;
-      Localization;
-      ThemeService;
     </UnoFeatures>
 
   </PropertyGroup>


### PR DESCRIPTION
Modules should primarily use the Celbridge.BaseLibrary API to implement functionality, supplemented by external Nuget packages. This conservative approach will permit us to support module extensions in future.