### PR TITLE
Import scenes from screenplay Excel workbook

### DIFF
--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -53,7 +53,8 @@ public partial class TextBoxElement : FormElement
             "text",
             "header",
             "placeholder",
-            "checkSpelling"
+            "checkSpelling",
+            "isReadOnly"
         });
 
         if (validateResult.IsFailure)
@@ -113,6 +114,13 @@ public partial class TextBoxElement : FormElement
         {
             return Result<FrameworkElement>.Fail($"Failed to apply 'text' config property")
                 .WithErrors(textResult);
+        }
+
+        var readOnlyResult = ApplyReadOnlyConfig(config, textBox);
+        if (readOnlyResult.IsFailure)
+        {
+            return Result<FrameworkElement>.Fail($"Failed to apply 'isReadOnly' config property")
+                .WithErrors(readOnlyResult);
         }
 
         return Result<FrameworkElement>.Ok(textBox);
@@ -235,6 +243,31 @@ public partial class TextBoxElement : FormElement
             else
             {
                 return Result.Fail($"'text' config is not valid");
+            }
+        }
+
+        return Result.Ok();
+    }
+
+    private Result ApplyReadOnlyConfig(JsonElement config, TextBox textBox)
+    {
+        if (config.TryGetProperty("isReadOnly", out var isReadOnlyValue))
+        {
+            // Check the type
+            if (isReadOnlyValue.ValueKind != JsonValueKind.True &&
+                isReadOnlyValue.ValueKind != JsonValueKind.False)
+            {
+                return Result.Fail("'isReadOnly' property must be a boolean");
+            }
+
+            // Apply the property
+            var isReadOnly = isReadOnlyValue.GetBoolean();
+            if (isReadOnlyValue.GetBoolean())
+            {
+                // Text can be selected but not edited
+                textBox.IsReadOnly = true;
+                textBox.BorderThickness = new Thickness(0);
+                textBox.Background = new SolidColorBrush(Colors.Transparent);
             }
         }
 

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -266,8 +266,7 @@ public partial class TextBoxElement : FormElement
             {
                 // Text can be selected but not edited
                 textBox.IsReadOnly = true;
-                textBox.BorderThickness = new Thickness(0);
-                textBox.Background = new SolidColorBrush(Colors.Transparent);
+                textBox.Opacity = 0.6;
             }
         }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -2,7 +2,8 @@
   {
     "element": "TextBox",
     "header": "Dialogue Key",
-    "text": "/dialogueKey"
+    "text": "/dialogueKey",
+    "isReadOnly": true
   },
   {
     "element": "ComboBox",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/SceneForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/SceneForm.json
@@ -1,44 +1,20 @@
 [
   {
-    "element": "StackPanel",
-    "orientation": "Horizontal",
-    "children": [
-      {
-        "element": "TextBlock",
-        "text": "Excel file:"
-      },
-      {
-        "element": "TextBlock",
-        "text": "/dialogueFile"
-      }
-    ]
+    "element": "TextBox",
+    "header": "Dialogue File",
+    "text": "/dialogueFile",
+    "isReadOnly": true
   },
   {
-    "element": "StackPanel",
-    "orientation": "Horizontal",
-    "children": [
-      {
-        "element": "TextBlock",
-        "text": "Category:"
-      },
-      {
-        "element": "TextBlock",
-        "text": "/category"
-      }
-    ]
+    "element": "TextBox",
+    "header": "Category",
+    "text": "/category",
+    "isReadOnly": true
   },
   {
-    "element": "StackPanel",
-    "orientation": "Horizontal",
-    "children": [
-      {
-        "element": "TextBlock",
-        "text": "Namespace:"
-      },
-      {
-        "element": "TextBlock",
-        "text": "/namespace"
-      }
-    ]
+    "element": "TextBox",
+    "header": "Namespace",
+    "text": "/namespace",
+    "isReadOnly": true
   }
 ]

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Celbridge.Entities;
@@ -11,8 +12,12 @@ public class LineEditor : ComponentEditorBase
     private const string _formPath = "Celbridge.Screenplay.Assets.Forms.LineForm.json";
 
     public const string ComponentType = "Screenplay.Line";
+    public const string DialogueKey = "/dialogueKey";
     public const string CharacterId = "/characterId";
+    public const string SpeakingTo = "/speakingTo";
     public const string SourceText = "/sourceText";
+    public const string ContextNotes = "/contextNotes";
+    public const string Direction = "/direction";
 
     private readonly IEntityService _entityService;
 
@@ -33,11 +38,42 @@ public class LineEditor : ComponentEditorBase
 
     public override ComponentSummary GetComponentSummary()
     {
+        var dialogueKey = Component.GetString(DialogueKey);
         var characterId = Component.GetString(CharacterId);
+        var speakingTo = Component.GetString(SpeakingTo);
         var sourceText = Component.GetString(SourceText);
+        var contextNotes = Component.GetString(ContextNotes);
+        var direction = Component.GetString(Direction);
 
+        // Display most important properties in the summary
         var summaryText = $"{characterId}: {sourceText}";
-        return new ComponentSummary(summaryText, summaryText);
+
+        // Display important properties in the tooltip
+        var sb = new StringBuilder();
+
+        sb.AppendLine(sourceText);
+        sb.AppendLine();
+
+        sb.AppendLine($"Character: {characterId}");
+        if (!string.IsNullOrEmpty(speakingTo))
+        {
+            sb.AppendLine($"Speaking To: {speakingTo}");
+        }
+        if (!string.IsNullOrEmpty(contextNotes))
+        {
+            sb.AppendLine($"Context Notes: {contextNotes}");
+        }
+        if (!string.IsNullOrEmpty(direction))
+        {
+            sb.AppendLine($"Direction: {direction}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"{dialogueKey}"); // Dialogue key contains character id
+
+        var tooltipText = sb.ToString();
+
+        return new ComponentSummary(summaryText, tooltipText);
     }
 
     protected override Result<string> TryGetProperty(string propertyPath)

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -118,7 +118,7 @@ public class LineEditor : ComponentEditorBase
 
         var characterIdsJson = JsonSerializer.Serialize(characterIds);
 
-        return Result<String>.Ok(characterIdsJson);
+        return Result<string>.Ok(characterIdsJson);
     }
 }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Models/DialogueLine.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Models/DialogueLine.cs
@@ -1,9 +1,9 @@
 namespace Celbridge.Screenplay.Models;
 
 public record DialogueLine(
-    string DialogueKey,
     string Category,
     string Namespace,
+    string DialogueKey,
     string CharacterId,
     string SpeakingTo,
     string SourceText,
@@ -14,5 +14,4 @@ public record DialogueLine(
     string SoundProcessing,
     string Platform,
     string LinePriority,
-    string ProductionStatus,
-    string DialogueAsset);
+    string ProductionStatus);

--- a/Celbridge/Modules/Celbridge.Screenplay/Models/Scene.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Models/Scene.cs
@@ -1,0 +1,9 @@
+
+namespace Celbridge.Screenplay.Models;
+
+public record Scene(string Category, string Namespace, string Context, string AssetPath, List<DialogueLine> Lines)
+{
+    public Scene(string Category, string Namespace, string Context, string AssetPath)
+        : this(Category, Namespace, Context, AssetPath, new List<DialogueLine>())
+    {}
+}

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -118,7 +118,7 @@ public class ScreenplayActivity : IActivity
             entityAnnotation.AddError(0, error);
         }
 
-        // Lookup character list from the screenplay component
+        // Get the character list from the screenplay component
         var getCharactersResult = GetCharacters(entity);
         if (getCharactersResult.IsFailure)
         {
@@ -164,7 +164,8 @@ public class ScreenplayActivity : IActivity
             // Mark Line component as recognized
             entityAnnotation.SetIsRecognized(i);
 
-            //Build a list of existing line ids so we can safely allocate a random one later if needed 
+            // Build a list of the existing line ids so that we can allocate a new random line id that won't clash
+            // with any existing one.
             var dialogueKey = component.GetString("/dialogueKey");
             var segments = dialogueKey.Split('-');
             if (segments.Length == 3)
@@ -177,7 +178,7 @@ public class ScreenplayActivity : IActivity
         }
 
         //
-        // Second pass checks all line components are valid, and check that
+        // Second pass checks all line components are valid, and checks that
         // each line has a valid character id, line id and dialogue key.
         // If the current line id is invalid then a new one is generated.
         //
@@ -272,7 +273,7 @@ public class ScreenplayActivity : IActivity
             }
             else
             {
-                // This is an NPC line, so stop tracking any player line group
+                // This is an NPC line, so stop tracking the player line group
                 playerLineId = string.Empty;
             }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -261,10 +261,11 @@ public class ScreenplayActivity : IActivity
                 }
                 else
                 {
-                    // Indent player variant lines
+                    // Flag this as a player variant line
                     isPlayerVariantLine = true;
 
-                    // Ensure that the line id matches the player line id of the group
+                    // Force the line id to match the player line id of the group.
+                    // This happens for example when a player variant line is moved to a different group.
                     if (lineId != playerLineId)
                     {
                         correctLineId = playerLineId;
@@ -280,15 +281,15 @@ public class ScreenplayActivity : IActivity
             if (string.IsNullOrEmpty(correctLineId))
             {
                 // No line id has been assigned yet, assign a new random one
-                // Generate random line ids until a unique one is found.
+                var random = new Random();
                 do
                 {
-                    // Generate a random 4 digit hex code for line id
-                    var random = new Random();
+                    // Try a random 4 digit hex code until a unique one is found.
                     int number = random.Next(0x1000, 0x10000);
                     correctLineId = number.ToString("X4");
                 }
                 while (activeLineIds.Contains(correctLineId));
+                
                 activeLineIds.Add(correctLineId);
             }
              
@@ -296,8 +297,8 @@ public class ScreenplayActivity : IActivity
             var correctDialogueKey = $"{characterId}-{@namespace}-{correctLineId}";
             if (dialogueKey != correctDialogueKey)
             {
-                // Set the property directly rather than using a command because we
-                // don't want to register an undo operation in this case.
+                // This operation currently can't be undone because the undo triggers the activity update. 
+                // Todo: Fix the undo / redo logic to support this case.
                 component.SetString("/dialogueKey", correctDialogueKey);
                 dialogueKey = correctDialogueKey;
             }
@@ -315,7 +316,6 @@ public class ScreenplayActivity : IActivity
             // Indent player variant lines
             if (isPlayerVariantLine)
             {
-                // Indent the line
                 entityAnnotation.SetIndent(i, 1);
             }
         }
@@ -441,7 +441,7 @@ public class ScreenplayActivity : IActivity
             return Result<List<Character>>.Fail($"Failed to get dialogue file property");
         }
 
-        // Get the ScreenplayData component on the Excel resource
+        // Get the ScreenplayData component from the dialogue file resource
         var getScreenplayDataResult = _entityService.GetComponentOfType(dialogueFileResource, ScreenplayDataEditor.ComponentType);
         if (getScreenplayDataResult.IsFailure)
         {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayImporter.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayImporter.cs
@@ -588,12 +588,30 @@ public class ScreenplayImporter
         charactersObject["Player"] = new JsonObject
         {
             ["name"] = "Player",
-            ["tag"] = ""
+            ["tag"] = "Character.Player"
         };
 
         // Add the characters from the 'Characters' sheet
+        var names = new HashSet<string>();
+        var tags = new HashSet<string>();
+
         foreach (var character in characters)
         {
+            // Check for duplicate names
+            if (names.Contains(character.Name))
+            {
+                return Result.Fail($"Duplicate character name '{character.Name}'");
+            }
+            names.Add(character.Name);
+
+            // Check for duplicate tags
+            if (tags.Contains(character.Tag))
+            {
+                return Result.Fail($"Duplicate character tag '{character.Tag}'");
+            }
+            tags.Add(character.Tag);
+
+            // Add character
             charactersObject[character.CharacterId] = new JsonObject
             {
                 ["name"] = character.Name,

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayImporter.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayImporter.cs
@@ -493,18 +493,21 @@ public class ScreenplayImporter
             // Create the .scene resource and entity data
 
             await SaveSceneFileAsync(sceneFolderPath, category, scene.AssetPath);
-            await SaveEntityFileAsync(excelResource, entityFolderPath, category, scene.AssetPath, scene.Lines);
+            await SaveEntityFileAsync(excelResource, entityFolderPath, category, scene.Namespace, scene.AssetPath, scene.Lines);
         }
 
         return Result.Ok();
     }
 
-    private static async Task SaveSceneFileAsync(string sceneFolderPath, string category, string asset_path)
+    private static async Task SaveSceneFileAsync(string sceneFolderPath, string category, string assetPath)
     {
         // Create a .scene file
-        var sceneFilePath = Path.Combine(sceneFolderPath, category, $"{asset_path}.scene");
 
+        var subFolder = Path.GetDirectoryName(assetPath) ?? string.Empty;
+        var assetName = Path.GetFileNameWithoutExtension(assetPath);
+        var sceneFilePath = Path.Combine(sceneFolderPath, category, subFolder, $"{assetName}.scene");
         var sceneFolder = Path.GetDirectoryName(sceneFilePath);
+
         if (!string.IsNullOrEmpty(sceneFolder) &&
             !Directory.Exists(sceneFolder))
         {
@@ -514,11 +517,13 @@ public class ScreenplayImporter
         await File.WriteAllTextAsync(sceneFilePath, string.Empty);
     }
 
-    private static async Task SaveEntityFileAsync(ResourceKey excelResource, string entityFolderPath, string category, string namespace_key, List<DialogueLine> line_list)
+    private static async Task SaveEntityFileAsync(ResourceKey excelResource, string entityFolderPath, string category, string @namespace, string assetPath, List<DialogueLine> lineList)
     {
-        var entityFilePath = Path.Combine(entityFolderPath, category, $"{namespace_key}.scene.json");
-
+        var subFolder = Path.GetDirectoryName(assetPath) ?? string.Empty;
+        var assetName = Path.GetFileNameWithoutExtension(assetPath);
+        var entityFilePath = Path.Combine(entityFolderPath, category, subFolder, $"{assetName}.scene.json");
         var entityFolder = Path.GetDirectoryName(entityFilePath);
+
         if (!string.IsNullOrEmpty(entityFolder) &&
             !Directory.Exists(entityFolder))
         {
@@ -534,11 +539,11 @@ public class ScreenplayImporter
         sceneComponent["_type"] = "Screenplay.Scene#1";
         sceneComponent["dialogueFile"] = excelResource.ToString();
         sceneComponent["category"] = category;
-        sceneComponent["namespace"] = namespace_key;
+        sceneComponent["namespace"] = @namespace;
         components.Add(sceneComponent);
 
         // Add line components
-        foreach (var line in line_list)
+        foreach (var line in lineList)
         {
             var lineComponent = new JsonObject();
             lineComponent["_type"] = "Screenplay.Line#1";

--- a/Celbridge/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
@@ -53,13 +53,20 @@ public partial class ComponentItem : ObservableObject
         var showErrorIcon = Visibility.Collapsed;
         var showWarningIcon = Visibility.Collapsed;
 
+        if (Summary is not null)
+        {
+            description = Summary.SummaryText;
+            tooltip = Summary.Tooltip;
+            showErrorIcon = Visibility.Collapsed;
+            showWarningIcon = Visibility.Collapsed;
+        }
+
         if (Annotation is not null)
         {
             if (Annotation.Errors.Count > 0)
             {
                 var error = Annotation.Errors[0];
-                description = error.Message;
-                tooltip = error.Description;
+                tooltip = $"Error: {error.Message}\n{error.Description}";
 
                 if (error.Severity == ComponentErrorSeverity.Critical ||
                     error.Severity == ComponentErrorSeverity.Error)
@@ -71,16 +78,6 @@ public partial class ComponentItem : ObservableObject
                 {
                     showErrorIcon = Visibility.Collapsed;
                     showWarningIcon = Visibility.Visible;
-                }
-            }
-            else
-            {
-                if (Summary is not null)
-                {
-                    description = Summary.SummaryText;
-                    tooltip = Summary.Tooltip;
-                    showErrorIcon = Visibility.Collapsed;
-                    showWarningIcon = Visibility.Collapsed;
                 }
             }
 

--- a/Celbridge/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Models/ComponentItem.cs
@@ -29,6 +29,9 @@ public partial class ComponentItem : ObservableObject
     [ObservableProperty]
     private ComponentSummary? _summary;
 
+    [ObservableProperty]
+    private GridLength _indentWidth;
+
     public ComponentItem()
     {
         PropertyChanged += ComponentItem_PropertyChanged;
@@ -50,31 +53,38 @@ public partial class ComponentItem : ObservableObject
         var showErrorIcon = Visibility.Collapsed;
         var showWarningIcon = Visibility.Collapsed;
 
-        if (Annotation is not null &&
-            Annotation.Errors.Count > 0)
+        if (Annotation is not null)
         {
-            var error = Annotation.Errors[0];
-            description = error.Message;
-            tooltip = error.Description;
+            if (Annotation.Errors.Count > 0)
+            {
+                var error = Annotation.Errors[0];
+                description = error.Message;
+                tooltip = error.Description;
 
-            if (error.Severity == ComponentErrorSeverity.Critical ||
-                error.Severity == ComponentErrorSeverity.Error)
-            {
-                showErrorIcon = Visibility.Visible;
-                showWarningIcon = Visibility.Collapsed;
+                if (error.Severity == ComponentErrorSeverity.Critical ||
+                    error.Severity == ComponentErrorSeverity.Error)
+                {
+                    showErrorIcon = Visibility.Visible;
+                    showWarningIcon = Visibility.Collapsed;
+                }
+                else if (error.Severity == ComponentErrorSeverity.Warning)
+                {
+                    showErrorIcon = Visibility.Collapsed;
+                    showWarningIcon = Visibility.Visible;
+                }
             }
-            else if (error.Severity == ComponentErrorSeverity.Warning)
+            else
             {
-                showErrorIcon = Visibility.Collapsed;
-                showWarningIcon = Visibility.Visible;
+                if (Summary is not null)
+                {
+                    description = Summary.SummaryText;
+                    tooltip = Summary.Tooltip;
+                    showErrorIcon = Visibility.Collapsed;
+                    showWarningIcon = Visibility.Collapsed;
+                }
             }
-        }
-        else if (Summary is not null)
-        {
-            description = Summary.SummaryText;
-            tooltip = Summary.Tooltip;
-            showErrorIcon = Visibility.Collapsed;
-            showWarningIcon = Visibility.Collapsed;
+
+            IndentWidth = new GridLength(Annotation.IndentLevel * 20);
         }
 
         Description = description;

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml
@@ -64,12 +64,13 @@
                 ContextFlyout="{StaticResource ComponentContextMenu}">
 
             <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="{x:Bind IndentWidth, Mode=OneWay}"/>
               <ColumnDefinition Width="Auto"/>
               <ColumnDefinition Width="*"/>
               <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <Grid Grid.Column="0"
+            <Grid Grid.Column="1"
                   Margin="0 0 8 0">
 
               <!-- TextBlock is displayed when component name does not have focus -->
@@ -93,7 +94,7 @@
             </Grid>
 
             <!-- A grid with the background color set is needed for tooltip to work -->
-            <Grid Grid.Column="1"
+            <Grid Grid.Column="2"
                   Margin="8 0 0 0"
                   Background="Transparent" 
                   ToolTipService.ToolTip="{x:Bind Tooltip, Mode=OneWay}">
@@ -125,7 +126,7 @@
             </Grid>
 
             <!-- Component menu button -->
-            <Button Grid.Column="2"
+            <Button Grid.Column="3"
                     Margin="8 0 0 0"
                     Width="24"
                     Height="24"

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/ComponentListView.xaml
@@ -97,7 +97,8 @@
             <Grid Grid.Column="2"
                   Margin="8 0 0 0"
                   Background="Transparent" 
-                  ToolTipService.ToolTip="{x:Bind Tooltip, Mode=OneWay}">
+                  ToolTipService.ToolTip="{x:Bind Tooltip, Mode=OneWay}"
+                  ToolTipService.Placement="Bottom">
               <StackPanel Orientation="Horizontal">
 
                 <!-- Error icon -->

--- a/Celbridge/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml
@@ -17,10 +17,15 @@
     <StackPanel x:Name="UtilitiesPanel"
                 Grid.Row="0"
                 Orientation="Vertical"/>
-    
-    <StackPanel x:Name="ComponentListPanel"
-                Grid.Row="1"
-                Orientation="Vertical"/>
+
+    <ScrollViewer x:Name="ComponentsScrollViewer"
+                  Grid.Row="1"
+                  HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollBarVisibility="Auto"
+                  Margin="4,0,0,0">
+      <StackPanel x:Name="ComponentListPanel"
+                  Orientation="Vertical"/>
+    </ScrollViewer>
 
     <ScrollViewer x:Name="DetailScrollViewer"
                   Grid.Row="2"


### PR DESCRIPTION
Import scenes, characters and dialogue lines from a Dialogue Excel workbook.
Player variant line components now indent under the main Player line they are grouped with.
Screenplay activity updates the line id for player variant lines to ensure it matches the Player line.

UX fixes:
Component error messages are now only displayed in the tooltip (not the summary text).
Added scrolling support to the component list.
Improved tooltip for Line component.
