### PR TITLE
Generate HTML preview of scene using a screenplay layout

### DIFF
--- a/Celbridge/Modules/Celbridge.HTML/Services/HTMLPreviewProvider.cs
+++ b/Celbridge/Modules/Celbridge.HTML/Services/HTMLPreviewProvider.cs
@@ -10,6 +10,7 @@ public class HTMLPreviewProvider : IPreviewProvider
     public HTMLPreviewProvider()
     {
         _supportedFileExtensions.Add(".html");
+        _supportedFileExtensions.Add(".scene");
     }
 
     public async Task<Result<string>> GeneratePreview(string text, IEditorPreview editorPreview)

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/SceneComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/SceneComponent.json
@@ -3,7 +3,8 @@
   "additionalProperties": false,
 
   "attributes": {
-    "rootActivity": "ScreenplayActivity"
+    "rootActivity": "ScreenplayActivity",
+    "isPreviewController": "true"
   },
 
   "properties": {
@@ -39,4 +40,4 @@
     "context": "",
     "dialogueFile": ""
   }
-}    
+}

--- a/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
+++ b/Celbridge/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" />
+    <PackageReference Include="Humanizer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/SceneEditor.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Celbridge.Documents;
 using Celbridge.Entities;
 
 namespace Celbridge.Screenplay.Components;
@@ -31,5 +33,17 @@ public class SceneEditor : ComponentEditorBase
         var summaryText = $"{categoryText}: {namespaceText}";
         var tooltipText = $"{summaryText}\n\n{context}";
         return new ComponentSummary(summaryText, tooltipText);
+    }
+
+    protected override Result<string> TryGetProperty(string propertyPath)
+    {
+        if (propertyPath == DocumentConstants.EditorModeProperty)
+        {
+            // _editorMode is always set to "Preview" for Scene components.
+            var jsonValue = JsonSerializer.Serialize(nameof(EditorMode.Preview));
+            return Result<string>.Ok(jsonValue);
+        }
+
+        return Result<string>.Fail();
     }
 }

--- a/Celbridge/Workspace/Celbridge.Documents/Assets/DocumentTypes/TextEditorTypes.json
+++ b/Celbridge/Workspace/Celbridge.Documents/Assets/DocumentTypes/TextEditorTypes.json
@@ -152,7 +152,7 @@
   ".sbt": "scala",
   ".sc": "scala",
   ".scala": "scala",
-  ".scene": "markdown",
+  ".scene": "html",
   ".sch": "scheme",
   ".scm": "scheme",
   ".scss": "scss",


### PR DESCRIPTION
Changed Screenplay activity to generate a HTML document using a traditional screenplay layout.
Modified the document preview system to force .scene documents to use the Preview mode exclusively.
Added Humanizer package to convert namespace to human readable format.