### PR TITLE
Refactored ComponentEditorBase to simplify component editor implementation

### DIFF
--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -22,7 +22,7 @@ public abstract class ComponentEditorBase : IComponentEditor
         return Result.Ok();
     }
 
-    public abstract Result<ComponentSummary> GetComponentSummary();
+    public abstract ComponentSummary GetComponentSummary();
 
     public virtual void OnFormUnloaded()
     {
@@ -31,6 +31,8 @@ public abstract class ComponentEditorBase : IComponentEditor
             _component.ComponentPropertyChanged -= OnComponentPropertyChanged;
         }
     }
+
+    public string GetString(string propertyPath) => Component.GetString(propertyPath);
 
     public virtual Result<string> GetProperty(string propertyPath)
     {

--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -7,7 +7,6 @@ namespace Celbridge.Entities;
 /// </summary>
 public abstract class ComponentEditorBase : IComponentEditor
 {
-    public abstract string ComponentConfigPath { get; }
     private IComponentEditorHelper? _helper;
 
     public event Action<string>? FormPropertyChanged;
@@ -29,6 +28,8 @@ public abstract class ComponentEditorBase : IComponentEditor
         FormPropertyChanged?.Invoke(propertyPath);
     }
 
+    public abstract string GetComponentConfig();
+
     public abstract ComponentSummary GetComponentSummary();
 
     public virtual void OnFormUnloaded()
@@ -37,6 +38,23 @@ public abstract class ComponentEditorBase : IComponentEditor
 
         _helper.ComponentPropertyChanged -= OnComponentPropertyChanged;
         _helper.Uninitialize();
+    }
+
+    public string LoadEmbeddedResource(string resourcePath)
+    {
+        var helper = _helper;
+
+        if (helper is null)
+        {
+            // This happens when the config registry is populated during startup.
+            // We can't initalize the helper because there's no component, but that's fine
+            // because we only need to access LoadEmbeddedResource()
+            helper = ServiceLocator.AcquireService<IComponentEditorHelper>();
+        }
+
+        // Get the type of the component editor class.
+        // The embedded resource must be in the same assembly as this type.
+        return helper.LoadEmbeddedResource(GetType(), resourcePath);
     }
 
     public string GetString(string propertyPath) => Component.GetString(propertyPath);

--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -8,64 +8,46 @@ namespace Celbridge.Entities;
 public abstract class ComponentEditorBase : IComponentEditor
 {
     public abstract string ComponentConfigPath { get; }
+    private IComponentEditorHelper? _helper;
 
     public event Action<string>? FormPropertyChanged;
 
-    protected IComponentProxy? _component;
-    public IComponentProxy Component => _component!;
+    public IComponentProxy Component => _helper!.Component;
 
     public virtual Result Initialize(IComponentProxy component)
     {
-        _component = component;
-        _component.ComponentPropertyChanged += OnComponentPropertyChanged;
+        _helper = ServiceLocator.AcquireService<IComponentEditorHelper>();
+        _helper.Initialize(component);
+        _helper.ComponentPropertyChanged += OnComponentPropertyChanged;
 
         return Result.Ok();
+    }
+
+    private void OnComponentPropertyChanged(string propertyPath)
+    {
+        // Forward component property changes to the form
+        FormPropertyChanged?.Invoke(propertyPath);
     }
 
     public abstract ComponentSummary GetComponentSummary();
 
     public virtual void OnFormUnloaded()
     {
-        if (_component is not null)
-        {
-            _component.ComponentPropertyChanged -= OnComponentPropertyChanged;
-        }
+        Guard.IsNotNull(_helper);
+
+        _helper.ComponentPropertyChanged -= OnComponentPropertyChanged;
+        _helper.Uninitialize();
     }
 
     public string GetString(string propertyPath) => Component.GetString(propertyPath);
 
     public virtual Result<string> GetProperty(string propertyPath)
     {
-        if (_component is null)
-        {
-            return Result<string>.Fail("Component is null");
-        }
-
-        var value = Component.GetString(propertyPath);
-
-        return Result<string>.Ok(value);
+        return Component.GetProperty<string>(propertyPath);
     }
 
     public virtual Result SetProperty(string propertyPath, string newValue, bool insert)
     {
-        if (_component is null)
-        {
-            return Result<string>.Fail("Component is null");
-        }
-
-        var setResult = Component.SetProperty(propertyPath, newValue);
-        if (setResult.IsFailure)
-        {
-            return Result.Fail($"SetProperty failed: {propertyPath}")
-                .WithErrors(setResult);
-        }
-
-        return Result.Ok();
-    }
-
-    protected virtual void OnComponentPropertyChanged(string propertyPath)
-    {
-        // Forward the property changed event so the editor view can update itself
-        FormPropertyChanged?.Invoke(propertyPath);
+        return Component.SetProperty<string>(propertyPath, newValue, insert);
     }
 }

--- a/Celbridge/BaseLibrary/Entities/IComponentEditor.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentEditor.cs
@@ -9,11 +9,6 @@ namespace Celbridge.Entities;
 public interface IComponentEditor : IFormDataProvider
 {
     /// <summary>
-    /// Path to the JSON confuration file for this component.
-    /// </summary>
-    string ComponentConfigPath { get; }
-
-    /// <summary>
     /// Returns the component that the editor instance edits.
     /// </summary>
     IComponentProxy Component { get; }
@@ -22,6 +17,11 @@ public interface IComponentEditor : IFormDataProvider
     /// Initializes the component editor with the component to be edited.
     /// </summary>
     Result Initialize(IComponentProxy component);
+
+    /// <summary>
+    /// Gets the configuration data for the component.
+    /// </summary>
+    string GetComponentConfig();
 
     /// <summary>
     /// Gets summary information for the edited component.

--- a/Celbridge/BaseLibrary/Entities/IComponentEditor.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentEditor.cs
@@ -26,5 +26,5 @@ public interface IComponentEditor : IFormDataProvider
     /// <summary>
     /// Gets summary information for the edited component.
     /// </summary>
-    Result<ComponentSummary> GetComponentSummary();
+    ComponentSummary GetComponentSummary();
 }

--- a/Celbridge/BaseLibrary/Entities/IComponentEditorHelper.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentEditorHelper.cs
@@ -12,13 +12,17 @@ public interface IComponentEditorHelper
     /// Initializes the helper with the component to be edited.
     /// </summary>
     /// <param name="component"></param>
-    /// <returns></returns>
     Result Initialize(IComponentProxy component);
 
     /// <summary>
     /// Called when the component editor is shutting down.
     /// </summary>
     void Uninitialize();
+
+    /// <summary>
+    /// Loads an embedded resource at resourcePath from the assembly containing the specified type.
+    /// </summary>
+    string LoadEmbeddedResource(Type type, string resourcePath);
 
     /// <summary>
     /// The component being edited.

--- a/Celbridge/BaseLibrary/Entities/IComponentEditorHelper.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentEditorHelper.cs
@@ -1,0 +1,32 @@
+namespace Celbridge.Entities;
+
+/// <summary>
+/// Provides supporting functionality for ComponentEditorBase.
+/// Internally, ComponentEditorHelper uses other services via the DI system to implement all the
+/// required functionality. This simplifies the design of ComponentEditorBase as it only depends on
+/// this one interface.
+/// </summary>
+public interface IComponentEditorHelper
+{
+    /// <summary>
+    /// Initializes the helper with the component to be edited.
+    /// </summary>
+    /// <param name="component"></param>
+    /// <returns></returns>
+    Result Initialize(IComponentProxy component);
+
+    /// <summary>
+    /// Called when the component editor is shutting down.
+    /// </summary>
+    void Uninitialize();
+
+    /// <summary>
+    /// The component being edited.
+    /// </summary>
+    IComponentProxy Component { get; }
+
+    /// <summary>
+    /// An event that is fired when a component property changes
+    /// </summary>
+    event Action<string>? ComponentPropertyChanged;
+}

--- a/Celbridge/BaseLibrary/Utilities/IUtilityService.cs
+++ b/Celbridge/BaseLibrary/Utilities/IUtilityService.cs
@@ -24,7 +24,7 @@ public interface IUtilityService
     /// <summary>
     /// Returns the current UTC time in "yyyyMMdd_HHmmss" format.
     /// </summary>
-    public string GetTimestamp();
+    string GetTimestamp();
 
     /// <summary>
     /// Deletes old files in the specified folder that start with the specified prefix.
@@ -34,5 +34,10 @@ public interface IUtilityService
     /// <summary>
     /// Converts a hex color string to an ARGB tuple.
     /// </summary>
-    public (byte a, byte r, byte g, byte b) ColorFromHex(string hex);
+    (byte a, byte r, byte g, byte b) ColorFromHex(string hex);
+
+    /// <summary>
+    /// Load the content of an embedded resource from the assembly containing the specified type.
+    /// </summary>
+    Result<string> LoadEmbeddedResource(Type type, string resourcePath);
 }

--- a/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
+++ b/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
@@ -1,5 +1,4 @@
 using Celbridge.Utilities;
-using System.Reflection;
 
 using Path = System.IO.Path;
 

--- a/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
+++ b/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Celbridge.Utilities;
 
 using Path = System.IO.Path;

--- a/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
+++ b/Celbridge/CoreServices/Celbridge.Utilities/Services/UtilityService.cs
@@ -143,4 +143,30 @@ public class UtilityService : IUtilityService
 
         return (a, r, g, b);
     }
+
+    public Result<string> LoadEmbeddedResource(Type type, string resourcePath)
+    {
+        // Load the component config JSON from an embedded resource
+        var assembly = type.Assembly;
+        var stream = assembly.GetManifestResourceStream(resourcePath);
+        if (stream is null)
+        {
+            return Result<string>.Fail($"Embedded resource '{resourcePath}' not found in assembly '{assembly}'");
+        }
+
+        try
+        {
+            using (stream)
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                var data = reader.ReadToEnd();
+                return Result<string>.Ok(data);
+            }
+        }
+        catch (Exception ex)
+        {
+            return Result<string>.Fail($"An exception occurred when reading content of embedded resource: {resourcePath}")
+                .WithException(ex);
+        }
+    }
 }

--- a/Celbridge/Modules/Celbridge.Core/ComponentEditors/EmptyEditor.cs
+++ b/Celbridge/Modules/Celbridge.Core/ComponentEditors/EmptyEditor.cs
@@ -5,18 +5,13 @@ namespace Celbridge.Core.Components;
 public class EmptyEditor : ComponentEditorBase
 {
     public override string ComponentConfigPath => "Celbridge.Core.Assets.Components.Empty.json";
+    public const string Comment = "/comment";
 
-    public override Result<ComponentSummary> GetComponentSummary()
+    public override ComponentSummary GetComponentSummary()
     {
-        var getComment = GetProperty("/comment");
-        if (getComment.IsFailure)
-        {
-            return Result<ComponentSummary>.Fail(getComment.Error);
-        }
-        var comment = getComment.Value;
-
+        var comment = GetString("/comment");
         var summary = new ComponentSummary(comment, comment);
 
-        return Result<ComponentSummary>.Ok(summary);
+        return summary;
     }
 }

--- a/Celbridge/Modules/Celbridge.Core/ComponentEditors/EmptyEditor.cs
+++ b/Celbridge/Modules/Celbridge.Core/ComponentEditors/EmptyEditor.cs
@@ -4,14 +4,18 @@ namespace Celbridge.Core.Components;
 
 public class EmptyEditor : ComponentEditorBase
 {
-    public override string ComponentConfigPath => "Celbridge.Core.Assets.Components.Empty.json";
+    private const string _configPath = "Celbridge.Core.Assets.Components.Empty.json";
+
     public const string Comment = "/comment";
+
+    public override string GetComponentConfig()
+    {
+        return LoadEmbeddedResource(_configPath);
+    }
 
     public override ComponentSummary GetComponentSummary()
     {
         var comment = GetString("/comment");
-        var summary = new ComponentSummary(comment, comment);
-
-        return summary;
+        return new ComponentSummary(comment, comment);
     }
 }

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -8,10 +8,9 @@ public class MarkdownEditor : ComponentEditorBase
 
     public override string ComponentConfigPath => "Celbridge.Markdown.Assets.Components.Markdown.json";
 
-    public override Result<ComponentSummary> GetComponentSummary()
+    public override ComponentSummary GetComponentSummary()
     {
         var summary = new ComponentSummary(string.Empty, string.Empty);
-
-        return Result<ComponentSummary>.Ok(summary);
+        return summary;
     }
 }

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -4,13 +4,17 @@ namespace Celbridge.Markdown.Components;
 
 public class MarkdownEditor : ComponentEditorBase
 {
+    private const string _configPath = "Celbridge.Markdown.Assets.Components.Markdown.json";
+
     public const string ComponentType = "Markdown.Markdown";
 
-    public override string ComponentConfigPath => "Celbridge.Markdown.Assets.Components.Markdown.json";
+    public override string GetComponentConfig()
+    {
+        return LoadEmbeddedResource(_configPath);
+    }
 
     public override ComponentSummary GetComponentSummary()
     {
-        var summary = new ComponentSummary(string.Empty, string.Empty);
-        return summary;
+        return new ComponentSummary(string.Empty, string.Empty);
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -4,11 +4,16 @@ namespace Celbridge.Screenplay.Components;
 
 public class LineEditor : ComponentEditorBase
 {
+    private const string _configPath = "Celbridge.Screenplay.Assets.Components.Line.json";
+
     public const string ComponentType = "Screenplay.Line";
     public const string Character = "/character";
     public const string SourceText = "/sourceText";
 
-    public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.Line.json";
+    public override string GetComponentConfig()
+    {
+        return LoadEmbeddedResource(_configPath);
+    }
 
     public override ComponentSummary GetComponentSummary()
     {
@@ -16,9 +21,7 @@ public class LineEditor : ComponentEditorBase
         var sourceText = GetString(SourceText);
 
         var summaryText = $"{character}: {sourceText}";
-        var summary = new ComponentSummary(summaryText, summaryText);
-
-        return summary;
+        return new ComponentSummary(summaryText, summaryText);
     }
 }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -10,26 +10,15 @@ public class LineEditor : ComponentEditorBase
 
     public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.Line.json";
 
-    public override Result<ComponentSummary> GetComponentSummary()
+    public override ComponentSummary GetComponentSummary()
     {
-        var getCharacter = GetProperty("/character");
-        if (getCharacter.IsFailure)
-        {
-            return Result<ComponentSummary>.Fail(getCharacter.Error);
-        }
-        var character = getCharacter.Value;
-
-        var getSourceText = GetProperty("/sourceText");
-        if (getSourceText.IsFailure)
-        {
-            return Result<ComponentSummary>.Fail(getSourceText.Error);
-        }
-        var sourceText = getSourceText.Value;
+        var character = GetString(Character);
+        var sourceText = GetString(SourceText);
 
         var summaryText = $"{character}: {sourceText}";
         var summary = new ComponentSummary(summaryText, summaryText);
 
-        return Result<ComponentSummary>.Ok(summary);
+        return summary;
     }
 }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
@@ -10,25 +10,15 @@ public class SceneEditor : ComponentEditorBase
 
     public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.Scene.json";
 
-    public override Result<ComponentSummary> GetComponentSummary()
+    public override ComponentSummary GetComponentSummary()
     {
-        var getTitle = GetProperty("/sceneTitle");
-        if (getTitle.IsFailure)
-        {
-            return Result<ComponentSummary>.Fail(getTitle.Error);
-        }
-        var sceneTitle = getTitle.Value;
+        var sceneTitle = GetString(SceneTitle);
 
-        var getDescriptionText = GetProperty("/sceneDescription");
-        if (getDescriptionText.IsFailure)
-        {
-            return Result<ComponentSummary>.Fail(getDescriptionText.Error);
-        }
-        var sceneDescription = getDescriptionText.Value;
+        var sceneDescription = GetProperty(SceneDescription);
 
         var summaryText = $"{sceneTitle}: {sceneDescription}";
         var summary = new ComponentSummary(summaryText, summaryText);
 
-        return Result<ComponentSummary>.Ok(summary);
+        return summary;
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
@@ -4,11 +4,16 @@ namespace Celbridge.Screenplay.Components;
 
 public class SceneEditor : ComponentEditorBase
 {
+    private const string _configPath = "Celbridge.Screenplay.Assets.Components.Scene.json";
+
     public const string ComponentType = "Screenplay.Scene";
     public const string SceneTitle = "/sceneTitle";
     public const string SceneDescription = "/sceneDescription";
 
-    public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.Scene.json";
+    public override string GetComponentConfig()
+    {
+        return LoadEmbeddedResource(_configPath);
+    }
 
     public override ComponentSummary GetComponentSummary()
     {
@@ -16,8 +21,6 @@ public class SceneEditor : ComponentEditorBase
         var sceneDescription = GetString(SceneDescription);
 
         var summaryText = $"{sceneTitle}: {sceneDescription}";
-        var summary = new ComponentSummary(summaryText, summaryText);
-
-        return summary;
+        return new ComponentSummary(summaryText, summaryText);
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
@@ -13,8 +13,7 @@ public class SceneEditor : ComponentEditorBase
     public override ComponentSummary GetComponentSummary()
     {
         var sceneTitle = GetString(SceneTitle);
-
-        var sceneDescription = GetProperty(SceneDescription);
+        var sceneDescription = GetString(SceneDescription);
 
         var summaryText = $"{sceneTitle}: {sceneDescription}";
         var summary = new ComponentSummary(summaryText, summaryText);

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayActivityEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayActivityEditor.cs
@@ -6,10 +6,9 @@ public class ScreenplayActivityEditor : ComponentEditorBase
 {
     public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.ScreenplayActivity.json";
 
-    public override Result<ComponentSummary> GetComponentSummary()
+    public override ComponentSummary GetComponentSummary()
     {
         var summary = new ComponentSummary(string.Empty, string.Empty);
-
-        return Result<ComponentSummary>.Ok(summary);
+        return summary;
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayActivityEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayActivityEditor.cs
@@ -4,11 +4,15 @@ namespace Celbridge.Screenplay.Components;
 
 public class ScreenplayActivityEditor : ComponentEditorBase
 {
-    public override string ComponentConfigPath => "Celbridge.Screenplay.Assets.Components.ScreenplayActivity.json";
+    private const string _configPath = "Celbridge.Screenplay.Assets.Components.ScreenplayActivity.json";
+
+    public override string GetComponentConfig()
+    {
+        return LoadEmbeddedResource(_configPath);
+    }
 
     public override ComponentSummary GetComponentSummary()
     {
-        var summary = new ComponentSummary(string.Empty, string.Empty);
-        return summary;
+        return new ComponentSummary(string.Empty, string.Empty);
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -203,7 +203,7 @@ public class ScreenplayActivity : IActivity
         foreach (var lineComponent in lineComponents)
         {
             var character = lineComponent.GetString(LineEditor.Character);
-            var sourceText = lineComponent.GetString(LineEditor.SourceText);
+            var sourceText = lineComponent.GetString(LineEditor.SourceTextProperty);
 
             if (string.IsNullOrWhiteSpace(character) || string.IsNullOrWhiteSpace(sourceText))
             {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -203,7 +203,7 @@ public class ScreenplayActivity : IActivity
         foreach (var lineComponent in lineComponents)
         {
             var character = lineComponent.GetString(LineEditor.Character);
-            var sourceText = lineComponent.GetString(LineEditor.SourceTextProperty);
+            var sourceText = lineComponent.GetString(LineEditor.SourceText);
 
             if (string.IsNullOrWhiteSpace(character) || string.IsNullOrWhiteSpace(sourceText))
             {

--- a/Celbridge/Workspace/Celbridge.Entities/ServiceConfiguration.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/ServiceConfiguration.cs
@@ -17,6 +17,7 @@ public static class ServiceConfiguration
         services.AddTransient<ComponentProxyService>();
         services.AddTransient<EntityRegistry>();
         services.AddTransient<IEntityAnnotation, EntityAnnotation>();
+        services.AddTransient<IComponentEditorHelper, ComponentEditorHelper>();
 
         //
         // Register commands

--- a/Celbridge/Workspace/Celbridge.Entities/Services/ComponentEditorHelper.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/ComponentEditorHelper.cs
@@ -1,8 +1,25 @@
+using Celbridge.Logging;
+using Celbridge.Utilities;
+
 namespace Celbridge.Entities.Services;
 
 public class ComponentEditorHelper : IComponentEditorHelper
 {
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ComponentEditorHelper> _logger;
+    private readonly IUtilityService _utilityService;
+
     public event Action<string>? ComponentPropertyChanged;
+
+    public ComponentEditorHelper(
+        IServiceProvider serviceProvider,
+        ILogger<ComponentEditorHelper> logger,
+        IUtilityService utilityService)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _utilityService = utilityService;
+    }
 
     protected IComponentProxy? _component;
     public IComponentProxy Component => _component!;
@@ -21,6 +38,19 @@ public class ComponentEditorHelper : IComponentEditorHelper
         {
             _component.ComponentPropertyChanged -= OnComponentPropertyChanged;
         }
+    }
+
+    public string LoadEmbeddedResource(Type componentEditorType, string resourcePath)
+    {
+        var loadResult = _utilityService.LoadEmbeddedResource(componentEditorType, resourcePath);
+        if (loadResult.IsFailure)
+        {
+            _logger.LogError(loadResult.Error);
+            return string.Empty;
+        }
+        var content = loadResult.Value;
+
+        return content;
     }
 
     protected virtual void OnComponentPropertyChanged(string propertyPath)

--- a/Celbridge/Workspace/Celbridge.Entities/Services/ComponentEditorHelper.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/ComponentEditorHelper.cs
@@ -1,0 +1,31 @@
+namespace Celbridge.Entities.Services;
+
+public class ComponentEditorHelper : IComponentEditorHelper
+{
+    public event Action<string>? ComponentPropertyChanged;
+
+    protected IComponentProxy? _component;
+    public IComponentProxy Component => _component!;
+
+    public virtual Result Initialize(IComponentProxy component)
+    {
+        _component = component;
+        _component.ComponentPropertyChanged += OnComponentPropertyChanged;
+
+        return Result.Ok();
+    }
+
+    public virtual void Uninitialize()
+    {
+        if (_component is not null)
+        {
+            _component.ComponentPropertyChanged -= OnComponentPropertyChanged;
+        }
+    }
+
+    protected virtual void OnComponentPropertyChanged(string propertyPath)
+    {
+        // Forward the property changed event so the editor view can update itself
+        ComponentPropertyChanged?.Invoke(propertyPath);
+    }
+}

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -375,13 +375,7 @@ public partial class ComponentListViewModel : InspectorViewModel
             var editor = acquireEditorResult.Value;
 
             // Get the component summary from the component editor
-            var getSummaryResult = editor.GetComponentSummary();
-            if (getSummaryResult.IsFailure)
-            {
-                _logger.LogError($"Failed to get component summary for component: '{componentKey}'");
-                continue;
-            }
-            var summary = getSummaryResult.Value;
+            var summary = editor.GetComponentSummary();
 
             // Populate the component summary
             componentItem.Summary = summary;


### PR DESCRIPTION
Refactored ComponentEditorBase so that most of the implementation details are delegated to a ComponentEditorHelper class. This keeps ComponentEditorBase lean and with only the single dependency on ComponentEditorHelper.

ComponentEditorBase now has a GetComponentConfig() abstract method which editors implement to provide the component config data. Added a utility for loading content from an embedded text file.


