### PR TITLE
Refactor registration of preview providers

### DIFF
--- a/Celbridge/BaseLibrary/Documents/IDocumentsService.cs
+++ b/Celbridge/BaseLibrary/Documents/IDocumentsService.cs
@@ -90,7 +90,7 @@ public interface IDocumentsService
     /// <summary>
     /// Adds a preview provider that generates a HTML preview for a specific file extension.
     /// </summary>
-    Result AddPreviewProvider(IPreviewProvider previewProvider);
+    Result AddPreviewProvider(string fileExtension, IPreviewProvider previewProvider);
 
     /// <summary>
     /// Returns a previously registered preview provider for the specified file extension.

--- a/Celbridge/BaseLibrary/Documents/IHTMLPreviewProvider.cs
+++ b/Celbridge/BaseLibrary/Documents/IHTMLPreviewProvider.cs
@@ -1,0 +1,7 @@
+namespace Celbridge.Documents;
+
+/// <summary>
+/// Provides a HTML preview rendering of text data in a specific language (e.g. .html files)
+/// </summary>
+public interface IHTMLPreviewProvider : IPreviewProvider
+{}

--- a/Celbridge/BaseLibrary/Documents/IPreviewProvider.cs
+++ b/Celbridge/BaseLibrary/Documents/IPreviewProvider.cs
@@ -8,11 +8,6 @@ namespace Celbridge.Documents;
 public interface IPreviewProvider
 {
     /// <summary>
-    /// The list of supported file extensions.
-    /// </summary>
-    public IReadOnlyList<string> SupportedFileExtensions { get; }
-
-    /// <summary>
     /// Generates a HTML preview of the specified text.
     /// </summary>
     public abstract Task<Result<string>> GeneratePreview(string text, IEditorPreview editorPreview);

--- a/Celbridge/Modules/Celbridge.HTML/Module.cs
+++ b/Celbridge/Modules/Celbridge.HTML/Module.cs
@@ -1,4 +1,5 @@
 using Celbridge.Activities;
+using Celbridge.Documents;
 using Celbridge.HTML.Components;
 using Celbridge.HTML.Services;
 using Celbridge.Modules;
@@ -19,7 +20,7 @@ public class Module : IModule
         //
 
         services.AddTransient<HTMLActivity>();
-        services.AddTransient<HTMLPreviewProvider>();
+        services.AddTransient<IHTMLPreviewProvider, HTMLPreviewProvider>();
 
         //
         // Register component editors

--- a/Celbridge/Modules/Celbridge.HTML/Services/HTMLActivity.cs
+++ b/Celbridge/Modules/Celbridge.HTML/Services/HTMLActivity.cs
@@ -23,12 +23,13 @@ public class HTMLActivity : IActivity
 
     public async Task<Result> ActivateAsync()
     {
-        // Register the HTML preview provider
-        var provider = _serviceProvider.AcquireService<HTMLPreviewProvider>();
-        var addProviderResult = _documentsService.AddPreviewProvider(provider);
+        // Register a HTML preview provider for .html files
+        var provider = _serviceProvider.AcquireService<IHTMLPreviewProvider>();
+
+        var addProviderResult = _documentsService.AddPreviewProvider(".html", provider);
         if (addProviderResult.IsFailure)
         {
-            return Result.Fail("Failed to add HTML preview provider.")
+            return Result.Fail("Failed to register HTML preview provider for '.html' file extension.")
                 .WithErrors(addProviderResult);
         }
 

--- a/Celbridge/Modules/Celbridge.HTML/Services/HTMLPreviewProvider.cs
+++ b/Celbridge/Modules/Celbridge.HTML/Services/HTMLPreviewProvider.cs
@@ -2,16 +2,10 @@ using Celbridge.Documents;
 
 namespace Celbridge.HTML.Services;
 
-public class HTMLPreviewProvider : IPreviewProvider
+public class HTMLPreviewProvider : IHTMLPreviewProvider
 {
-    private List<string> _supportedFileExtensions = new();
-    public IReadOnlyList<string> SupportedFileExtensions => _supportedFileExtensions;
-
     public HTMLPreviewProvider()
-    {
-        _supportedFileExtensions.Add(".html");
-        _supportedFileExtensions.Add(".scene");
-    }
+    {}
 
     public async Task<Result<string>> GeneratePreview(string text, IEditorPreview editorPreview)
     {

--- a/Celbridge/Modules/Celbridge.Markdown/Services/AsciiDocPreviewProvider.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Services/AsciiDocPreviewProvider.cs
@@ -4,15 +4,6 @@ namespace Celbridge.Markdown.Services;
 
 public class AsciiDocPreviewProvider : IPreviewProvider
 {
-    private List<string> _supportedFileExtensions = new();
-    public IReadOnlyList<string> SupportedFileExtensions => _supportedFileExtensions;
-
-
-    public AsciiDocPreviewProvider()
-    {
-        _supportedFileExtensions.Add(".adoc");
-    }
-
     public async Task<Result<string>> GeneratePreview(string text, IEditorPreview editorPreview)
     {
         // Todo: Refactor this - I'm using the AsciiDoctor.js library in the preview webview to do the conversion.

--- a/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
@@ -33,7 +33,7 @@ public class MarkdownActivity : IActivity
     {
         // Register the Markdown preview provider
         var markdownProvider = _serviceProvider.AcquireService<MarkdownPreviewProvider>();
-        var addMarkdownResult = _documentsService.AddPreviewProvider(markdownProvider);
+        var addMarkdownResult = _documentsService.AddPreviewProvider(".md", markdownProvider);
         if (addMarkdownResult.IsFailure)
         {
             return Result.Fail("Failed to add Markdown preview provider.")
@@ -42,7 +42,7 @@ public class MarkdownActivity : IActivity
 
         // Register the AsciiDoc preview provider
         var asciiDocProvider = _serviceProvider.AcquireService<AsciiDocPreviewProvider>();
-        var addAsciiDocResult = _documentsService.AddPreviewProvider(asciiDocProvider);
+        var addAsciiDocResult = _documentsService.AddPreviewProvider(".adoc", asciiDocProvider);
         if (addAsciiDocResult.IsFailure)
         {
             return Result.Fail("Failed to add Asciidoc preview provider.")

--- a/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownPreviewProvider.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownPreviewProvider.cs
@@ -6,14 +6,6 @@ namespace Celbridge.Markdown.Services;
 
 public class MarkdownPreviewProvider : IPreviewProvider
 {
-    private List<string> _supportedFileExtensions = new();
-    public IReadOnlyList<string> SupportedFileExtensions => _supportedFileExtensions;
-
-    public MarkdownPreviewProvider()
-    {
-        _supportedFileExtensions.Add(".md");
-    }
-
     public async Task<Result<string>> GeneratePreview(string text, IEditorPreview editorPreview)
     {
         await Task.CompletedTask;


### PR DESCRIPTION
It is now the responsibility of the module that uses a preview provider to register it with the documents service using the required file extension. This decouples the module that implements a preview provider from client modules that want to make use of that provider.