### PR TITLE
Display screenplay save errors in the the ScreenplayData component editor

### DIFF
--- a/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentEditorBase.cs
@@ -255,7 +255,7 @@ public abstract class ComponentEditorBase : IComponentEditor
         var name = propertyPath.Substring(1);
         var propertyName = char.ToUpperInvariant(name[0]) + name.Substring(1);
 
-        // Search for a matching property (case sensitive)
+        // Search for a matching property on this class (case sensitive)
         var ownerType = this.GetType();
         var properties = ownerType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         var propertyInfo = properties.FirstOrDefault(prop =>

--- a/Celbridge/BaseLibrary/Entities/ComponentPropertyAttribute.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentPropertyAttribute.cs
@@ -1,0 +1,8 @@
+namespace Celbridge.Entities;
+
+/// <summary>
+/// Marks a component editor class property as bindable with a Form Data provider.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ComponentPropertyAttribute : Attribute
+{}

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/FormElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/FormElement.cs
@@ -1,7 +1,7 @@
-using System.ComponentModel;
-using System.Text.Json;
 using Celbridge.Forms;
 using Celbridge.UserInterface.Services.Forms;
+using System.ComponentModel;
+using System.Text.Json;
 
 namespace Celbridge.UserInterface.ViewModels.Forms;
 
@@ -17,7 +17,10 @@ public abstract partial class FormElement : ObservableObject
 
     private FrameworkElement? _frameworkElement;
 
+    [ObservableProperty]
+    private Visibility _visibility = Visibility.Visible;
     private PropertyBinder<string>? _visibilityBinder;
+
     private PropertyBinder<string>? _tooltipBinder;
 
     public Result<FrameworkElement> Create(JsonElement config, FormBuilder formBuilder)
@@ -108,11 +111,12 @@ public abstract partial class FormElement : ObservableObject
             if (configValue.IsBindingConfig())
             {
                 _visibilityBinder = PropertyBinder<string>.Create(frameworkElement, this)
+                    .Binding(UIElement.VisibilityProperty, BindingMode.OneWay, nameof(Visibility))
                     .Setter((value) =>
                     {
                         if (Enum.TryParse<Visibility>(value, out var visibility))
                         {
-                            frameworkElement.Visibility = visibility;
+                            Visibility = visibility;
                         }
                     });
 
@@ -290,11 +294,17 @@ public abstract partial class FormElement : ObservableObject
     }
 
     protected virtual void OnElementUnloaded()
-    {}
+    {
+        _visibilityBinder?.OnElementUnloaded();
+    }
 
     protected virtual void OnFormDataChanged(string propertyPath)
-    {}
+    {
+        _visibilityBinder?.OnFormDataChanged(propertyPath);
+    }
 
     protected virtual void OnMemberDataChanged(string propertyName)
-    {}
+    {
+        _visibilityBinder?.OnMemberDataChanged(propertyName);
+    }
 }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
@@ -58,6 +58,9 @@ public partial class TextBlockElement : FormElement
         // Apply element-specific config properties
         //
 
+        // Todo: Set this via a config property
+        textBlock.TextWrapping = TextWrapping.Wrap;
+
         var italicResult = ApplyItalicConfig(config, textBlock);
         if (italicResult.IsFailure)
         {

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
@@ -16,7 +16,23 @@
     "buttonId": "SaveScreenplay"
   },
   {
-    "element": "TextBlock",
-    "text": "/errorMessage"
+    "element": "StackPanel",
+    "orientation": "Vertical",
+    "horizontalAlignment": "Center",
+    "visibility": "/errorVisibility",
+    "children": [
+      {
+        "element": "TextBlock",
+        "text": "/errorMessage"
+      },
+      {
+        "element": "Button",
+        "horizontalAlignment": "Center",
+        "text": "Open scene",
+        "tooltip": "Open the scene document containing the error",
+        "icon": "OpenFile",
+        "buttonId": "OpenScene"
+      }
+    ]
   }
 ]

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
@@ -14,5 +14,9 @@
     "tooltip": "Save screenplay data to the Excel file",
     "icon": "Save",
     "buttonId": "SaveScreenplay"
+  },
+  {
+    "element": "TextBlock",
+    "text": "/testProperty"
   }
 ]

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/ScreenplayDataForm.json
@@ -17,6 +17,6 @@
   },
   {
     "element": "TextBlock",
-    "text": "/testProperty"
+    "text": "/errorMessage"
   }
 ]

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayDataEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayDataEditor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Celbridge.Commands;
 using Celbridge.Entities;
 using Celbridge.Screenplay.Commands;
@@ -12,6 +13,15 @@ public class ScreenplayDataEditor : ComponentEditorBase
     private const string _formPath = "Celbridge.Screenplay.Assets.Forms.ScreenplayDataForm.json";
 
     public const string ComponentType = "Screenplay.ScreenplayData";
+
+    [ComponentProperty]
+    public string TestProperty
+    {
+        get
+        {
+            return "Hi there";
+        }
+    }
 
     public ScreenplayDataEditor(ICommandService commandService)
     {

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayDataEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/ScreenplayDataEditor.cs
@@ -1,12 +1,15 @@
-using System.Text.Json.Serialization;
+using System.Text.Json;
 using Celbridge.Commands;
 using Celbridge.Entities;
+using Celbridge.Messaging;
 using Celbridge.Screenplay.Commands;
+using Celbridge.Screenplay.Services;
 
 namespace Celbridge.Screenplay.Components;
 
 public class ScreenplayDataEditor : ComponentEditorBase
 {
+    private IMessengerService _messengerService;
     private ICommandService _commandService;
 
     private const string _configPath = "Celbridge.Screenplay.Assets.Components.ScreenplayDataComponent.json";
@@ -15,16 +18,13 @@ public class ScreenplayDataEditor : ComponentEditorBase
     public const string ComponentType = "Screenplay.ScreenplayData";
 
     [ComponentProperty]
-    public string TestProperty
-    {
-        get
-        {
-            return "Hi there";
-        }
-    }
+    public string ErrorMessage { get; set; } = string.Empty;
 
-    public ScreenplayDataEditor(ICommandService commandService)
+    public ScreenplayDataEditor(
+        IMessengerService messengerService,
+        ICommandService commandService)
     {
+        _messengerService = messengerService;
         _commandService = commandService;
     }
 
@@ -43,8 +43,35 @@ public class ScreenplayDataEditor : ComponentEditorBase
         return new ComponentSummary(string.Empty, string.Empty);
     }
 
+    public override void OnFormLoaded()
+    {
+        base.OnFormLoaded();
+        _messengerService.Register<SaveScreenplayErrorMessage>(this, OnSaveScreenplayErrorMessage);
+    }
+
+    public override void OnFormUnloaded()
+    {
+        base.OnFormUnloaded();
+        _messengerService.Unregister<SaveScreenplayErrorMessage>(this);
+    }
+
+    private void OnSaveScreenplayErrorMessage(object recipient, SaveScreenplayErrorMessage message)
+    {
+        var sceneResource = message.SceneResource;
+        var sceneFile = Path.GetFileName(sceneResource);
+
+        var errorMessage = $"Save failed. Please fix all errors in '{sceneFile}' and try again.";
+
+        var json = JsonSerializer.Serialize(errorMessage);
+        SetProperty("/errorMessage", json);
+    }
+
     public override void OnButtonClicked(string buttonId)
     {
+        // Clear the error message
+        var json = JsonSerializer.Serialize(string.Empty);
+        SetProperty("/errorMessage", json);
+
         if (buttonId == "LoadScreenplay")
         {
             _commandService.Execute<LoadScreenplayCommand>(command =>

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayMessages.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayMessages.cs
@@ -1,0 +1,7 @@
+namespace Celbridge.Screenplay.Services;
+
+/// <summary>
+/// Message sent when an error is found while attempting to save a screenplay.
+/// </summary>
+/// <param name="SceneResource"></param>
+public record SaveScreenplayErrorMessage(ResourceKey SceneResource);

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayMessages.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayMessages.cs
@@ -3,5 +3,4 @@ namespace Celbridge.Screenplay.Services;
 /// <summary>
 /// Message sent when an error is found while attempting to save a screenplay.
 /// </summary>
-/// <param name="SceneResource"></param>
 public record SaveScreenplayErrorMessage(ResourceKey SceneResource);

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -20,7 +20,6 @@ public class ScreenplaySaver
     private const string PlayerVariantColor = "e3e3e3";
     private const string SceneNoteColor = "a8e6a3";
 
-    private readonly ILogger<ScreenplaySaver> _logger;
     private readonly IMessengerService _messengerService;
     private readonly IExplorerService _explorerService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
@@ -28,12 +27,10 @@ public class ScreenplaySaver
     private record SceneData(ResourceKey SceneResource, string Category, string Namespace, IComponentProxy SceneComponent, List<IComponentProxy> DialogueComponents);
 
     public ScreenplaySaver(
-        ILogger<ScreenplaySaver> logger,
         IMessengerService messengerService,
         IDialogService dialogService,
         IWorkspaceWrapper workspaceWrapper)
     {
-        _logger = logger;
         _messengerService = messengerService;
         _workspaceWrapper = workspaceWrapper;
         _explorerService = workspaceWrapper.WorkspaceService.ExplorerService;

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -39,10 +39,10 @@ public partial class ComponentListViewModel : InspectorViewModel
     private bool _showEntityError;
 
     [ObservableProperty]
-    private string _entityErrorDescription;
+    private string _entityErrorDescription = string.Empty;
 
     [ObservableProperty]
-    private string _entityErrorTooltip;
+    private string _entityErrorTooltip = string.Empty;
 
     // Code gen requires a parameterless constructor
     public ComponentListViewModel()


### PR DESCRIPTION
If any scene errors were found during screenplay saving, display the first error to the user in ScreenplayData component editor.
Display a button that opens the scene containing the error.
Bind the Visibility property of any Form UI element to a string component property.
Use reflection to bind to properties on the ComponentEditor class. These properties have the same lifetime scope as the ComponentEditor instance, so they are primarily useful for storing temporary state.
 