### PR TITLE
Add support for Form buttons

### DIFF
--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -85,4 +85,7 @@ public abstract class ComponentEditorBase : IComponentEditor
 
         return Component.SetProperty(propertyPath, jsonValue, insert);
     }
+
+    public virtual void OnButtonClicked(string buttonId)
+    {}
 }

--- a/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
@@ -56,8 +56,13 @@ public interface IComponentProxy
     Result SetProperty(string propertyPath, string jsonValue, bool insert = false);
 
     /// <summary>
-    /// Convenience method to get a string comopnent property.
+    /// Convenience method to get a string component property.
     /// Returns the default value if the property cannot be found.
     /// </summary>
     string GetString(string propertyPath, string defaultValue = "");
+
+    /// <summary>
+    /// Convenience method to set a string component property.
+    /// </summary>
+    void SetString(string propertyPath, string defaultValue = "");
 }

--- a/Celbridge/BaseLibrary/Forms/IButtonViewModel.cs
+++ b/Celbridge/BaseLibrary/Forms/IButtonViewModel.cs
@@ -1,0 +1,22 @@
+namespace Celbridge.Forms;
+
+/// <summary>
+/// A view model that binds a form button UI element to a form property via a form data provider.
+/// </summary>
+public interface IButtonViewModel
+{
+    /// <summary>
+    /// Initializes the view model with the form data provider and a buttonId.
+    /// </summary>
+    Result Initialize(IFormDataProvider formDataProvider, string buttonId);
+    
+    /// <summary>
+    /// Called when the use clicks the button.
+    /// </summary>
+    void OnButtonClicked();
+
+    /// <summary>
+    /// Called when the view is unloaded.
+    /// </summary>
+    void OnViewUnloaded();
+}

--- a/Celbridge/BaseLibrary/Forms/IFormDataProvider.cs
+++ b/Celbridge/BaseLibrary/Forms/IFormDataProvider.cs
@@ -30,4 +30,9 @@ public interface IFormDataProvider
     /// Sets the property at the specified path as JSON.
     /// </summary>
     Result SetProperty(string propertyPath, string jsonValue, bool insert = false);
+
+    /// <summary>
+    /// Called when a form button is clicked.
+    /// </summary>
+    void OnButtonClicked(string buttonId);
 }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ServiceConfiguration.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ServiceConfiguration.cs
@@ -44,6 +44,7 @@ public static class ServiceConfiguration
         services.AddTransient<NewProjectDialogViewModel>();
         services.AddTransient<InputTextDialogViewModel>();
         services.AddTransient<StringPropertyViewModel>();
+        services.AddTransient<ButtonViewModel>();
     }
 
     public static void Initialize()

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
@@ -148,6 +148,12 @@ public class FormBuilder
     {
         var stackPanel = new StackPanel();
 
+        if (!ApplyAlignmentConfig(stackPanel, jsonElement))
+        {
+            _buildErrors.Add($"Failed to apply alignment configuration to StackPanel");
+            return null;
+        }
+
         // Set the spacing between elements
         if (jsonElement.TryGetProperty("spacing", out var spacing))
         {
@@ -529,7 +535,8 @@ public class FormBuilder
                 if (configKey == "element" ||
                     configKey == "horizontalAlignment" ||
                     configKey == "verticalAlignment" ||
-                    configKey == "tooltip")
+                    configKey == "tooltip" ||
+                    configKey == "alignment")
                 {
                     // Skip general config properties that apply to all elements
                     continue;

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
@@ -360,7 +360,10 @@ public class FormBuilder
             return null;
         }
 
+        // Add a horizontal panel for the button content
+
         var buttonPanel = new StackPanel();
+        buttonPanel.Orientation = Orientation.Horizontal;
         button.Content = buttonPanel;
 
         //
@@ -373,7 +376,6 @@ public class FormBuilder
             buttonIcon = icon.GetString();
         }
 
-        buttonPanel.Orientation = Orientation.Horizontal;
         if (!string.IsNullOrEmpty(buttonIcon))
         {
             string glyph = string.Empty;
@@ -425,7 +427,7 @@ public class FormBuilder
             buttonId = buttonIdElement.GetString() ?? string.Empty;
         }
 
-        // Create and assign a button view model
+        // Create and assign a button view model to handle clicks
         var viewModel = _serviceProvider.GetRequiredService<ButtonViewModel>();
         viewModel.Initialize(_formDataProvider, buttonId);
         button.DataContext = viewModel;

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/FormBuilder.cs
@@ -328,6 +328,8 @@ public class FormBuilder
 
     private Button? CreateButton(JsonElement jsonElement)
     {
+        Guard.IsNotNull(_formDataProvider);
+
         var button = new Button();
 
         if (!ApplyAlignmentConfig(button, jsonElement))
@@ -342,13 +344,26 @@ public class FormBuilder
             button.Content = text.GetString();
         }
 
-        //if (element.TryGetProperty("command", out var command))
-        //{
-        //    button.Click += (sender, args) =>
-        //    {
-        //        Console.WriteLine($"Button command: {command.GetString()}");
-        //    };
-        //}
+        // Set the buttonId
+        string buttonId = string.Empty;
+        if (jsonElement.TryGetProperty("buttonId", out var buttonIdElement))
+        {
+            buttonId = buttonIdElement.GetString() ?? string.Empty;
+        }
+
+        // Create and assign a button view model
+        var viewModel = _serviceProvider.GetRequiredService<ButtonViewModel>();
+        viewModel.Initialize(_formDataProvider, buttonId);
+        button.DataContext = viewModel;
+
+        if (!string.IsNullOrEmpty(buttonId))
+        {
+            // Bind the button click handler to the button view model
+            button.Click += (sender, args) =>
+            {
+                viewModel.OnButtonClicked();
+            };
+        }
 
         return button;
     }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonViewModel.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonViewModel.cs
@@ -1,0 +1,27 @@
+using Celbridge.Forms;
+
+namespace Celbridge.UserInterface.ViewModels.Forms;
+
+public class ButtonViewModel : IButtonViewModel
+{
+    private IFormDataProvider? _formDataProvider;
+    private string _buttonId = string.Empty;
+
+    public Result Initialize(IFormDataProvider formDataProvider, string buttonId)
+    {
+        _formDataProvider = formDataProvider;
+        _buttonId = buttonId;
+
+        return Result.Ok();
+    }
+
+    public void OnButtonClicked()
+    {
+        _formDataProvider?.OnButtonClicked(_buttonId);
+    }
+
+    public void OnViewUnloaded()
+    {
+        _formDataProvider = null;
+    }
+}

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -10,22 +10,26 @@
     "children": [
       {
         "element": "Button",
-        "text": "Open",
+        "tooltip": "Open document",
+        "icon": "OpenFile",
         "buttonId": "OpenDocument"
       },
       {
         "element": "Button",
-        "text": "Editor",
+        "tooltip": "Editor view",
+        "icon": "DockLeft",
         "buttonId": "Editor"
       },
       {
         "element": "Button",
-        "text": "EditorAndPreview",
+        "tooltip": "Split view",
+        "icon": "DockBottom",
         "buttonId": "EditorAndPreview"
       },
       {
         "element": "Button",
-        "text": "Preview",
+        "tooltip": "Preview view",
+        "icon": "DockRight",
         "buttonId": "Preview"
       }
     ]

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -7,6 +7,7 @@
   {
     "element": "StackPanel",
     "orientation": "Horizontal",
+    "horizontalAlignment": "Center",
     "children": [
       {
         "element": "Button",

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -5,8 +5,24 @@
     "textBinding": "/editorMode"
   },
   {
-    "element": "Button",
-    "text": "Press me",
-    "buttonId": "ButtonA"
+    "element": "StackPanel",
+    "orientation": "Horizontal",
+    "children": [
+      {
+        "element": "Button",
+        "text": "A",
+        "buttonId": "ButtonA"
+      },
+      {
+        "element": "Button",
+        "text": "B",
+        "buttonId": "ButtonB"
+      },
+      {
+        "element": "Button",
+        "text": "C",
+        "buttonId": "ButtonC"
+      }
+    ]
   }
 ]

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -3,5 +3,10 @@
     "element": "TextBox",
     "header": "Editor Mode",
     "textBinding": "/editorMode"
+  },
+  {
+    "element": "Button",
+    "text": "Press me",
+    "buttonId": "ButtonA"
   }
 ]

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -10,18 +10,23 @@
     "children": [
       {
         "element": "Button",
-        "text": "A",
-        "buttonId": "ButtonA"
+        "text": "Open",
+        "buttonId": "OpenDocument"
       },
       {
         "element": "Button",
-        "text": "B",
-        "buttonId": "ButtonB"
+        "text": "Editor",
+        "buttonId": "Editor"
       },
       {
         "element": "Button",
-        "text": "C",
-        "buttonId": "ButtonC"
+        "text": "EditorAndPreview",
+        "buttonId": "EditorAndPreview"
+      },
+      {
+        "element": "Button",
+        "text": "Preview",
+        "buttonId": "Preview"
       }
     ]
   }

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -1,3 +1,5 @@
+using Celbridge.Commands;
+using Celbridge.Documents;
 using Celbridge.Entities;
 using Celbridge.Logging;
 
@@ -6,15 +8,24 @@ namespace Celbridge.Markdown.Components;
 public class MarkdownEditor : ComponentEditorBase
 {
     private readonly ILogger<MarkdownEditor> _logger;
+    private readonly ICommandService _commandService;
 
     private const string _configPath = "Celbridge.Markdown.Assets.Components.MarkdownComponent.json";
     private const string _formPath = "Celbridge.Markdown.Assets.Forms.MarkdownForm.json";
 
+    private const string _openDocumentButtonId = "OpenDocument";
+    private const string _editorButtonId = "Editor";
+    private const string _editorAndPreviewButtonId = "EditorAndPreview";
+    private const string _previewButtonId = "Preview";
+
     public const string ComponentType = "Markdown.Markdown";
 
-    public MarkdownEditor(ILogger<MarkdownEditor> logger)
+    public MarkdownEditor(
+        ILogger<MarkdownEditor> logger,
+        ICommandService commandService)
     {
         _logger = logger;
+        _commandService = commandService;
     }
 
     public override string GetComponentConfig()
@@ -34,6 +45,43 @@ public class MarkdownEditor : ComponentEditorBase
 
     public override void OnButtonClicked(string buttonId)
     {
-        _logger.LogInformation(buttonId);
+        switch (buttonId)
+        {
+            case _openDocumentButtonId:
+                OpenDocument();
+                break;
+
+            case _editorButtonId:
+                SetEditorMode(EditorMode.Editor);
+                OpenDocument();
+                break;
+
+            case _editorAndPreviewButtonId:
+                SetEditorMode(EditorMode.EditorAndPreview);
+                OpenDocument();
+                break;
+
+            case _previewButtonId:
+                SetEditorMode(EditorMode.Preview);
+                OpenDocument();
+                break;
+        }
+    }
+
+    private void OpenDocument()
+    {
+        var resource = Component.Key.Resource;
+
+        // Execute a command to open the markdown document.
+        _commandService.Execute<IOpenDocumentCommand>(command =>
+        {
+            command.FileResource = resource;
+            command.ForceReload = false;
+        });
+    }
+
+    private void SetEditorMode(EditorMode editorMode)
+    {
+        Component.SetString(MarkdownComponentConstants.EditorMode, editorMode.ToString());
     }
 }

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -1,13 +1,21 @@
 using Celbridge.Entities;
+using Celbridge.Logging;
 
 namespace Celbridge.Markdown.Components;
 
 public class MarkdownEditor : ComponentEditorBase
 {
+    private readonly ILogger<MarkdownEditor> _logger;
+
     private const string _configPath = "Celbridge.Markdown.Assets.Components.MarkdownComponent.json";
     private const string _formPath = "Celbridge.Markdown.Assets.Forms.MarkdownForm.json";
 
     public const string ComponentType = "Markdown.Markdown";
+
+    public MarkdownEditor(ILogger<MarkdownEditor> logger)
+    {
+        _logger = logger;
+    }
 
     public override string GetComponentConfig()
     {
@@ -22,5 +30,10 @@ public class MarkdownEditor : ComponentEditorBase
     public override ComponentSummary GetComponentSummary()
     {
         return new ComponentSummary(string.Empty, string.Empty);
+    }
+
+    public override void OnButtonClicked(string buttonId)
+    {
+        _logger.LogInformation(buttonId);
     }
 }


### PR DESCRIPTION
Forms may now specify Button controls, with icon and button text properties. The "icon" property be a value from the built-in Symbol enum, or any Unicode character code supported by the SymbolThemeFontFamily. The value of the "buttonId" property is passed to the ComponentEditor (via IFormDataProvider) so that client code can determine which button was pressed. 