### PR TITLE
Refactor service locator

### DIFF
--- a/Celbridge/BaseLibrary/Core/ServiceLocator.cs
+++ b/Celbridge/BaseLibrary/Core/ServiceLocator.cs
@@ -8,6 +8,9 @@ public static class ServiceLocator
 {
     private static IServiceProvider? _serviceProvider;
 
+    /// <summary>
+    /// Initializes the service locator with the service provider.
+    /// </summary>
     public static void Initialize(IServiceProvider serviceProvider)
     {
         if (serviceProvider is null)
@@ -18,12 +21,24 @@ public static class ServiceLocator
         _serviceProvider = serviceProvider;
     }
 
-    public static IServiceProvider ServiceProvider => _serviceProvider!;
-
+    /// <summary>
+    /// Extension method to acquire a service from the service provider.
+    /// This can be used in contexts where Microsoft.Extensions.DependencyInjection should be avoided, e.g. Modules.
+    /// </summary>
     public static T AcquireService<T>(this IServiceProvider provider) where T : class
     {
         var service = provider.GetService(typeof(T)) as T;
         Guard.IsNotNull(service, $"Failed to acquire unknown service: '{typeof(T)}'");
         return service;
+    }
+
+    /// <summary>
+    /// Service locator method that can be used to acquire services from the service provider from anywhere.
+    /// This is a bit of an anti-pattern, so should only be used where regualar dependency injection is not viable (e.g. constuction XAML views)
+    /// </summary>
+    public static T AcquireService<T>() where T : class
+    {
+        Guard.IsNotNull(_serviceProvider, "ServiceLocator not initialized");
+        return _serviceProvider.AcquireService<T>();
     }
 }

--- a/Celbridge/BaseLibrary/Core/ServiceLocator.cs
+++ b/Celbridge/BaseLibrary/Core/ServiceLocator.cs
@@ -19,4 +19,11 @@ public static class ServiceLocator
     }
 
     public static IServiceProvider ServiceProvider => _serviceProvider!;
+
+    public static T AcquireService<T>(this IServiceProvider provider) where T : class
+    {
+        var service = provider.GetService(typeof(T)) as T;
+        Guard.IsNotNull(service, $"Failed to acquire unknown service: '{typeof(T)}'");
+        return service;
+    }
 }

--- a/Celbridge/BaseLibrary/Projects/ProjectConstants.cs
+++ b/Celbridge/BaseLibrary/Projects/ProjectConstants.cs
@@ -1,9 +1,9 @@
-namespace Celbridge.Core;
+namespace Celbridge.Projects;
 
 /// <summary>
-/// Strings constants for Celbridge file names.
+/// Strings constants for project files and folders.
 /// </summary>
-public static class FileNameConstants
+public static class ProjectConstants
 {
     /// <summary>
     /// File extension for Celbridge projects.
@@ -11,7 +11,7 @@ public static class FileNameConstants
     public const string ProjectFileExtension = ".celproject";
 
     /// <summary>
-    /// Folder containing the project data file.
+    /// Folder containing the project meta data.
     /// </summary>
     public const string ProjectDataFolder = "CelData";
 

--- a/Celbridge/Celbridge.Tests/WorkspaceSettingsTests.cs
+++ b/Celbridge/Celbridge.Tests/WorkspaceSettingsTests.cs
@@ -39,7 +39,7 @@ public class WorkspaceSettingsTests
         Guard.IsNotNull(_workspaceSettingsService);
         Guard.IsNotNullOrEmpty(_workspaceFolderPath);
 
-        var databaseFilePath = Path.Combine(_workspaceFolderPath, FileNameConstants.WorkspaceSettingsFile);
+        var databaseFilePath = Path.Combine(_workspaceFolderPath, EntityConstants.WorkspaceSettingsFile);
 
         var createResult = await _workspaceSettingsService.CreateWorkspaceSettingsAsync(databaseFilePath);
         createResult.IsSuccess.Should().BeTrue();

--- a/Celbridge/Celbridge.Tests/WorkspaceSettingsTests.cs
+++ b/Celbridge/Celbridge.Tests/WorkspaceSettingsTests.cs
@@ -1,3 +1,4 @@
+using Celbridge.Projects;
 using Celbridge.Workspace;
 using Celbridge.Workspace.Services;
 
@@ -39,7 +40,7 @@ public class WorkspaceSettingsTests
         Guard.IsNotNull(_workspaceSettingsService);
         Guard.IsNotNullOrEmpty(_workspaceFolderPath);
 
-        var databaseFilePath = Path.Combine(_workspaceFolderPath, EntityConstants.WorkspaceSettingsFile);
+        var databaseFilePath = Path.Combine(_workspaceFolderPath, ProjectConstants.WorkspaceSettingsFile);
 
         var createResult = await _workspaceSettingsService.CreateWorkspaceSettingsAsync(databaseFilePath);
         createResult.IsSuccess.Should().BeTrue();

--- a/Celbridge/CoreServices/Celbridge.Logging/Services/MessageTarget.cs
+++ b/Celbridge/CoreServices/Celbridge.Logging/Services/MessageTarget.cs
@@ -19,7 +19,7 @@ public sealed class MessageTarget : TargetWithLayout
             return;
         }
 
-        IMessengerService messengerService = ServiceLocator.ServiceProvider.GetRequiredService<IMessengerService>();
+        IMessengerService messengerService = ServiceLocator.AcquireService<IMessengerService>();
 
         // Send the log event as a message to the console panel
         var message = new LogEventMessage(messageJson);

--- a/Celbridge/CoreServices/Celbridge.Projects/Commands/CreateProjectCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Commands/CreateProjectCommand.cs
@@ -59,7 +59,8 @@ public class CreateProjectCommand : CommandBase, ICreateProjectCommand
 
     public static void CreateProject(string projectFilePath)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICreateProjectCommand>(command =>
         {
             command.Config = new NewProjectConfig(projectFilePath);

--- a/Celbridge/CoreServices/Celbridge.Projects/Commands/LoadProjectCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Commands/LoadProjectCommand.cs
@@ -115,7 +115,11 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
 
     public static void LoadProject(string projectFilePath)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<ILoadProjectCommand>(command => command.ProjectFilePath = projectFilePath);
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
+        commandService.Execute<ILoadProjectCommand>(command =>
+        {
+            command.ProjectFilePath = projectFilePath;
+        });
     }
 }

--- a/Celbridge/CoreServices/Celbridge.Projects/Commands/UnloadProjectCommand.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Commands/UnloadProjectCommand.cs
@@ -37,7 +37,8 @@ public class UnloadProjectCommand : CommandBase, IUnloadProjectCommand
 
     public static void UnloadProject()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IUnloadProjectCommand>();
     }
 }

--- a/Celbridge/CoreServices/Celbridge.Projects/Services/Project.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Services/Project.cs
@@ -103,7 +103,7 @@ public class Project : IDisposable, IProject
             var projectPath = Path.GetDirectoryName(projectFilePath);
             Guard.IsNotNull(projectPath);
 
-            var projectDataFolderPath = Path.Combine(projectPath, FileNameConstants.ProjectDataFolder);
+            var projectDataFolderPath = Path.Combine(projectPath, ProjectConstants.ProjectDataFolder);
 
             if (!Directory.Exists(projectDataFolderPath))
             {
@@ -132,7 +132,7 @@ public class Project : IDisposable, IProject
         _projectFolderPath = Path.GetDirectoryName(projectFilePath)!;
         Guard.IsNotNullOrWhiteSpace(ProjectFolderPath);
 
-        _projectDataFolderPath = Path.Combine(ProjectFolderPath, FileNameConstants.ProjectDataFolder);
+        _projectDataFolderPath = Path.Combine(ProjectFolderPath, ProjectConstants.ProjectDataFolder);
     }
 
     private bool _disposed = false;

--- a/Celbridge/CoreServices/Celbridge.Projects/Services/Project.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Services/Project.cs
@@ -42,8 +42,7 @@ public class Project : IDisposable, IProject
 
         try
         {
-            var serviceProvider = ServiceLocator.ServiceProvider;
-            var project = serviceProvider.GetRequiredService<IProject>() as Project;
+            var project = ServiceLocator.AcquireService<IProject>() as Project;
             Guard.IsNotNull(project);
 
             project.PopulatePaths(projectFilePath);
@@ -54,7 +53,7 @@ public class Project : IDisposable, IProject
 
             var configJson = File.ReadAllText(projectFilePath);
 
-            var projectConfig = serviceProvider.GetRequiredService<IProjectConfig>() as ProjectConfig;
+            var projectConfig = ServiceLocator.AcquireService<IProjectConfig>() as ProjectConfig;
             Guard.IsNotNull(projectConfig);
 
             var initResult = projectConfig.Initialize(configJson);

--- a/Celbridge/CoreServices/Celbridge.Projects/Services/ProjectService.cs
+++ b/Celbridge/CoreServices/Celbridge.Projects/Services/ProjectService.cs
@@ -49,7 +49,7 @@ public class ProjectService : IProjectService
         }
 
         var extension = Path.GetExtension(projectName);
-        if (extension != FileNameConstants.ProjectFileExtension)
+        if (extension != ProjectConstants.ProjectFileExtension)
         {
             return Result.Fail($"Project file extension is not valid: '{projectName}'");
         }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ServiceConfiguration.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ServiceConfiguration.cs
@@ -49,7 +49,7 @@ public static class ServiceConfiguration
 
     public static void Initialize()
     {
-        var navigationService = ServiceLocator.ServiceProvider.GetRequiredService<INavigationService>();
+        var navigationService = ServiceLocator.AcquireService<INavigationService>();
 
         navigationService.RegisterPage(nameof(EmptyPage), typeof(EmptyPage));
         navigationService.RegisterPage(nameof(HomePage), typeof(HomePage));

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/FilePickerService.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/FilePickerService.cs
@@ -19,7 +19,7 @@ public class FilePickerService : IFilePickerService
 
 #if WINDOWS
         // For Uno.WinUI-based apps
-        var userInterfaceService = ServiceLocator.ServiceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         var mainWindow = userInterfaceService.MainWindow;
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(mainWindow);
         WinRT.Interop.InitializeWithWindow.Initialize(fileOpenPicker, hwnd);
@@ -51,7 +51,7 @@ public class FilePickerService : IFilePickerService
 
 #if WINDOWS
         // For Uno.WinUI-based apps
-        var userInterfaceService = ServiceLocator.ServiceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         var mainWindow = userInterfaceService.MainWindow;
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(mainWindow);
         WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hwnd);

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/MainMenuUtils.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/MainMenuUtils.cs
@@ -39,7 +39,7 @@ public class MainMenuUtils
 
     public async Task ShowOpenProjectDialogAsync()
     {
-        var result = await _filePickerService.PickSingleFileAsync(new List<string> { FileNameConstants.ProjectFileExtension });
+        var result = await _filePickerService.PickSingleFileAsync(new List<string> { ProjectConstants.ProjectFileExtension });
         if (result.IsSuccess)
         {
             var projectFilePath = result.Value;

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Dialogs/NewProjectDialogViewModel.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Dialogs/NewProjectDialogViewModel.cs
@@ -85,11 +85,11 @@ public partial class NewProjectDialogViewModel : ObservableObject
                     return;
                 }
 
-                destProjectFilePath = Path.Combine(subfolderPath, $"{ProjectName}{FileNameConstants.ProjectFileExtension}");
+                destProjectFilePath = Path.Combine(subfolderPath, $"{ProjectName}{ProjectConstants.ProjectFileExtension}");
             }
             else
             {
-                destProjectFilePath = Path.Combine(DestFolderPath, $"{ProjectName}{FileNameConstants.ProjectFileExtension}");
+                destProjectFilePath = Path.Combine(DestFolderPath, $"{ProjectName}{ProjectConstants.ProjectFileExtension}");
             }
 
             if (File.Exists(destProjectFilePath)) 

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/AlertDialog.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/AlertDialog.cs
@@ -24,13 +24,12 @@ public sealed partial class AlertDialog : ContentDialog, IAlertDialog
 
     public AlertDialog()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
-        ViewModel = serviceProvider.GetRequiredService<AlertDialogViewModel>();
+        ViewModel = ServiceLocator.AcquireService<AlertDialogViewModel>();
 
         this.DataContext(ViewModel, (dialog, vm) => dialog
             .Title(x => x.Binding(() => ViewModel.TitleText).Mode(BindingMode.OneWay))

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.cs
@@ -25,13 +25,12 @@ public sealed partial class ConfirmationDialog : ContentDialog, IConfirmationDia
 
     public ConfirmationDialog()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
-        ViewModel = serviceProvider.GetRequiredService<ConfirmationDialogViewModel>();
+        ViewModel = ServiceLocator.AcquireService<ConfirmationDialogViewModel>();
 
         this.DataContext(ViewModel, (dialog, vm) => dialog
             .Title(x => x.Binding(() => ViewModel.TitleText).Mode(BindingMode.OneWay))

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/InputTextDialog.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/InputTextDialog.cs
@@ -29,14 +29,12 @@ public sealed partial class InputTextDialog : ContentDialog, IInputTextDialog
 
     public InputTextDialog()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
-        ViewModel = serviceProvider.GetRequiredService<InputTextDialogViewModel>();
+        ViewModel = ServiceLocator.AcquireService<InputTextDialogViewModel>();
 
         _inputTextbox = new TextBox()
             .Header

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.cs
@@ -24,14 +24,12 @@ public sealed partial class NewProjectDialog : ContentDialog, INewProjectDialog
 
     public NewProjectDialog()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
-        ViewModel = serviceProvider.GetRequiredService<NewProjectDialogViewModel>();
+        ViewModel = ServiceLocator.AcquireService<NewProjectDialogViewModel>();
 
         var newProjectName = 
             new TextBox()

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/ProgressDialog.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Dialogs/ProgressDialog.cs
@@ -16,12 +16,10 @@ public sealed partial class ProgressDialog : ContentDialog, IProgressDialog
 
     public ProgressDialog()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
-        ViewModel = serviceProvider.GetRequiredService<ProgressDialogViewModel>();
+        ViewModel = ServiceLocator.AcquireService<ProgressDialogViewModel>();
 
         this.DataContext(ViewModel, (dialog, vm) => dialog
             .Title(x => x.Binding(() => ViewModel.TitleText).Mode(BindingMode.OneWay))

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/HomePage.xaml.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/HomePage.xaml.cs
@@ -1,3 +1,4 @@
+using Celbridge.Projects;
 using Celbridge.UserInterface.Models;
 using Celbridge.UserInterface.ViewModels.Pages;
 
@@ -36,7 +37,7 @@ public sealed partial class HomePage : Page
             return;
         }
 
-        var projectFilePath = Path.Combine(recentProject.ProjectFolderPath, $"{recentProject.ProjectName}{FileNameConstants.ProjectFileExtension}");
+        var projectFilePath = Path.Combine(recentProject.ProjectFolderPath, $"{recentProject.ProjectName}{ProjectConstants.ProjectFileExtension}");
         ViewModel.OpenProject(projectFilePath);
     }
 }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/HomePage.xaml.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/HomePage.xaml.cs
@@ -20,10 +20,9 @@ public sealed partial class HomePage : Page
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<HomePageViewModel>();
+        ViewModel = ServiceLocator.AcquireService<HomePageViewModel>();
 
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
     }
 
     private void RecentProjectButton_Click(object sender, RoutedEventArgs e)

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/MainPage.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/MainPage.cs
@@ -23,11 +23,10 @@ public sealed partial class MainPage : Page
 
     public MainPage()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-        _userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        _userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
 
-        ViewModel = serviceProvider.GetRequiredService<MainPageViewModel>();
+        ViewModel = ServiceLocator.AcquireService<MainPageViewModel>();
 
         _contentFrame = new Frame()
             .Background(ThemeResource.Get<Brush>("ApplicationBackgroundBrush"))

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/SettingsPage.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/SettingsPage.cs
@@ -12,10 +12,8 @@ public sealed partial class SettingsPage : Page
 
     public SettingsPage()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-
-        ViewModel = serviceProvider.GetRequiredService<SettingsPageViewModel>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        ViewModel = ServiceLocator.AcquireService<SettingsPageViewModel>();
 
         this.DataContext(ViewModel, (page, vm) => page
             .Content(new Grid()

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/TitleBar.xaml.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Views/Pages/TitleBar.xaml.cs
@@ -11,9 +11,8 @@ public sealed partial class TitleBar : UserControl
     {
         InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _messengerService = serviceProvider.GetRequiredService<IMessengerService>();
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _messengerService = ServiceLocator.AcquireService<IMessengerService>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         Loaded += OnTitleBar_Loaded;
         Unloaded += OnTitleBar_Unloaded;

--- a/Celbridge/Modules/Celbridge.Core/Celbridge.Core.csproj
+++ b/Celbridge/Modules/Celbridge.Core/Celbridge.Core.csproj
@@ -7,11 +7,6 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <UnoFeatures>
-      Hosting;
-    </UnoFeatures>
-
   </PropertyGroup>
 
   <ItemGroup>

--- a/Celbridge/Modules/Celbridge.Core/GlobalUsings.cs
+++ b/Celbridge/Modules/Celbridge.Core/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Celbridge.Core;
-global using Microsoft.Extensions.DependencyInjection;
 

--- a/Celbridge/Modules/Celbridge.Markdown/Celbridge.Markdown.csproj
+++ b/Celbridge/Modules/Celbridge.Markdown/Celbridge.Markdown.csproj
@@ -8,11 +8,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-
-    <UnoFeatures>
-      Hosting;
-    </UnoFeatures>
-
   </PropertyGroup>
 
   <!-- Modules manage their own package dependency versions -->

--- a/Celbridge/Modules/Celbridge.Markdown/GlobalUsings.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Celbridge.Core;
-global using Microsoft.Extensions.DependencyInjection;
 

--- a/Celbridge/Modules/Celbridge.Markdown/Module.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Module.cs
@@ -39,7 +39,7 @@ public class Module : IModule
         if (activityName == nameof(MarkdownActivity))
         {
             var serviceProvider = ServiceLocator.ServiceProvider;   
-            var activity = serviceProvider.GetRequiredService<MarkdownActivity>();
+            var activity = serviceProvider.AcquireService<MarkdownActivity>();
             return Result<IActivity>.Ok(activity);
         }
 

--- a/Celbridge/Modules/Celbridge.Markdown/Module.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Module.cs
@@ -38,8 +38,7 @@ public class Module : IModule
     {
         if (activityName == nameof(MarkdownActivity))
         {
-            var serviceProvider = ServiceLocator.ServiceProvider;   
-            var activity = serviceProvider.AcquireService<MarkdownActivity>();
+            var activity = ServiceLocator.AcquireService<MarkdownActivity>();
             return Result<IActivity>.Ok(activity);
         }
 

--- a/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
@@ -32,7 +32,7 @@ public class MarkdownActivity : IActivity
     public async Task<Result> ActivateAsync()
     {
         // Register the Markdown preview provider
-        var markdownProvider = _serviceProvider.GetRequiredService<MarkdownPreviewProvider>();
+        var markdownProvider = _serviceProvider.AcquireService<MarkdownPreviewProvider>();
         var addMarkdownResult = _documentsService.AddPreviewProvider(markdownProvider);
         if (addMarkdownResult.IsFailure)
         {
@@ -41,7 +41,7 @@ public class MarkdownActivity : IActivity
         }
 
         // Register the AsciiDoc preview provider
-        var asciiDocProvider = _serviceProvider.GetRequiredService<AsciiDocPreviewProvider>();
+        var asciiDocProvider = _serviceProvider.AcquireService<AsciiDocPreviewProvider>();
         var addAsciiDocResult = _documentsService.AddPreviewProvider(asciiDocProvider);
         if (addAsciiDocResult.IsFailure)
         {

--- a/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
+++ b/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
@@ -7,11 +7,6 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <UnoFeatures>
-      Hosting;
-    </UnoFeatures>
-
   </PropertyGroup>
 
   <ItemGroup>

--- a/Celbridge/Modules/Celbridge.Screenplay/GlobalUsings.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/GlobalUsings.cs
@@ -1,2 +1,1 @@
 global using Celbridge.Core;
-global using Microsoft.Extensions.DependencyInjection;

--- a/Celbridge/Modules/Celbridge.Screenplay/Module.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Module.cs
@@ -38,8 +38,7 @@ public class Module : IModule
     {
         if (activityName == nameof(ScreenplayActivity))
         {
-            var serviceProvider = ServiceLocator.ServiceProvider;
-            var activity = serviceProvider.AcquireService<ScreenplayActivity>();
+            var activity = ServiceLocator.AcquireService<ScreenplayActivity>();
             return Result<IActivity>.Ok(activity);
         }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Module.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Module.cs
@@ -39,7 +39,7 @@ public class Module : IModule
         if (activityName == nameof(ScreenplayActivity))
         {
             var serviceProvider = ServiceLocator.ServiceProvider;
-            var activity = serviceProvider.GetRequiredService<ScreenplayActivity>();
+            var activity = serviceProvider.AcquireService<ScreenplayActivity>();
             return Result<IActivity>.Ok(activity);
         }
 

--- a/Celbridge/Workspace/Celbridge.Console/Commands/ClearCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/ClearCommand.cs
@@ -37,7 +37,8 @@ public class ClearCommand : CommandBase, IClearCommand
 
     public static void Clear()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IClearCommand>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Console/Commands/ClearHistoryCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/ClearHistoryCommand.cs
@@ -37,7 +37,8 @@ public class ClearHistoryCommand : CommandBase, IClearHistoryCommand
 
     public static void ClearHistory()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IClearHistoryCommand>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Console/Commands/HelpCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/HelpCommand.cs
@@ -43,7 +43,8 @@ public class HelpCommand : CommandBase, IHelpCommand
 
     public static void Help(string searchTerm)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IHelpCommand>(command =>
         {
             command.SearchTerm = searchTerm;

--- a/Celbridge/Workspace/Celbridge.Console/Commands/PrintCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/PrintCommand.cs
@@ -63,7 +63,8 @@ public class PrintCommand : CommandBase, IPrintCommand
     private static void Print(MessageType messageType, object message)
     {
         var messageText = message.ToString() ?? string.Empty;
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IPrintCommand>(command =>
         {
             command.Message = messageText;

--- a/Celbridge/Workspace/Celbridge.Console/Commands/RedoCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/RedoCommand.cs
@@ -6,7 +6,7 @@ public class RedoCommand : CommandBase, IRedoCommand
 {
     public override async Task<Result> ExecuteAsync()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
         commandService.Redo();
 
         await Task.CompletedTask;
@@ -19,7 +19,8 @@ public class RedoCommand : CommandBase, IRedoCommand
 
     public static void Redo()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IRedoCommand>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Console/Commands/RunCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/RunCommand.cs
@@ -49,7 +49,8 @@ public class RunCommand : CommandBase, IRunCommand
 
     public static void Run(ResourceKey scriptResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IRunCommand>(command =>
         {
             command.ScriptResource = scriptResource;

--- a/Celbridge/Workspace/Celbridge.Console/Commands/UndoCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Console/Commands/UndoCommand.cs
@@ -6,7 +6,8 @@ public class UndoCommand : CommandBase, IUndoCommand
 {
     public override async Task<Result> ExecuteAsync()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Undo();
 
         await Task.CompletedTask;
@@ -19,7 +20,8 @@ public class UndoCommand : CommandBase, IUndoCommand
 
     public static void Undo()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IUndoCommand>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Documents/Commands/CloseDocumentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Commands/CloseDocumentCommand.cs
@@ -43,7 +43,8 @@ public class CloseDocumentCommand : CommandBase, ICloseDocumentCommand
 
     public static void CloseDocument(ResourceKey fileResource, bool forceClose)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICloseDocumentCommand>(command =>
         {
             command.FileResource = fileResource;

--- a/Celbridge/Workspace/Celbridge.Documents/Commands/OpenDocumentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Commands/OpenDocumentCommand.cs
@@ -37,7 +37,8 @@ public class OpenDocumentCommand : CommandBase, IOpenDocumentCommand
     //
     public static void OpenDocument(ResourceKey fileResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IOpenDocumentCommand>(command =>
         {
             command.FileResource = fileResource;
@@ -46,7 +47,8 @@ public class OpenDocumentCommand : CommandBase, IOpenDocumentCommand
 
     public static void OpenDocument(ResourceKey fileResource, bool forceReload)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IOpenDocumentCommand>(command =>
         {
             command.FileResource = fileResource;

--- a/Celbridge/Workspace/Celbridge.Documents/Commands/SelectDocumentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Commands/SelectDocumentCommand.cs
@@ -36,7 +36,8 @@ public class SelectDocumentCommand : CommandBase, ISelectDocumentCommand
     //
     public static void SelectDocument(ResourceKey fileResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ISelectDocumentCommand>(command =>
         {
             command.FileResource = fileResource;

--- a/Celbridge/Workspace/Celbridge.Documents/Services/TextEditorWebViewPool.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Services/TextEditorWebViewPool.cs
@@ -74,9 +74,8 @@ public class TextEditorWebViewPool
 
         await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.isWebView = true;");
 
-        // Set Monaco color theme to match the user interface theme
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        var userInterfaceService = serviceProvider.GetRequiredService<IUserInterfaceService>();
+        // Set Monaco color theme to match the user interface theme        
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
         var theme = userInterfaceService.UserInterfaceTheme;
         var vsTheme = theme == UserInterfaceTheme.Light ? "vs-light" : "vs-dark";
         await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync($"window.theme = '{vsTheme}';");

--- a/Celbridge/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -13,7 +13,6 @@ public partial class DocumentTab : TabViewItem
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<DocumentTabViewModel>();
+        ViewModel = ServiceLocator.AcquireService<DocumentTabViewModel>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -15,11 +15,8 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     {
         InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-
-        _logger = serviceProvider.GetRequiredService<IDocumentsLogger>();
-
-        ViewModel = serviceProvider.GetRequiredService<DocumentsPanelViewModel>();
+        _logger = ServiceLocator.AcquireService<IDocumentsLogger>();
+        ViewModel = ServiceLocator.AcquireService<DocumentsPanelViewModel>();
 
         //
         // Set the data context

--- a/Celbridge/Workspace/Celbridge.Documents/Views/EditorPreviewView.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/EditorPreviewView.cs
@@ -15,9 +15,7 @@ public sealed partial class EditorPreviewView : UserControl, IEditorPreview
 
     public EditorPreviewView()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-
-        ViewModel = serviceProvider.GetRequiredService<EditorPreviewViewModel>();
+        ViewModel = ServiceLocator.AcquireService<EditorPreviewViewModel>();
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 

--- a/Celbridge/Workspace/Celbridge.Documents/Views/MonacoEditorView.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/MonacoEditorView.cs
@@ -17,13 +17,12 @@ public sealed partial class MonacoEditorView : DocumentView
 
     public MonacoEditorView()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        var workspaceWrapper = serviceProvider.GetRequiredService<IWorkspaceWrapper>();
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
 
         _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
         _documentsService = workspaceWrapper.WorkspaceService.DocumentsService;
 
-        ViewModel = serviceProvider.GetRequiredService<MonacoEditorViewModel>();
+        ViewModel = ServiceLocator.AcquireService<MonacoEditorViewModel>();
 
         // Set the data context
         // The webview is not created until LoadContent is called, so we can pool webviews

--- a/Celbridge/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/TextEditorDocumentView.xaml.cs
@@ -20,8 +20,7 @@ public sealed partial class TextEditorDocumentView : UserControl, IDocumentView
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<TextEditorDocumentViewModel>();
+        ViewModel = ServiceLocator.AcquireService<TextEditorDocumentViewModel>();
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/AddComponentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/AddComponentCommand.cs
@@ -39,7 +39,7 @@ public class AddComponentCommand : CommandBase, IAddComponentCommand
 
     public static async Task<Result> AddComponent(ResourceKey resource, int insertAtIndex, string componentType)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
 
         var result = await commandService.ExecuteAsync<IAddComponentCommand>(command =>
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/CopyComponentCommand.cs
@@ -40,7 +40,7 @@ public class CopyComponentCommand : CommandBase, ICopyComponentCommand
 
     public static async Task<Result> CopyComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
 
         return await commandService.ExecuteAsync<ICopyComponentCommand>(command =>
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/MoveComponentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/MoveComponentCommand.cs
@@ -40,7 +40,7 @@ public class MoveComponentCommand : CommandBase, IMoveComponentCommand
 
     public static async Task<Result> MoveComponent(ResourceKey resource, int sourceComponentIndex, int destComponentIndex)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
 
         return await commandService.ExecuteAsync<IMoveComponentCommand>(command =>
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/PrintPropertyCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/PrintPropertyCommand.cs
@@ -45,7 +45,7 @@ public class PrintPropertyCommand : CommandBase, IPrintPropertyCommand
 
     public static void PrintProperty(ResourceKey resource, int componentIndex, string propertyPath)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
 
         commandService.Execute<IPrintPropertyCommand>(command =>
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/RedoEntityCommand.cs
@@ -33,7 +33,8 @@ public class RedoEntityCommand : CommandBase, IRedoEntityCommand
 
     public static async Task<Result> RedoEntity(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         return await commandService.ExecuteAsync<IRedoEntityCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/RemoveComponentCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/RemoveComponentCommand.cs
@@ -38,7 +38,7 @@ public class RemoveComponentCommand : CommandBase, IRemoveComponentCommand
 
     public static async Task<Result> RemoveComponent(ResourceKey resource, int componentIndex)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
 
         return await commandService.ExecuteAsync<IRemoveComponentCommand>(command =>
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/SetPropertyCommand.cs
@@ -40,7 +40,8 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     /// </summary>
     public static async Task<Result> SetProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         return await commandService.ExecuteAsync<ISetPropertyCommand>(command =>
         {
             command.ComponentKey = new ComponentKey(resource, componentIndex);
@@ -56,7 +57,8 @@ public class SetPropertyCommand : CommandBase, ISetPropertyCommand
     /// </summary>
     public static async Task<Result> InsertProperty(ResourceKey resource, int componentIndex, string propertyPath, string jsonValue)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         return await commandService.ExecuteAsync<ISetPropertyCommand>(command =>
         {
             command.ComponentKey = new ComponentKey(resource, componentIndex);

--- a/Celbridge/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Commands/UndoEntityCommand.cs
@@ -33,7 +33,8 @@ public class UndoEntityCommand : CommandBase, IUndoEntityCommand
 
     public static async Task<Result> UndoEntity(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         return await commandService.ExecuteAsync<IUndoEntityCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/EntityRegistry.cs
@@ -416,7 +416,7 @@ public class EntityRegistry
     private string GetEntitiesFolderPath()
     {
         var projectDataFolderPath = _projectService.CurrentProject!.ProjectDataFolderPath;
-        var path = Path.Combine(projectDataFolderPath, FileNameConstants.EntitiesFolder);
+        var path = Path.Combine(projectDataFolderPath, ProjectConstants.EntitiesFolder);
         return path;
     }
 }

--- a/Celbridge/Workspace/Celbridge.Entities/Services/EntityService.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/EntityService.cs
@@ -96,7 +96,7 @@ public class EntityService : IEntityService, IDisposable
 
     public string GetEntityDataRelativePath(ResourceKey resource)
     {
-        var relativePath = $"{FileNameConstants.ProjectDataFolder}/{FileNameConstants.EntitiesFolder}/{resource}.json";
+        var relativePath = $"{ProjectConstants.ProjectDataFolder}/{ProjectConstants.EntitiesFolder}/{resource}.json";
         return relativePath;
     }
 

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/AddResourceCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/AddResourceCommand.cs
@@ -235,7 +235,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
 
     public static void AddFile(string sourcePath, ResourceKey destResource)
     {
-        var workspaceWrapper = ServiceLocator.ServiceProvider.GetRequiredService<IWorkspaceWrapper>();
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
         if (!workspaceWrapper.IsWorkspacePageLoaded)
         {
             throw new InvalidOperationException("Failed to add resource because workspace is not loaded");
@@ -246,7 +246,8 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         var resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
         var resolvedDestResource = resourceRegistry.ResolveSourcePathDestinationResource(sourcePath, destResource);
 
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IAddResourceCommand>(command =>
         {
             command.ResourceType = ResourceType.File;
@@ -262,7 +263,7 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
 
     public static void AddFolder(string sourcePath, ResourceKey destResource)
     {
-        var workspaceWrapper = ServiceLocator.ServiceProvider.GetRequiredService<IWorkspaceWrapper>();
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
         if (!workspaceWrapper.IsWorkspacePageLoaded)
         {
             throw new InvalidOperationException("Failed to add resource because workspace is not loaded");
@@ -273,7 +274,8 @@ public class AddResourceCommand : CommandBase, IAddResourceCommand
         var resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
         var resolvedDestResource = resourceRegistry.ResolveSourcePathDestinationResource(sourcePath, destResource);
 
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IAddResourceCommand>(command =>
         {
             command.ResourceType = ResourceType.Folder;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/AddResourceDialogCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/AddResourceDialogCommand.cs
@@ -133,7 +133,8 @@ public class AddResourceDialogCommand : CommandBase, IAddResourceDialogCommand
 
     public static void AddFileDialog(ResourceKey parentFolderResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IAddResourceDialogCommand>(command =>
         {
             command.ResourceType = ResourceType.File;
@@ -143,7 +144,8 @@ public class AddResourceDialogCommand : CommandBase, IAddResourceDialogCommand
 
     public static void AddFolderDialog(ResourceKey parentFolderResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IAddResourceDialogCommand>(command =>
         {
             command.ResourceType = ResourceType.Folder;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/CopyResourceCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/CopyResourceCommand.cs
@@ -365,7 +365,8 @@ public class CopyResourceCommand : CommandBase, ICopyResourceCommand
     private static void CopyResourceInternal(ResourceKey sourceResource, ResourceKey destResource, DataTransferMode operation)
     {
         // Execute the copy resource command
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICopyResourceCommand>(command =>
         {
             command.SourceResource = sourceResource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/DeleteResourceCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/DeleteResourceCommand.cs
@@ -129,7 +129,11 @@ public class DeleteResourceCommand : CommandBase, IDeleteResourceCommand
 
     public static void DeleteResource(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
-        commandService.Execute<IDeleteResourceCommand>(command => command.Resource = resource);
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
+        commandService.Execute<IDeleteResourceCommand>(command =>
+        {
+            command.Resource = resource;
+        });
     }
 }

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/DeleteResourceDialogCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/DeleteResourceDialogCommand.cs
@@ -91,7 +91,8 @@ public class DeleteResourceDialogCommand : CommandBase, IDeleteResourceDialogCom
 
     public static void DeleteResourceDialog(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IDeleteResourceDialogCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/DuplicateResourceDialogCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/DuplicateResourceDialogCommand.cs
@@ -126,7 +126,8 @@ public class DuplicateResourceDialogCommand : CommandBase, IDuplicateResourceDia
 
     public static void DuplicateResourceDialog(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IDuplicateResourceDialogCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/ExpandFolderCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/ExpandFolderCommand.cs
@@ -54,7 +54,8 @@ public class ExpandFolderCommand : CommandBase, IExpandFolderCommand
     //
     public static void ExpandFolder(ResourceKey folderResource, bool IsExpanded)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IExpandFolderCommand>(command =>
         {
             command.FolderResource = folderResource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenApplicationCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenApplicationCommand.cs
@@ -34,7 +34,8 @@ public class OpenApplicationCommand : CommandBase, IOpenApplicationCommand
 
     public static void OpenApplication(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IOpenApplicationCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenBrowserCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenBrowserCommand.cs
@@ -34,7 +34,8 @@ public class OpenBrowserCommand : CommandBase, IOpenBrowserCommand
 
     public static void OpenBrowser(string url)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IOpenBrowserCommand>(command =>
         {
             command.URL = url;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenFileManagerCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/OpenFileManagerCommand.cs
@@ -34,7 +34,8 @@ public class OpenFileManagerCommand : CommandBase, IOpenFileManagerCommand
 
     public static void OpenFileManager(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IOpenFileManagerCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/RenameResourceDialogCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/RenameResourceDialogCommand.cs
@@ -122,7 +122,8 @@ public class RenameResourceDialogCommand : CommandBase, IRenameResourceDialogCom
 
     public static void RenameResourceDialog(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IRenameResourceDialogCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
@@ -36,7 +36,8 @@ public class SelectResourceCommand : CommandBase, ISelectResourceCommand
     //
     public static void SelectResource(ResourceKey resource, bool showExplorerPanel)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ISelectResourceCommand>(command =>
         {
             command.Resource = resource;

--- a/Celbridge/Workspace/Celbridge.Explorer/Commands/UpdateResourcesCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Commands/UpdateResourcesCommand.cs
@@ -31,7 +31,8 @@ public class UpdateResourcesCommand : CommandBase, IUpdateResourcesCommand
     //
     public static void UpdateResourceRegistry()
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IUpdateResourcesCommand>();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Explorer/Services/ResourceRegistry.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Services/ResourceRegistry.cs
@@ -1,4 +1,5 @@
 using Celbridge.Explorer.Models;
+using Celbridge.Projects;
 using Celbridge.UserInterface;
 using System.Text;
 
@@ -392,7 +393,7 @@ public class ResourceRegistry : IResourceRegistry
 #endif
 
             if (isRootFolder &&
-                path.EndsWith(FileNameConstants.ProjectDataFolder))
+                path.EndsWith(ProjectConstants.ProjectDataFolder))
             {
                 // Ignore the "CelData" project data folder
                 return true;

--- a/Celbridge/Workspace/Celbridge.Explorer/Views/ExplorerPanel.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Views/ExplorerPanel.cs
@@ -14,10 +14,8 @@ public sealed partial class ExplorerPanel : UserControl, IExplorerPanel
 
     public ExplorerPanel()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-        ViewModel = serviceProvider.GetRequiredService<ExplorerPanelViewModel>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        ViewModel = ServiceLocator.AcquireService<ExplorerPanelViewModel>();
 
         var refreshProjectButton = new Button()
             .Grid(column: 2)

--- a/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
@@ -32,9 +32,8 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<ResourceTreeViewModel>();
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        ViewModel = ServiceLocator.AcquireService<ResourceTreeViewModel>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         Loaded += ResourceTreeView_Loaded;
         Unloaded += ResourceTreeView_Unloaded;

--- a/Celbridge/Workspace/Celbridge.GenerativeAI/Commands/MakeTextCommand.cs
+++ b/Celbridge/Workspace/Celbridge.GenerativeAI/Commands/MakeTextCommand.cs
@@ -65,7 +65,8 @@ public class MakeTextCommand : CommandBase, IMakeTextCommand
 
     public static void MakeText(ResourceKey destFileResource, string prompt)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IMakeTextCommand>(command =>
         {
             command.DestFileResource = destFileResource;

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml.cs
@@ -34,9 +34,8 @@ public partial class ComponentListView : UserControl, IInspector
         ViewModel = viewModel;
         DataContext = ViewModel;
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _logger = serviceProvider.GetRequiredService<ILogger<ComponentListView>>();
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _logger = ServiceLocator.AcquireService<ILogger<ComponentListView>>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         Loaded += (s, e) => ViewModel.OnViewLoaded();
         Unloaded += (s, e) => ViewModel.OnViewUnloaded();

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentTypeEditor.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentTypeEditor.xaml.cs
@@ -10,8 +10,7 @@ public sealed partial class ComponentTypeEditor : UserControl
 	{
 		this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<ComponentTypeEditorViewModel>();
+        ViewModel = ServiceLocator.AcquireService<ComponentTypeEditorViewModel>();
 
         DataContext = ViewModel;
     }

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentValueEditor.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentValueEditor.xaml.cs
@@ -10,8 +10,7 @@ public sealed partial class ComponentValueEditor : UserControl
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<ComponentValueEditorViewModel>();
+        ViewModel = ServiceLocator.AcquireService<ComponentValueEditorViewModel>();
 
         DataContext = ViewModel;
 

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml.cs
@@ -10,9 +10,7 @@ public sealed partial class EntityEditor : UserControl
     {
         this.InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-
-        ViewModel = serviceProvider.GetRequiredService<EntityEditorViewModel>();
+        ViewModel = ServiceLocator.AcquireService<EntityEditorViewModel>();
         DataContext = ViewModel;
 
         Loaded += EntityEditor_Loaded;

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/InspectorPanel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/InspectorPanel.cs
@@ -19,14 +19,13 @@ public sealed partial class InspectorPanel : UserControl, IInspectorPanel
 
     public InspectorPanel()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _logger = serviceProvider.GetRequiredService<ILogger<InspectorPanel>>();
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _logger = ServiceLocator.AcquireService<ILogger<InspectorPanel>>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        var workspaceWrapper = serviceProvider.GetRequiredService<IWorkspaceWrapper>();
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
         _inspectorService = workspaceWrapper.WorkspaceService.InspectorService;
 
-        ViewModel = serviceProvider.GetRequiredService<InspectorPanelViewModel>();
+        ViewModel = ServiceLocator.AcquireService<InspectorPanelViewModel>();
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
         var titleBar = new Grid()

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/MarkdownInspector.cs
@@ -31,8 +31,7 @@ public partial class MarkdownInspector : UserControl, IInspector
 
     public MarkdownInspector(MarkdownInspectorViewModel viewModel)
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         DataContext = viewModel;
 

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/WebInspector.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/WebInspector.cs
@@ -29,8 +29,7 @@ public partial class WebInspector : UserControl, IInspector
 
     public WebInspector(WebInspectorViewModel viewModel)
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         DataContext = viewModel;
 

--- a/Celbridge/Workspace/Celbridge.Status/Views/StatusPanel.cs
+++ b/Celbridge/Workspace/Celbridge.Status/Views/StatusPanel.cs
@@ -13,10 +13,8 @@ public partial class StatusPanel : UserControl, IStatusPanel
 
     public StatusPanel()
     {
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
-
-        ViewModel = serviceProvider.GetRequiredService<StatusPanelViewModel>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        ViewModel = ServiceLocator.AcquireService<StatusPanelViewModel>();
 
         Loaded += (s, e) => ViewModel.OnLoaded();
         Unloaded += (s, e) => ViewModel.OnUnloaded();

--- a/Celbridge/Workspace/Celbridge.Workspace/Commands/AlertCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Commands/AlertCommand.cs
@@ -11,7 +11,7 @@ public class AlertCommand : CommandBase, IAlertCommand
 
     public override async Task<Result> ExecuteAsync()
     {
-        var dialogService = ServiceLocator.ServiceProvider.GetRequiredService<IDialogService>();
+        var dialogService = ServiceLocator.AcquireService<IDialogService>();
         await dialogService.ShowAlertDialogAsync(Title, Message);
 
         return Result.Ok();
@@ -23,7 +23,8 @@ public class AlertCommand : CommandBase, IAlertCommand
 
     public static void Alert(string title, string message)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IAlertCommand>(command =>
         {
             command.Title = title;
@@ -33,7 +34,7 @@ public class AlertCommand : CommandBase, IAlertCommand
 
     public static void Alert(string message)
     {
-        var stringLocalizer = ServiceLocator.ServiceProvider.GetRequiredService<IStringLocalizer>();
+        var stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         var titleString = stringLocalizer.GetString("WorkspacePage_AlertTitleDefault");
 
         Alert(titleString, message);

--- a/Celbridge/Workspace/Celbridge.Workspace/Commands/CopyResourceToClipboardCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Commands/CopyResourceToClipboardCommand.cs
@@ -81,7 +81,8 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
 
     public static void CopyResourceToClipboard(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICopyResourceToClipboardCommand>(command =>
         {
             command.SourceResource = resource;
@@ -91,7 +92,8 @@ public class CopyResourceToClipboardCommand : CommandBase, ICopyResourceToClipbo
 
     public static void CutResourceToClipboard(ResourceKey resource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICopyResourceToClipboardCommand>(command =>
         {
             command.SourceResource = resource;

--- a/Celbridge/Workspace/Celbridge.Workspace/Commands/CopyTextToClipboardCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Commands/CopyTextToClipboardCommand.cs
@@ -41,7 +41,8 @@ public class CopyTextToClipboardCommand : CommandBase, ICopyTextToClipboardComma
 
     public static void CopyTextToClipboard(string text)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<ICopyTextToClipboardCommand>(command =>
         {
             command.Text = text;

--- a/Celbridge/Workspace/Celbridge.Workspace/Commands/PasteResourceFromClipboardCommand.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Commands/PasteResourceFromClipboardCommand.cs
@@ -36,7 +36,8 @@ public class PasteResourceFromClipboardCommand : CommandBase, IPasteResourceFrom
 
     public static void PasteResourceFromClipboard(ResourceKey folderResource)
     {
-        var commandService = ServiceLocator.ServiceProvider.GetRequiredService<ICommandService>();
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
         commandService.Execute<IPasteResourceFromClipboardCommand>(command =>
         {
             command.DestFolderResource = folderResource;

--- a/Celbridge/Workspace/Celbridge.Workspace/ServiceConfiguration.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/ServiceConfiguration.cs
@@ -54,7 +54,7 @@ public static class ServiceConfiguration
 
     public static void Initialize()
     {
-        var navigationService = ServiceLocator.ServiceProvider.GetRequiredService<INavigationService>();
+        var navigationService = ServiceLocator.AcquireService<INavigationService>();
         navigationService.RegisterPage(nameof(WorkspacePage), typeof(WorkspacePage));
     }
 }

--- a/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceService.cs
@@ -69,7 +69,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
 
         var project = projectService.CurrentProject;
         Guard.IsNotNull(project);
-        var workspaceSettingsFolder = Path.Combine(project.ProjectFolderPath, FileNameConstants.WorkspaceSettingsFolder);
+        var workspaceSettingsFolder = Path.Combine(project.ProjectFolderPath, ProjectConstants.WorkspaceSettingsFolder);
         Guard.IsNotNullOrEmpty(workspaceSettingsFolder);
         WorkspaceSettingsService.WorkspaceSettingsFolderPath = workspaceSettingsFolder;
     }

--- a/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceSettingsService.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceSettingsService.cs
@@ -1,3 +1,5 @@
+using Celbridge.Projects;
+
 namespace Celbridge.Workspace.Services;
 
 public class WorkspaceSettingsService : IWorkspaceSettingsService, IDisposable
@@ -12,7 +14,7 @@ public class WorkspaceSettingsService : IWorkspaceSettingsService, IDisposable
         {
             return Result.Fail("The workspace settings folder has not been set.");
         }
-        var databaseFilePath = Path.Combine(WorkspaceSettingsFolderPath, FileNameConstants.WorkspaceSettingsFile);
+        var databaseFilePath = Path.Combine(WorkspaceSettingsFolderPath, ProjectConstants.WorkspaceSettingsFile);
 
         //
         // Create the workspace settings database if it doesn't exist yet

--- a/Celbridge/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
@@ -18,11 +18,10 @@ public sealed partial class WorkspacePage : Page
     {
         InitializeComponent();
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        ViewModel = serviceProvider.GetRequiredService<WorkspacePageViewModel>();
+        ViewModel = ServiceLocator.AcquireService<WorkspacePageViewModel>();
 
-        _messengerService = serviceProvider.GetRequiredService<IMessengerService>();
-        _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
+        _messengerService = ServiceLocator.AcquireService<IMessengerService>();
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
         ApplyPanelButtonTooltips();
 
@@ -96,8 +95,7 @@ public sealed partial class WorkspacePage : Page
         // Populate the workspace panels.
         //
 
-        var serviceProvider = ServiceLocator.ServiceProvider;
-        var workspaceWrapper = serviceProvider.GetRequiredService<IWorkspaceWrapper>();
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
         var workspaceService = workspaceWrapper.WorkspaceService as WorkspaceService;
         Guard.IsNotNull(workspaceService);
 


### PR DESCRIPTION
Simplifies the ServiceLocator class and usage. This allows the Modules to remove all Uno feature dependencies.
Moved FileNameConstants to the Celbridge.Projects namespace.