### PR TITLE
Require user to resolve invalid dialogue key issues

### DIFF
--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -1,9 +1,22 @@
 [
   {
-    "element": "TextBox",
-    "header": "Dialogue Key",
-    "text": "/dialogueKey",
-    "isReadOnly": true
+    "element": "StackPanel",
+    "orientation": "Horizontal",
+    "children": [
+      {
+        "element": "TextBox",
+        "header": "Dialogue Key",
+        "text": "/dialogueKey",
+        "isReadOnly": true
+      },
+      {
+        "element": "Button",
+        "verticalAlignment": "Bottom",
+        "tooltip": "Assign a new dialogue key for this dialogue line",
+        "icon": "Refresh",
+        "buttonId": "UpdateDialogueKey"
+      }
+    ]
   },
   {
     "element": "ComboBox",

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -144,7 +144,9 @@ public class LineEditor : ComponentEditorBase
             return;
         }
 
-        // Get a new line id
+        // Assign a new line id
+
+        // Todo: If this is a player variant line then use the preceeding player line id
 
         // Build the set of line ids currently in use
         var activeLineIds = new HashSet<string>();

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -1,9 +1,11 @@
-using System.Text;
-using System.Text.Json;
 using Celbridge.Activities;
 using Celbridge.Entities;
+using Celbridge.Logging;
+using Celbridge.Screenplay.Models;
 using Celbridge.Screenplay.Services;
 using Celbridge.Workspace;
+using System.Text.Json;
+using System.Text;
 
 namespace Celbridge.Screenplay.Components;
 
@@ -20,11 +22,15 @@ public class LineEditor : ComponentEditorBase
     public const string ContextNotes = "/contextNotes";
     public const string Direction = "/direction";
 
+    private readonly ILogger<LineEditor> _logger;
     private readonly IEntityService _entityService;
     private readonly IActivityService _activityService;
 
-    public LineEditor(IWorkspaceWrapper workspaceWrapper)
+    public LineEditor(
+        ILogger<LineEditor> logger,
+        IWorkspaceWrapper workspaceWrapper)
     {
+        _logger = logger;
         _entityService = workspaceWrapper.WorkspaceService.EntityService;
         _activityService = workspaceWrapper.WorkspaceService.ActivityService;
     }
@@ -84,7 +90,7 @@ public class LineEditor : ComponentEditorBase
         // Get list of available characters to populate the Character combo box
         if (propertyPath == "/characterIds")
         {
-            var getCharactersResult = GetCharacterIds();
+            var getCharactersResult = GetCharactersAsJSON();
             if (getCharactersResult.IsFailure)
             {
                 return Result<string>.Fail($"Failed to get character ids")
@@ -106,141 +112,16 @@ public class LineEditor : ComponentEditorBase
         }
     }
 
-    private void UpdateDialogueKey()
+    private Result<string> GetCharactersAsJSON()
     {
-        var sceneResource = Component.Key.Resource;
-        var getComponentsResult = _entityService.GetComponents(sceneResource);
-        if (getComponentsResult.IsFailure)
-        {
-            throw new InvalidProgramException($"Failed to get components for resource: '{sceneResource}'");
-        }
-        var components = getComponentsResult.Value;
-
-        if (components.Count == 0)
-        {
-            return;
-        }
-
-        // Get the character id
-
-        var characterId = Component.GetString(CharacterId);
-        if (string.IsNullOrEmpty(characterId))
-        {
-            // Todo: Log error
-            return;
-        }
-
-        // Get the namespace from the Scene component
-
-        if (components[0].Schema.ComponentType != SceneEditor.ComponentType)
-        {
-            throw new InvalidProgramException($"First component is not a Scene component");
-        }
-
-        var @namespace = components[0].GetString(SceneEditor.Namespace);
-        if (string.IsNullOrEmpty(@namespace))
-        {
-            // Todo: Log error
-            return;
-        }
-
-        // Assign a new line id
-
-        // Todo: If this is a player variant line then use the preceeding player line id
-
-        // Build the set of line ids currently in use
-        var activeLineIds = new HashSet<string>();
-        foreach (var component in components)
-        {
-            if (component.Schema.ComponentType != ComponentType)
-            {
-                // Skip non-line components
-                continue;
-            }
-
-            // Get the dialogue key property
-            var dialogueKey = component.GetString(DialogueKey);
-            if (string.IsNullOrEmpty(dialogueKey))
-            {
-                // Skip empty dialogue keys
-                continue;
-            }
-
-            var lineId = string.Empty;
-            var segments = dialogueKey.Split('-');
-            if (segments.Length == 3)
-            {
-                lineId = segments[2];
-            }
-
-            if (!string.IsNullOrEmpty(lineId))
-            {
-                activeLineIds.Add(lineId);
-            }
-        }
-
-        // Find a new line id that is not already in use
-        string newLineId;
-        var random = new Random();
-        do
-        {
-            // Try a random 4 digit hex code until a unique one is found.
-            int number = random.Next(0x1000, 0x10000);
-            newLineId = number.ToString("X4");
-        }
-        while (activeLineIds.Contains(newLineId));
-
-        if (string.IsNullOrEmpty(newLineId))
-        {
-            // Todo: Log error
-            return;
-        }
-
-        // Set the new dialogue key
-        var newDialogueKey = $"{characterId}-{@namespace}-{newLineId}";
-        var jsonValue = JsonSerializer.Serialize(newDialogueKey);
-        Component.SetProperty(DialogueKey, jsonValue);
-    }
-
-    private Result<string> GetCharacterIds()
-    {
-        // Get the scene component on this entity
-        var sceneComponentKey = new ComponentKey(Component.Key.Resource, 0);
-        var getComponentResult = _entityService.GetComponent(sceneComponentKey);
-        if (getComponentResult.IsFailure)
-        {
-            return Result<string>.Fail($"Failed to get scene component: '{sceneComponentKey}'")
-                .WithErrors(getComponentResult);
-        }
-        var sceneComponent = getComponentResult.Value;
-
-        // Check the component is a scene component
-        if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
-        {
-            return Result<string>.Fail($"Primary component is not a Scene component");
-        }
-
-        // Get the dialogue file resource from the scene component
-        ResourceKey excelFileResource = sceneComponent.GetString("/dialogueFile");
-        if (string.IsNullOrEmpty(excelFileResource))
-        {
-            return Result<string>.Fail($"Failed to get dialogue file property");
-        }
-
-        var activityResult = _activityService.GetActivity(nameof(ScreenplayActivity));
-        if (activityResult.IsFailure || 
-            activityResult.Value is not ScreenplayActivity screenplayActivity)
-        {
-            return Result<string>.Fail($"Failed to get Screenplay activity");
-        }
-
-        var charactersResult = screenplayActivity.GetCharacters(Component.Key.Resource);
-        if (charactersResult.IsFailure)
+        // Get the list of characters
+        var getCharactersResult = GetCharacters();
+        if (getCharactersResult.IsFailure)
         {
             return Result<string>.Fail($"Failed to get characters")
-                .WithErrors(charactersResult);
+                .WithErrors(getCharactersResult);
         }
-        var characters = charactersResult.Value;
+        var characters = getCharactersResult.Value;
 
         // Build a list of character ids
         var characterIds = new List<string>();
@@ -250,10 +131,196 @@ public class LineEditor : ComponentEditorBase
             characterIds.Add(characterId);
         }
 
-        // Convert the character list to JSON so we can return it as a component property
+        // Convert the character id list to JSON so we can return it as a component property
         var characterIdsJson = JsonSerializer.Serialize(characterIds);
 
         return Result<string>.Ok(characterIdsJson);
+    }
+
+    private Result<List<Character>> GetCharacters()
+    {
+        // Get the scene component on this entity
+        var sceneComponentKey = new ComponentKey(Component.Key.Resource, 0);
+        var getComponentResult = _entityService.GetComponent(sceneComponentKey);
+        if (getComponentResult.IsFailure)
+        {
+            return Result<List<Character>>.Fail($"Failed to get scene component: '{sceneComponentKey}'")
+                .WithErrors(getComponentResult);
+        }
+        var sceneComponent = getComponentResult.Value;
+        if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
+        {
+            return Result<List<Character>>.Fail($"Root component is not a Scene component");
+        }
+
+        // Get the dialogue file resource from the scene component
+        ResourceKey excelFileResource = sceneComponent.GetString("/dialogueFile");
+        if (string.IsNullOrEmpty(excelFileResource))
+        {
+            return Result<List<Character>>.Fail($"Failed to get dialogue file property");
+        }
+
+        var activityResult = _activityService.GetActivity(nameof(ScreenplayActivity));
+        if (activityResult.IsFailure ||
+            activityResult.Value is not ScreenplayActivity screenplayActivity)
+        {
+            return Result<List<Character>>.Fail($"Failed to get Screenplay activity");
+        }
+
+        var charactersResult = screenplayActivity.GetCharacters(Component.Key.Resource);
+        if (charactersResult.IsFailure)
+        {
+            return Result<List<Character>>.Fail($"Failed to get characters")
+                .WithErrors(charactersResult);
+        }
+        var characters = charactersResult.Value;
+
+        return Result<List<Character>>.Ok(characters);
+    }
+
+    private void UpdateDialogueKey()
+    {
+        //
+        // Get all components on this entity
+        //
+
+        var sceneResource = Component.Key.Resource;
+        var getComponentsResult = _entityService.GetComponents(sceneResource);
+        if (getComponentsResult.IsFailure)
+        {
+            _logger.LogError($"Failed to update dialogue key. {getComponentsResult.Error}");
+            return;
+        }
+        var components = getComponentsResult.Value;
+        if (components.Count == 0)
+        {
+            return;
+        }
+
+        //
+        // Get the list of characters from the screenplay
+        //
+
+        var getCharactersResult = GetCharacters();
+        if (getCharactersResult.IsFailure)
+        {
+            _logger.LogError($"Failed to update dialogue key. {getCharactersResult.Error}");
+            return;
+        }
+        var characters = getCharactersResult.Value;
+
+        //
+        // Get the character speaking this line
+        //
+
+        var characterId = Component.GetString(CharacterId);
+        if (string.IsNullOrEmpty(characterId))
+        {
+            _logger.LogError($"Failed to update dialogue key. Character id is empty.");
+            return;
+        }
+        var speakingCharacter = characters.FirstOrDefault(c => c.CharacterId == characterId);
+        if (speakingCharacter is null)
+        {
+            _logger.LogError($"Failed to update dialogue key. No character matching '{characterId}' was found.");
+            return;
+        }
+
+        // Note if the current line is a player variant line
+        bool isPlayerVariant = speakingCharacter.Tag.StartsWith("Character.Player.");
+
+        //
+        // Get the namespace from the Scene component on this entity
+        //
+
+        if (components[0].Schema.ComponentType != SceneEditor.ComponentType)
+        {
+            _logger.LogError($"Failed to update dialogue key. First component is not a Scene component.");
+            return;
+        }
+
+        var @namespace = components[0].GetString(SceneEditor.Namespace);
+        if (string.IsNullOrEmpty(@namespace))
+        {
+            _logger.LogError($"Failed to update dialogue key. Namespace is empty.");
+            return;
+        }
+
+        //
+        // Assign a new line id
+        //
+
+        // Build the set of line ids currently in use
+        var activeLineIds = new HashSet<string>();
+
+        var lineComponentIndex = Component.Key.ComponentIndex;
+        var playerLineId = string.Empty;
+
+        for (int i = 0; i < components.Count; i++)
+        {
+            var lineComponent = components[i];
+            if (lineComponent.Schema.ComponentType != ComponentType)
+            {
+                // Skip non-line components
+                continue;
+            }
+
+            // Get the dialogue key property
+            var dialogueKey = lineComponent.GetString(DialogueKey);
+            if (string.IsNullOrEmpty(dialogueKey))
+            {
+                // Skip empty dialogue keys
+                continue;
+            }
+
+            // Extract the line id from the dialogue key and add it to the active set
+            var lineId = string.Empty;
+            var segments = dialogueKey.Split('-');
+            if (segments.Length == 3)
+            {
+                lineId = segments[2];
+            }
+            if (!string.IsNullOrEmpty(lineId))
+            {
+                activeLineIds.Add(lineId);
+            }
+
+            // If this is a player variant line, attempt to find a preceding player line id.
+            if (isPlayerVariant &&
+                i < lineComponentIndex)
+            {
+                if (lineComponent.GetString(CharacterId) == "Player")
+                {
+                    playerLineId = lineId;
+                }
+            }
+        }
+
+        // If this is a player variant line and a player line id was found, then use the player line id.
+        string newLineId = string.Empty;
+        if (isPlayerVariant)
+        {
+            newLineId = playerLineId;
+        }
+
+        // If no new line id has been assigned yet then assign a unique line id
+        if (string.IsNullOrEmpty(newLineId))
+        {
+            // Find a new line id that is not already in use
+            var random = new Random();
+            do
+            {
+                // Try a random 4 digit hex code until a unique one is found.
+                int number = random.Next(0x1000, 0x10000);
+                newLineId = number.ToString("X4");
+            }
+            while (activeLineIds.Contains(newLineId));
+        }
+
+        // Set the new dialogue key
+        var newDialogueKey = $"{characterId}-{@namespace}-{newLineId}";
+        var jsonValue = JsonSerializer.Serialize(newDialogueKey);
+        Component.SetProperty(DialogueKey, jsonValue);
     }
 }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -241,6 +241,9 @@ public class ScreenplayActivity : IActivity
                     "Invalid dialogue key",
                     "Dialogue keys must be non-empty and contain 3 segments.");
                 entityAnnotation.AddError(i, error);
+
+                // Can't do any more checks until the user assigns a valid dialogue key
+                continue;
             }
 
             var lineId = segments[2];
@@ -284,7 +287,7 @@ public class ScreenplayActivity : IActivity
                 var error = new ComponentError(
                     ComponentErrorSeverity.Critical,
                     "Invalid dialogue key",
-                    "A dialogue key segment is not correct. Update the dialogue key.");
+                    "The dialogue key is not correctly formed. Update the dialogue key to assign a correct one.");
                 entityAnnotation.AddError(i, error);
             }
 
@@ -293,7 +296,7 @@ public class ScreenplayActivity : IActivity
                 var error = new ComponentError(
                     ComponentErrorSeverity.Critical,
                     "Duplicate dialogue key",
-                    "Dialogue keys must be unique for each line");
+                    "Dialogue keys must be unique for each line. Update the dialogue key to assign a new one.");
                 entityAnnotation.AddError(i, error);
             }
             activeDialogueKeys.Add(dialogueKey);
@@ -368,7 +371,7 @@ public class ScreenplayActivity : IActivity
         // Check the component is a scene component
         if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
         {
-            return Result<List<Character>>.Fail($"Primary component of resource '{sceneResource}' is not a scene component");
+            return Result<List<Character>>.Fail($"Root component of resource '{sceneResource}' is not a scene component");
         }
 
         // Get the dialogue file resource from the scene component
@@ -497,7 +500,7 @@ public class ScreenplayActivity : IActivity
         sb.AppendLine("body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: transparent; }");
         sb.AppendLine(".screenplay { max-width: 800px; width: 100%; margin: 0 auto; }");
         sb.AppendLine(".page { max-width: 794px; margin: 0 auto; }");
-        sb.AppendLine(".scene { text-align: left; margin-bottom: 2em; font-weight: bold; }");
+        sb.AppendLine(".scene { text-align: left; margin-bottom: 2em; font-size: 2em; font-weight: bold; margin: 0 0 0.67em 0;}");
         sb.AppendLine(".scene-note { text-align: left; margin-bottom: 2em; font-style: italic; }");
         sb.AppendLine(".line { margin-bottom: 2em; text-align: center; }");
         sb.AppendLine(".character { display: block; font-weight: bold; text-transform: uppercase; margin-bottom: 0.5em; }");


### PR DESCRIPTION
It is now the user's responsibility to ensure that a valid dialogue key is assigned to each line. This approach is more robust in general, but it also allows for the case where an existing dialogue key is invalid in its current position, but the line could be moved  to a position where it would be valid, without having to change the dialogue key.
