### PR TITLE
Bind form element properrties to virtual form prooperties

### DIFF
--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -22,12 +22,6 @@ public abstract class ComponentEditorBase : IComponentEditor
         return Result.Ok();
     }
 
-    private void OnComponentPropertyChanged(string propertyPath)
-    {
-        // Forward component property changes to the form
-        FormPropertyChanged?.Invoke(propertyPath);
-    }
-
     public abstract string GetComponentConfig();
 
     public abstract string GetComponentForm();
@@ -56,12 +50,54 @@ public abstract class ComponentEditorBase : IComponentEditor
         _helper = null;
     }
 
-    public string LoadEmbeddedResource(string resourcePath)
-    {    
+    public Result<string> GetProperty(string propertyPath)
+    {
+        var getResult = TryGetProperty(propertyPath);
+        if (getResult.IsSuccess)
+        {
+            // Derived class has intercepted this property get
+            return getResult;
+        }
+
+        // Get the property from the component
+        return Component.GetProperty(propertyPath);
+    }
+
+    public Result SetProperty(string propertyPath, string jsonValue, bool insert = false)
+    {
+        var setResult = TrySetProperty(propertyPath, jsonValue);
+        if (setResult.IsSuccess)
+        {
+            // The derived class has intercepted this property get
+            return Result.Ok();
+        }
+
+        return Component.SetProperty(propertyPath, jsonValue, insert);
+    }
+
+    protected virtual Result<string> TryGetProperty(string propertyPath)
+    {
+        return Result<string>.Fail();
+    }
+
+    protected virtual Result TrySetProperty(string propertyPath, string jsonValue)
+    {
+        return Result.Fail();
+    }
+
+    public virtual void OnButtonClicked(string buttonId)
+    {}
+
+    /// <summary>
+    /// Loads a text file from an embedded resource.
+    /// </summary>
+    protected string LoadEmbeddedResource(string resourcePath)
+    {
         var utilityService = ServiceLocator.AcquireService<IUtilityService>();
-     
+
         // Get the type of the component editor class.
-        // The embedded resource must be in the same assembly as this type.
+        // The embedded resource must be in the same assembly as the class that inherits
+        // from ComponentEditorBase.
         var loadResult = utilityService.LoadEmbeddedResource(GetType(), resourcePath);
         if (loadResult.IsFailure)
         {
@@ -72,20 +108,26 @@ public abstract class ComponentEditorBase : IComponentEditor
         return content;
     }
 
-    public Result<string> GetProperty(string propertyPath)
+    /// <summary>
+    /// Notify the form that a property has changed.
+    /// This is generally used for updating "virtual" properties that are not stored in 
+    /// the component.
+    /// </summary>
+    protected virtual void NotifyFormPropertyChanged(string propertyPath)
     {
-        // Todo: Add property override mechanism
-
-        return Component.GetProperty(propertyPath);
+        FormPropertyChanged?.Invoke(propertyPath);
+        OnFormPropertyChanged(propertyPath);
     }
 
-    public Result SetProperty(string propertyPath, string jsonValue, bool insert = false)
-    {
-        // Todo: Add property override mechanism
-
-        return Component.SetProperty(propertyPath, jsonValue, insert);
-    }
-
-    public virtual void OnButtonClicked(string buttonId)
+    /// <summary>
+    /// Event handler called when a form property has changed
+    /// </summary>
+    protected virtual void OnFormPropertyChanged(string propertyPath)
     {}
+
+    private void OnComponentPropertyChanged(string propertyPath)
+    {
+        // Forward component property changes to the form
+        NotifyFormPropertyChanged(propertyPath);
+    }
 }

--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -72,6 +72,7 @@ public abstract class ComponentEditorBase : IComponentEditor
             return Result.Ok();
         }
 
+        // Set the property on the component
         return Component.SetProperty(propertyPath, jsonValue, insert);
     }
 

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
@@ -3,7 +3,7 @@ using Celbridge.UserInterface.ViewModels.Forms;
 
 namespace Celbridge.UserInterface.Services.Forms;
 
-public class PropertyBinder
+public class PropertyBinder<T> where T : notnull
 {
     private FrameworkElement _frameworkElement;
     private FormElement _formElement;
@@ -13,8 +13,8 @@ public class PropertyBinder
     private string _memberName = string.Empty;
     private bool HasBinding => _dependencyProperty is not null && !string.IsNullOrEmpty(_memberName);
 
-    private Action<string>? _setterAction;
-    private Func<string>? _getterAction;
+    private Action<T>? _setterAction;
+    private Func<T>? _getterAction;
 
     private string _formPropertyPath = string.Empty;
 
@@ -26,29 +26,30 @@ public class PropertyBinder
 
     public static bool IsBindingConfig(JsonElement config)
     {
-        if (config.ValueKind == JsonValueKind.String)
+        if (config.ValueKind != JsonValueKind.String)
         {
-            var value = config.GetString();
-            if (!string.IsNullOrEmpty(value) &&
-                value.StartsWith('/') && 
-                value.Length > 1)
-            {
-                return true;
-            }
+            return false;
+        }
+
+        var value = config.GetString();
+        if (!string.IsNullOrEmpty(value) &&
+            value.Length > 1 &&
+            value.StartsWith('/'))
+        {
+            return true;
         }
 
         return false;
     }
 
-    public static PropertyBinder Create(
+    public static PropertyBinder<T> Create(
         FrameworkElement frameworkElement,
         FormElement formElement)
     {
-        var propertyBinder = new PropertyBinder(frameworkElement, formElement);
-        return propertyBinder;
+        return new PropertyBinder<T>(frameworkElement, formElement);
     }
 
-    public PropertyBinder Binding(
+    public PropertyBinder<T> Binding(
         DependencyProperty dependencyProperty,
         BindingMode bindingMode,
         string memberName)
@@ -59,13 +60,13 @@ public class PropertyBinder
         return this;
     }
 
-    public PropertyBinder Setter(Action<string> setterAction)
+    public PropertyBinder<T> Setter(Action<T> setterAction)
     {
         _setterAction = setterAction;
         return this;
     }
 
-    public PropertyBinder Getter(Func<string> getterAction)
+    public PropertyBinder<T> Getter(Func<T> getterAction)
     {
         _getterAction = getterAction;
         return this;
@@ -73,107 +74,77 @@ public class PropertyBinder
 
     public Result Initialize(JsonElement configValue)
     {
+        if (!IsBindingConfig(configValue))
+        {
+            return Result.Fail("Invalid binding configuration");
+        }
+
         if (_setterAction is null)
         {
-            return Result.Fail($"No setter action specified");
+            return Result.Fail("No setter action specified");
         }
 
-        // Check the type
-        if (configValue.ValueKind != JsonValueKind.String)
+        _formPropertyPath = configValue.GetString()!;
+        SynchonizeProperties();
+
+        if (HasBinding)
         {
-            return Result.Fail($"Config value must be a string");
-        }
-
-        // Apply the property
-        var configText = configValue.GetString()!;
-        if (configText.StartsWith('/'))
-        {
-            // Store the property path for future updates
-            _formPropertyPath = configText;
-
-            // Sync the member variable with the form data provider
-            SynchonizeProperties();
-
-            if (HasBinding)
+            _frameworkElement.SetBinding(_dependencyProperty, new Binding()
             {
-                // Bind dependency property to a member variable on the form element class
-                _frameworkElement.SetBinding(_dependencyProperty, new Binding()
-                {
-                    Path = new PropertyPath(_memberName),
-                    Mode = _bindingMode
-                });
-            }
-
-            // Set a flag to indicate that the form element needs to register for
-            // property update notifications.
-            _formElement.RequiresChangeNotifications = true;
+                Path = new PropertyPath(_memberName),
+                Mode = _bindingMode
+            });
         }
-        else
-        {
-            // Todo: Support localization
-            var jsonValue = configValue.GetRawText();
-            _setterAction?.Invoke(jsonValue);
 
-            if (HasBinding)
-            {
-                // Bind dependency property to a member variable on the form element class
-                _frameworkElement.SetBinding(_dependencyProperty, new Binding()
-                {
-                    Path = new PropertyPath(_memberName),
-                    Mode = BindingMode.OneTime, // Setting member to a fixed value that will never update
-                });
-            }
-        }
+        _formElement.RequiresChangeNotifications = true;
 
         return Result.Ok();
     }
 
     public void OnFormDataChanged(string propertyPath)
     {
-        if (string.IsNullOrEmpty(_formPropertyPath) ||
-            propertyPath != _formPropertyPath)
+        if (!string.IsNullOrEmpty(_formPropertyPath) && propertyPath == _formPropertyPath)
         {
-            return;
+            SynchonizeProperties();
         }
-
-        SynchonizeProperties();
     }
 
     public void OnMemberDataChanged(string propertyName)
     {
-        if (_getterAction is null ||
-            string.IsNullOrEmpty(_memberName) ||
-            propertyName != _memberName)
+        if (_getterAction is null || string.IsNullOrEmpty(_memberName) || propertyName != _memberName)
         {
             return;
         }
 
-        var jsonValue = _getterAction.Invoke();
-
-        var formDataProvider = _formElement.FormDataProvider;
-        formDataProvider.SetProperty(_formPropertyPath, jsonValue, false);
+        T value = _getterAction.Invoke();
+        string jsonValue = JsonSerializer.Serialize(value);
+        _formElement.FormDataProvider.SetProperty(_formPropertyPath, jsonValue, false);
     }
 
     private Result SynchonizeProperties()
     {
         if (_setterAction is null)
         {
-            return Result.Fail($"No setter action specified");
+            return Result.Fail("No setter action specified");
         }
 
         var formDataProvider = _formElement.FormDataProvider;
-
-        // Read the current property JSON value via the FormDataProvider
         var getResult = formDataProvider.GetProperty(_formPropertyPath);
         if (getResult.IsFailure)
         {
             return Result.Fail($"Failed to get property: '{_formPropertyPath}'")
                 .WithErrors(getResult);
         }
-        var jsonValue = getResult.Value;
 
-        // Update the member variable
-        _setterAction.Invoke(jsonValue);
+        try
+        {
+            T value = JsonSerializer.Deserialize<T>(getResult.Value) ?? throw new JsonException("Deserialization resulted in null");
+            _setterAction.Invoke(value);
+        }
+        catch (JsonException ex)
+        {
+            return Result.Fail($"Failed to deserialize JSON: {ex.Message}");
+        }
 
         return Result.Ok();
     }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
@@ -111,7 +111,9 @@ public class PropertyBinder<T> where T : notnull
 
     public void OnMemberDataChanged(string propertyName)
     {
-        if (_getterAction is null || string.IsNullOrEmpty(_memberName) || propertyName != _memberName)
+        if (_getterAction is null || 
+            string.IsNullOrEmpty(_memberName) || 
+            propertyName != _memberName)
         {
             return;
         }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
@@ -24,6 +24,22 @@ public class PropertyBinder
         _formElement = formElement;
     }
 
+    public static bool IsBindingConfig(JsonElement config)
+    {
+        if (config.ValueKind == JsonValueKind.String)
+        {
+            var value = config.GetString();
+            if (!string.IsNullOrEmpty(value) &&
+                value.StartsWith('/') && 
+                value.Length > 1)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static PropertyBinder Create(
         FrameworkElement frameworkElement,
         FormElement formElement)

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
@@ -12,7 +12,7 @@ public partial class ButtonElement : FormElement
         return formElement.Create(config, formBuilder);
     }
 
-    private PropertyBinder? _isEnabledBinder;
+    private PropertyBinder<bool>? _isEnabledBinder;
 
     protected override Result<FrameworkElement> CreateUIElement(JsonElement config, FormBuilder formBuilder)
     {
@@ -96,19 +96,12 @@ public partial class ButtonElement : FormElement
     {
         if (config.TryGetProperty("isEnabled", out var configValue))
         {
-            if (PropertyBinder.IsBindingConfig(configValue))
+            if (PropertyBinder<bool>.IsBindingConfig(configValue))
             {
-                _isEnabledBinder = PropertyBinder.Create(button, this)
-                    .Setter((jsonValue) =>
+                _isEnabledBinder = PropertyBinder<bool>.Create(button, this)
+                    .Setter((value) =>
                     {
-                        // Todo: Deserialize will cause an exception here if jsonValue is invalid
-
-                        var isEnabled = false;
-                        if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
-                        {
-                            isEnabled = result;
-                        }
-                        button.IsEnabled = isEnabled;
+                        button.IsEnabled = value;
                     });
 
                 return _isEnabledBinder.Initialize(configValue);

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
@@ -99,6 +99,8 @@ public partial class ButtonElement : FormElement
             _isEnabledBinder = PropertyBinder.Create(button, this)
                 .Setter((jsonValue) =>
                 {
+                    // Todo: Deserialize will cause an exception here if jsonValue is invalid
+
                     var isEnabled = false;
                     if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
                     {

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
@@ -1,5 +1,4 @@
 using Celbridge.UserInterface.Services.Forms;
-using Microsoft.UI.Xaml;
 using System.Text.Json;
 
 namespace Celbridge.UserInterface.ViewModels.Forms;

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ButtonElement.cs
@@ -96,20 +96,35 @@ public partial class ButtonElement : FormElement
     {
         if (config.TryGetProperty("isEnabled", out var configValue))
         {
-            _isEnabledBinder = PropertyBinder.Create(button, this)
-                .Setter((jsonValue) =>
-                {
-                    // Todo: Deserialize will cause an exception here if jsonValue is invalid
-
-                    var isEnabled = false;
-                    if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
+            if (PropertyBinder.IsBindingConfig(configValue))
+            {
+                _isEnabledBinder = PropertyBinder.Create(button, this)
+                    .Setter((jsonValue) =>
                     {
-                        isEnabled = result;
-                    }
-                    button.IsEnabled = isEnabled;
-                });
+                        // Todo: Deserialize will cause an exception here if jsonValue is invalid
 
-            return _isEnabledBinder.Initialize(configValue);
+                        var isEnabled = false;
+                        if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
+                        {
+                            isEnabled = result;
+                        }
+                        button.IsEnabled = isEnabled;
+                    });
+
+                return _isEnabledBinder.Initialize(configValue);
+            }
+            else if (configValue.ValueKind == JsonValueKind.True)
+            {
+                button.IsEnabled = true;
+            }
+            else if (configValue.ValueKind == JsonValueKind.False)
+            {
+                button.IsEnabled = false;
+            }
+            else
+            {
+                return Result<bool>.Fail("'isEnabled' config is not valid");
+            }
         }
 
         return Result.Ok();

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -122,18 +122,35 @@ public partial class TextBoxElement : FormElement
     {
         if (config.TryGetProperty("isEnabled", out var configValue))
         {
-            _isEnabledBinder = PropertyBinder.Create(textBox, this)
-                .Setter((jsonValue) =>
-                {
-                    var isEnabled = false;
-                    if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
+            if (PropertyBinder.IsBindingConfig(configValue))
+            {
+                _isEnabledBinder = PropertyBinder.Create(textBox, this)
+                    .Setter((jsonValue) =>
                     {
-                        isEnabled = result;
-                    }
-                    textBox.IsEnabled = isEnabled;
-                });
+                        // Todo: Deserialize will cause an exception here if jsonValue is invalid
 
-            return _isEnabledBinder.Initialize(configValue);
+                        var isEnabled = false;
+                        if (bool.TryParse(JsonSerializer.Deserialize<string>(jsonValue), out bool result))
+                        {
+                            isEnabled = result;
+                        }
+                        textBox.IsEnabled = isEnabled;
+                    });
+
+                return _isEnabledBinder.Initialize(configValue);
+            }
+            else if (configValue.ValueKind == JsonValueKind.True)
+            {
+                textBox.IsEnabled = false;
+            }
+            else if (configValue.ValueKind == JsonValueKind.False)
+            {
+                textBox.IsEnabled = false;
+            }
+            else
+            {
+                return Result<bool>.Fail("'isEnabled' config is not valid");
+            }
         }
 
         return Result.Ok();

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -227,15 +227,12 @@ public partial class TextBoxElement : FormElement
 
     protected override void OnFormDataChanged(string propertyPath)
     {
-        Guard.IsNotNull(_textBinder);
-
-        _textBinder.OnFormDataChanged(propertyPath);
+        _isEnabledBinder?.OnFormDataChanged(propertyPath);
+        _textBinder?.OnFormDataChanged(propertyPath);
     }
 
     protected override void OnMemberDataChanged(string propertyName)
     {
-        Guard.IsNotNull(_textBinder);
-
-        _textBinder.OnMemberDataChanged(propertyName);
+        _textBinder?.OnMemberDataChanged(propertyName);
     }
 }

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -20,6 +20,7 @@
       {
         "element": "Button",
         "tooltip": "/editorMode",
+        "isEnabled": "/openButtonEnabled",
         "icon": "OpenFile",
         "buttonId": "OpenDocument"
       },

--- a/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
+++ b/Celbridge/Modules/Celbridge.Markdown/Assets/Forms/MarkdownForm.json
@@ -19,25 +19,27 @@
     "children": [
       {
         "element": "Button",
-        "tooltip": "/editorMode",
-        "isEnabled": "/openButtonEnabled",
+        "tooltip": "Open document",
         "icon": "OpenFile",
         "buttonId": "OpenDocument"
       },
       {
         "element": "Button",
+        "isEnabled": "/editorEnabled",
         "tooltip": "Editor view",
         "icon": "DockLeft",
         "buttonId": "Editor"
       },
       {
         "element": "Button",
+        "isEnabled": "/editorAndPreviewEnabled",
         "tooltip": "Split view",
         "icon": "DockBottom",
         "buttonId": "EditorAndPreview"
       },
       {
         "element": "Button",
+        "isEnabled": "/previewEnabled",
         "tooltip": "Preview view",
         "icon": "DockRight",
         "buttonId": "Preview"

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Celbridge.Commands;
 using Celbridge.Documents;
 using Celbridge.Entities;
@@ -43,6 +44,15 @@ public class MarkdownEditor : ComponentEditorBase
         return new ComponentSummary(string.Empty, string.Empty);
     }
 
+    protected override void OnFormPropertyChanged(string propertyPath)
+    {
+        if (propertyPath == "/editorMode")
+        {
+            // Notify updates to "virtual" form properties
+            NotifyFormPropertyChanged("/openButtonEnabled");
+        }
+    }
+
     public override void OnButtonClicked(string buttonId)
     {
         switch (buttonId)
@@ -66,6 +76,28 @@ public class MarkdownEditor : ComponentEditorBase
                 OpenDocument();
                 break;
         }
+    }
+
+    protected override Result<string> TryGetProperty(string propertyPath)
+    {
+        if (propertyPath == "/openButtonEnabled")
+        {
+            var editorMode = Component.GetString(MarkdownComponentConstants.EditorMode);
+
+            string jsonValue;
+            if (editorMode == "Preview")
+            {
+                jsonValue = "\"true\"";
+            }
+            else
+            {
+                jsonValue = "\"false\"";
+            }
+
+            return Result<String>.Ok(jsonValue);
+        }
+
+        return Result<string>.Fail();
     }
 
     private void OpenDocument()

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -49,7 +49,9 @@ public class MarkdownEditor : ComponentEditorBase
         if (propertyPath == "/editorMode")
         {
             // Notify updates to "virtual" form properties
-            NotifyFormPropertyChanged("/openButtonEnabled");
+            NotifyFormPropertyChanged("/editorEnabled");
+            NotifyFormPropertyChanged("/editorAndPreviewEnabled");
+            NotifyFormPropertyChanged("/previewEnabled");
         }
     }
 
@@ -80,11 +82,29 @@ public class MarkdownEditor : ComponentEditorBase
 
     protected override Result<string> TryGetProperty(string propertyPath)
     {
-        if (propertyPath == "/openButtonEnabled")
+        if (propertyPath == "/editorEnabled")
         {
             var editorMode = Component.GetString(MarkdownComponentConstants.EditorMode);
 
-            bool isEnabled = editorMode == "Preview";
+            bool isEnabled = editorMode == "EditorAndPreview" || editorMode == "Preview";
+            var jsonValue = JsonSerializer.Serialize(isEnabled);
+
+            return Result<String>.Ok(jsonValue);
+        }
+        else if (propertyPath == "/editorAndPreviewEnabled")
+        {
+            var editorMode = Component.GetString(MarkdownComponentConstants.EditorMode);
+
+            bool isEnabled = editorMode == "Editor" || editorMode == "Preview";
+            var jsonValue = JsonSerializer.Serialize(isEnabled);
+
+            return Result<String>.Ok(jsonValue);
+        }
+        else if (propertyPath == "/previewEnabled")
+        {
+            var editorMode = Component.GetString(MarkdownComponentConstants.EditorMode);
+
+            bool isEnabled = editorMode == "Editor" || editorMode == "EditorAndPreview";
             var jsonValue = JsonSerializer.Serialize(isEnabled);
 
             return Result<String>.Ok(jsonValue);
@@ -92,6 +112,7 @@ public class MarkdownEditor : ComponentEditorBase
 
         return Result<string>.Fail();
     }
+
 
     private void OpenDocument()
     {

--- a/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -84,15 +84,8 @@ public class MarkdownEditor : ComponentEditorBase
         {
             var editorMode = Component.GetString(MarkdownComponentConstants.EditorMode);
 
-            string jsonValue;
-            if (editorMode == "Preview")
-            {
-                jsonValue = "\"true\"";
-            }
-            else
-            {
-                jsonValue = "\"false\"";
-            }
+            bool isEnabled = editorMode == "Preview";
+            var jsonValue = JsonSerializer.Serialize(isEnabled);
 
             return Result<String>.Ok(jsonValue);
         }

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -6,7 +6,6 @@
   },
   {
     "element": "TextBox",
-    "isEnabled": false,
     "header": "Character",
     "text": "/character"
   },

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -6,7 +6,7 @@
   },
   {
     "element": "TextBox",
-    "isEnabled": "false",
+    "isEnabled": false,
     "header": "Character",
     "text": "/character"
   },


### PR DESCRIPTION
Improved binding support so that form element properties (e.g. button.isEnabled) may be bound to virtual properties that are provided by the ComponentEditor instead of resolved via the Component. This allows an editor to control the behaviour of a form based on the current state of the component.