### PR TITLE
Change Line component to declare a LineType property

### DIFF
--- a/Celbridge/BaseLibrary/Entities/ComponentSchema.cs
+++ b/Celbridge/BaseLibrary/Entities/ComponentSchema.cs
@@ -8,35 +8,4 @@ public record ComponentSchema(
     int ComponentVersion, 
     IReadOnlySet<string> Tags,
     IReadOnlyDictionary<string, string> Attributes, 
-    IReadOnlyList<ComponentPropertyInfo> Properties)
-{
-    /// <summary>
-    /// Returns true if the component type has the specified tag.
-    /// Tags are defined at design time and are used to categorize component types.
-    /// </summary>
-    public bool HasTag(string tag) => Tags.Contains(tag);
-
-    /// <summary>
-    /// Gets a boolean attribute value.
-    /// Returns false if the attribute is not found or cannot be parsed.
-    /// </summary>
-    public bool GetBooleanAttribute(string attributeName) => Attributes.TryGetValue(attributeName, out var value) && bool.TryParse(value, out var result) && result;
-
-    /// <summary>
-    /// Gets a string attribute value.
-    /// Returns an empty string if the attribute is not found.
-    /// </summary>
-    public string GetStringAttribute(string attributeName) => Attributes.TryGetValue(attributeName, out var value) ? value : string.Empty;
-
-    /// <summary>
-    /// Gets an integer attribute value.
-    /// Returns 0 if the attribute is not found or cannot be parsed.
-    /// </summary>
-    public int GetIntAttribute(string attributeName) => Attributes.TryGetValue(attributeName, out var value) && int.TryParse(value, out var result) ? result : 0;
-
-    /// <summary>
-    /// Gets a double attribute value.
-    /// Returns 0 if the attribute is not found or cannot be parsed.
-    /// </summary>
-    public double GetDoubleAttribute(string attributeName) => Attributes.TryGetValue(attributeName, out var value) && double.TryParse(value, out var result) ? result : 0.0;
-}
+    IReadOnlyList<ComponentPropertyInfo> Properties);

--- a/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
@@ -30,6 +30,11 @@ public interface IComponentProxy
     ComponentSchema Schema { get; }
 
     /// <summary>
+    /// Returns a reader for querying the component schema.
+    /// </summary>
+    IComponentSchemaReader SchemaReader { get; }
+
+    /// <summary>
     /// Raised when a component property changes.
     /// </summary>
     event Action<string>? ComponentPropertyChanged;

--- a/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentProxy.cs
@@ -25,14 +25,14 @@ public interface IComponentProxy
     ComponentKey Key { get; }
 
     /// <summary>
-    /// Returns the schema of the component.
-    /// </summary>
-    ComponentSchema Schema { get; }
-
-    /// <summary>
-    /// Returns a reader for querying the component schema.
+    /// Returns a reader utility for querying the component schema.
     /// </summary>
     IComponentSchemaReader SchemaReader { get; }
+
+    /// <summary>
+    /// Returns true if the component is of the specified component type.
+    /// </summary>
+    bool IsComponentType(string componentType);
 
     /// <summary>
     /// Raised when a component property changes.

--- a/Celbridge/BaseLibrary/Entities/IComponentSchemaReader.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentSchemaReader.cs
@@ -1,0 +1,61 @@
+namespace Celbridge.Entities;
+
+/// <summary>
+/// A factory for creating component schema readers.
+/// </summary>
+public interface IComponentSchemaReaderFactory
+{
+    /// <summary>
+    /// Factory method for creating a component schema reader.
+    /// </summary>
+    IComponentSchemaReader Create(ComponentSchema schema);
+}
+
+/// <summary>
+/// A helper utility for reading component schema information.
+/// </summary>
+public interface IComponentSchemaReader
+{
+    /// <summary>
+    /// Returns true if the component type has the specified tag.
+    /// Tags are defined at design time and are used to categorize component types.
+    /// </summary>
+    bool HasTag(string tag);
+
+    Result<ComponentPropertyInfo> GetPropertyInfo(string propertyName);
+
+    /// <summary>
+    /// Gets a boolean attribute value at the specified property path.
+    /// If property name is empty, the entity attributes are searched.
+    /// Returns false if the attribute is not found or cannot be parsed.
+    /// </summary>
+    bool GetBooleanAttribute(string attributeName, string propertyName = "");
+
+    /// <summary>
+    /// Gets a string attribute value.
+    /// If property name is empty, the entity attributes are searched.
+    /// Returns an empty string if the attribute is not found.
+    /// </summary>
+    string GetStringAttribute(string attributeName, string propertyPath = "");
+
+    /// <summary>
+    /// Gets an integer attribute value.
+    /// If property name is empty, the entity attributes are searched.
+    /// Returns 0 if the attribute is not found or cannot be parsed.
+    /// </summary>    
+    int GetIntAttribute(string attributeName, string propertyPath = "");
+
+    /// <summary>
+    /// Gets a double attribute value.
+    /// If property name is empty, the entity attributes are searched.
+    /// Returns 0 if the attribute is not found or cannot be parsed.
+    /// </summary>
+    double GetDoubleAttribute(string attributeName, string propertyPath = "");
+
+    /// <summary>
+    /// Gets an JSON serialized object attribute value of type T.
+    /// If property name is empty, the entity attributes are searched.
+    /// </summary>
+    Result<T> GetObjectAttribute<T>(string attributeName, string propertyPath = "") where T : notnull;
+}
+

--- a/Celbridge/BaseLibrary/Entities/IComponentSchemaReader.cs
+++ b/Celbridge/BaseLibrary/Entities/IComponentSchemaReader.cs
@@ -17,44 +17,52 @@ public interface IComponentSchemaReaderFactory
 public interface IComponentSchemaReader
 {
     /// <summary>
-    /// Returns true if the component type has the specified tag.
+    /// Returns the schema of the component.
+    /// </summary>
+    ComponentSchema Schema { get; }
+
+    /// <summary>
+    /// Returns true if the component schema has the specified tag.
     /// Tags are defined at design time and are used to categorize component types.
     /// </summary>
     bool HasTag(string tag);
 
+    /// <summary>
+    /// Returns the property information for the specified property name
+    /// </summary>
     Result<ComponentPropertyInfo> GetPropertyInfo(string propertyName);
 
     /// <summary>
-    /// Gets a boolean attribute value at the specified property path.
-    /// If property name is empty, the entity attributes are searched.
+    /// Gets a boolean attribute value for the specified property name.
+    /// If property name is empty, the entity attributes are searched instead.
     /// Returns false if the attribute is not found or cannot be parsed.
     /// </summary>
     bool GetBooleanAttribute(string attributeName, string propertyName = "");
 
     /// <summary>
-    /// Gets a string attribute value.
-    /// If property name is empty, the entity attributes are searched.
+    /// Gets a string attribute value for the specified property name.
+    /// If property name is empty, the entity attributes are searched instead.
     /// Returns an empty string if the attribute is not found.
     /// </summary>
     string GetStringAttribute(string attributeName, string propertyPath = "");
 
     /// <summary>
-    /// Gets an integer attribute value.
-    /// If property name is empty, the entity attributes are searched.
+    /// Gets an integer attribute value for the specified property name.
+    /// If property name is empty, the entity attributes are searched instead.
     /// Returns 0 if the attribute is not found or cannot be parsed.
     /// </summary>    
     int GetIntAttribute(string attributeName, string propertyPath = "");
 
     /// <summary>
-    /// Gets a double attribute value.
-    /// If property name is empty, the entity attributes are searched.
+    /// Gets a double attribute value for the specified property name.
+    /// If property name is empty, the entity attributes are searched instead.
     /// Returns 0 if the attribute is not found or cannot be parsed.
     /// </summary>
     double GetDoubleAttribute(string attributeName, string propertyPath = "");
 
     /// <summary>
-    /// Gets an JSON serialized object attribute value of type T.
-    /// If property name is empty, the entity attributes are searched.
+    /// Gets an JSON serialized object attribute value of type T for the specified property name.
+    /// If property name is empty, the entity attributes are searched instead.
     /// </summary>
     Result<T> GetObjectAttribute<T>(string attributeName, string propertyPath = "") where T : notnull;
 }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ComboBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ComboBoxElement.cs
@@ -173,9 +173,8 @@ public partial class ComboBoxElement : FormElement
                 if (configValue.IsBindingConfig())
                 {
                     _valuesBinder = PropertyBinder<List<string>>.Create(comboBox, this)
-                        .Binding(ComboBox.ItemsSourceProperty,
-                            BindingMode.OneWay,
-                            nameof(Values))
+                        .Binding(ComboBox.ItemsSourceProperty, BindingMode.TwoWay, nameof(Values))
+                        .Getter(() => Values )
                         .Setter((value) =>
                         {
                             Values = value;
@@ -267,16 +266,19 @@ public partial class ComboBoxElement : FormElement
     {
         _isEnabledBinder?.OnFormDataChanged(propertyPath);
         _selectedValueBinder?.OnFormDataChanged(propertyPath);
+        _valuesBinder?.OnFormDataChanged(propertyPath);
     }
 
     protected override void OnMemberDataChanged(string propertyName)
     {
         _selectedValueBinder?.OnMemberDataChanged(propertyName);
+        _valuesBinder?.OnMemberDataChanged(propertyName);
     }
 
     protected override void OnElementUnloaded()
     {
         _isEnabledBinder?.OnElementUnloaded();
         _selectedValueBinder?.OnElementUnloaded();
+        _valuesBinder?.OnElementUnloaded();
     }
 }

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ComboBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/ComboBoxElement.cs
@@ -214,26 +214,16 @@ public partial class ComboBoxElement : FormElement
             }
             var component = componentEditor.Component;
 
-            // Acquire the property and check if it specifies enum values.
             var propertyPath = configValue.ToString();
-            var property = component.Schema.Properties.First((p) => propertyPath == $"/{p.PropertyName}");
-            if (property is null)
-            {
-                return Result.Fail($"Failed to acquire component property '{property}'");
-            }
 
-            if (property.Attributes.TryGetValue("enum", out var enumJson))
+            // Attempt to get enum values for the bound property.
+            var getEnumResult = component.SchemaReader.GetObjectAttribute<List<string>>("enum", propertyPath);
+            if (getEnumResult.IsSuccess)
             {
-                // The property specifies an enum attribute, so use the enum values as the ItemSource.
-                var enumValues = JsonSerializer.Deserialize<List<string>>(enumJson);
-                if (enumValues is null)
-                {
-                    return Result.Fail($"Failed to deserialize enum json");
-                }
-
+                var enumValues = getEnumResult.Value;
                 if (enumValues.Count != enumValues.Distinct().Count())
                 {
-                    return Result.Fail($"'selectedValues' property contains duplicate values");
+                    return Result.Fail($"'selectedValue' property contains duplicate enum values");
                 }
 
                 comboBox.ItemsSource = enumValues;

--- a/Celbridge/Modules/Celbridge.HTML/Services/HTMLActivity.cs
+++ b/Celbridge/Modules/Celbridge.HTML/Services/HTMLActivity.cs
@@ -78,7 +78,7 @@ public class HTMLActivity : IActivity
         //
 
         var sceneComponent = components[0];
-        if (sceneComponent.Schema.ComponentType == HTMLEditor.ComponentType)
+        if (sceneComponent.IsComponentType(HTMLEditor.ComponentType))
         {
             entityAnnotation.SetIsRecognized(0);
         }

--- a/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
+++ b/Celbridge/Modules/Celbridge.Markdown/Services/MarkdownActivity.cs
@@ -103,7 +103,7 @@ public class MarkdownActivity : IActivity
         //
 
         var rootComponent = components[0];
-        if (rootComponent.Schema.ComponentType == MarkdownEditor.ComponentType)
+        if (rootComponent.IsComponentType(MarkdownEditor.ComponentType))
         {
             entityAnnotation.SetIsRecognized(0);
         }

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
@@ -9,6 +9,10 @@
       "type": "string",
       "const": "Screenplay.Line#1"
     },
+    "lineType": {
+      "type": "string",
+      "enum": ["NPC", "Player", "PlayerVariant", "SceneNote" ]
+    },
     "dialogueKey": {
       "type": "string"
     },
@@ -49,6 +53,7 @@
 
   "required": [
     "_type",
+    "lineType",
     "dialogueKey",
     "characterId",
     "sourceText",
@@ -64,6 +69,7 @@
   ],
 
   "prototype": {
+    "lineType": "NPC",
     "dialogueKey": "",
     "characterId": "",
     "sourceText": "",
@@ -75,6 +81,6 @@
     "direction": "",
     "platform": "",
     "soundProcessing": "",
-    "productionStatus": ""
+    "productionStatus": "Placeholder"
   }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
@@ -11,7 +11,7 @@
     },
     "lineType": {
       "type": "string",
-      "enum": ["NPC", "Player", "PlayerVariant", "SceneNote" ]
+      "enum": [ "Player", "PlayerVariant", "NPC", "SceneNote" ]
     },
     "dialogueKey": {
       "type": "string"
@@ -69,12 +69,12 @@
   ],
 
   "prototype": {
-    "lineType": "NPC",
+    "lineType": "Player",
     "dialogueKey": "",
-    "characterId": "",
+    "characterId": "Player",
     "sourceText": "",
     "contextNotes": "",
-    "linePriority": "",
+    "linePriority": "Default",
     "speakingTo": "",
     "gameArea": "",
     "timeConstraint": "",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -1,5 +1,10 @@
 [
   {
+    "element": "ComboBox",
+    "header": "Line Type",
+    "selectedValue": "/lineType"
+  },
+  {
     "element": "StackPanel",
     "orientation": "Horizontal",
     "children": [

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -38,42 +38,50 @@
   },
   {
     "element": "TextBox",
+    "visibility": "/variantVisibility",
     "header": "Speaking To",
     "text": "/speakingTo"
   },
   {
     "element": "TextBox",
+    "visibility": "/variantVisibility",
     "header": "Context Notes",
     "text": "/contextNotes"
   },
   {
     "element": "TextBox",
+    "visibility": "/directionVisibility",
     "header": "Direction",
     "text": "/direction"
   },
   {
     "element": "TextBox",
+    "visibility": "/variantVisibility",
     "header": "Time Constraint",
     "text": "/timeConstraint"
   },
   {
     "element": "TextBox",
+    "visibility": "/variantVisibility",
     "header": "Game Area",
     "text": "/gameArea"
   },
   {
     "element": "TextBox",
+    "visibility": "/variantVisibility",
     "header": "Platform",
     "text": "/platform"
   },
   {
     "element": "ComboBox",
+    "visibility": "/variantVisibility",
     "header": "Production Status",
     "values": [ "Placeholder", "ReadyForReview", "CutCandidate", "ReadyForVO", "ReadyForLoc", "Final" ],
     "selectedValue": "/productionStatus"
   },
   {
     "element": "ComboBox",
+    "visibility": "/variantVisibility",
     "header": "Line Priority",
     "values": [ "Default", "Effort", "AIChatter", "PlayerChatter", "HitReaction", "Death" ],
     "selectedValue": "/linePriority"

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -25,6 +25,7 @@
   },
   {
     "element": "ComboBox",
+    "visibility": "/characterIdVisibility",
     "header": "Character",
     "values": "/characterIds",
     "selectedValue": "/characterId"

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -268,7 +268,7 @@ public class LineEditor : ComponentEditorBase
                 .WithErrors(getComponentResult);
         }
         var sceneComponent = getComponentResult.Value;
-        if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
+        if (!sceneComponent.IsComponentType(SceneEditor.ComponentType))
         {
             return Result<List<Character>>.Fail($"Root component is not a Scene component");
         }
@@ -359,7 +359,7 @@ public class LineEditor : ComponentEditorBase
         // Get the namespace from the Scene component on this entity
         //
 
-        if (components[0].Schema.ComponentType != SceneEditor.ComponentType)
+        if (!components[0].IsComponentType(SceneEditor.ComponentType))
         {
             _logger.LogError($"Failed to update dialogue key. First component is not a Scene component.");
             return;
@@ -385,7 +385,7 @@ public class LineEditor : ComponentEditorBase
         for (int i = 0; i < components.Count; i++)
         {
             var lineComponent = components[i];
-            if (lineComponent.Schema.ComponentType != ComponentType)
+            if (!lineComponent.IsComponentType(ComponentType))
             {
                 // Skip non-line components
                 continue;

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -110,6 +110,24 @@ public class LineEditor : ComponentEditorBase
 
             return Result<string>.Ok(charactersJson);
         }
+        else if (propertyPath == "/characterIdVisibility")
+        {
+            var lineType = Component.GetString(LineEditor.LineType);
+            switch (lineType)
+            {
+                case "Player":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
+
+                case "PlayerVariant":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+
+                case "NPC":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+
+                case "SceneNote":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
+            }
+        }
 
         return Result<string>.Fail();
     }
@@ -128,6 +146,7 @@ public class LineEditor : ComponentEditorBase
         {
             // Update the character id list, filtered for the new line type
             NotifyFormPropertyChanged("/characterIds");
+            NotifyFormPropertyChanged("/characterIdVisibility");
 
             // Get the filtered list of character ids            
             var getResult = GetProperty("/characterIds");

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -112,18 +112,48 @@ public class LineEditor : ComponentEditorBase
         }
         else if (propertyPath == "/characterIdVisibility")
         {
+            // Determine visiblity for Character Id field
             var lineType = Component.GetString(LineEditor.LineType);
             switch (lineType)
             {
                 case "Player":
                     return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
-
                 case "PlayerVariant":
                     return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
-
                 case "NPC":
                     return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
-
+                case "SceneNote":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
+            }
+        }
+        else if (propertyPath == "/variantVisibility")
+        {
+            // Determine visiblity for several different fields
+            var lineType = Component.GetString(LineEditor.LineType);
+            switch (lineType)
+            {
+                case "Player":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+                case "PlayerVariant":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
+                case "NPC":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+                case "SceneNote":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
+            }
+        }
+        else if (propertyPath == "/directionVisibility")
+        {
+            // Determine visibility for Direction field
+            var lineType = Component.GetString(LineEditor.LineType);
+            switch (lineType)
+            {
+                case "Player":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+                case "PlayerVariant":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
+                case "NPC":
+                    return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Visible));
                 case "SceneNote":
                     return Result<string>.Ok(JsonSerializer.Serialize(Visibility.Collapsed));
             }
@@ -144,9 +174,12 @@ public class LineEditor : ComponentEditorBase
     { 
         if (propertyPath == "/lineType")
         {
-            // Update the character id list, filtered for the new line type
+            // Update virtual properties when the line type changes
+            // The character ids list will be filtered depending on the line type.
             NotifyFormPropertyChanged("/characterIds");
             NotifyFormPropertyChanged("/characterIdVisibility");
+            NotifyFormPropertyChanged("/variantVisibility");
+            NotifyFormPropertyChanged("/directionVisibility");
 
             // Get the filtered list of character ids            
             var getResult = GetProperty("/characterIds");

--- a/Celbridge/Modules/Celbridge.Screenplay/Models/DialogueLine.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Models/DialogueLine.cs
@@ -1,6 +1,7 @@
 namespace Celbridge.Screenplay.Models;
 
 public record DialogueLine(
+    string LineType,
     string Category,
     string Namespace,
     string DialogueKey,

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -109,7 +109,7 @@ public class ScreenplayActivity : IActivity
         //
 
         var sceneComponent = components[0];
-        if (sceneComponent.Schema.ComponentType == SceneEditor.ComponentType)
+        if (sceneComponent.IsComponentType(SceneEditor.ComponentType))
         {
             entityAnnotation.SetIsRecognized(0);
         }
@@ -158,13 +158,13 @@ public class ScreenplayActivity : IActivity
         {
             var component = components[i];
 
-            if (component.Schema.ComponentType == EntityConstants.EmptyComponentType)
+            if (component.IsComponentType(EntityConstants.EmptyComponentType))
             {
                 // Skip empty components
                 continue;
             }
 
-            if (component.Schema.ComponentType != LineEditor.ComponentType)
+            if (!component.IsComponentType(LineEditor.ComponentType))
             {
                 entityAnnotation.AddComponentError(i, new AnnotationError(
                     AnnotationErrorSeverity.Error,
@@ -438,7 +438,7 @@ public class ScreenplayActivity : IActivity
         var sceneComponent = getComponentResult.Value;
 
         // Check the component is a scene component
-        if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
+        if (!sceneComponent.IsComponentType(SceneEditor.ComponentType))
         {
             return Result<List<Character>>.Fail($"Root component of resource '{sceneResource}' is not a scene component");
         }
@@ -533,7 +533,7 @@ public class ScreenplayActivity : IActivity
         var components = getComponentsResult.Value;
 
         if (components.Count == 0 ||
-            components[0].Schema.ComponentType != SceneEditor.ComponentType)
+            !components[0].IsComponentType(SceneEditor.ComponentType))
         {
             return Result<string>.Fail("Entity does not contain a Scene component");
         }
@@ -590,7 +590,7 @@ public class ScreenplayActivity : IActivity
 
         foreach (var component in components)
         {
-            if (component.Schema.ComponentType == LineEditor.ComponentType)
+            if (component.IsComponentType(LineEditor.ComponentType))
             {
                 // Add line to the screenplay
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -299,15 +299,6 @@ public class ScreenplayActivity : IActivity
                         // Flag this as a player variant line
                         isPlayerVariantLine = true;
                         correctLineId = playerLineId; // Variant lines must have the same line id as the player line
-
-                        // Speaking To property must match the player line
-                        if (speakingTo != playerSpeakingTo)
-                        {
-                            entityAnnotation.AddComponentError(i, new AnnotationError(
-                                AnnotationErrorSeverity.Error,
-                                "Invalid player variant line",
-                                "Player variant line 'Speaking To' value must exactly match the player line 'Speaking To' value"));
-                        }
                     }
                 }
                 else

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -636,20 +636,22 @@ public class ScreenplayActivity : IActivity
 
                 var directionText = WebUtility.HtmlEncode(component.GetString(LineEditor.Direction));
 
-                sb.AppendLine($"<div class=\"{lineClass}\">");
-                sb.AppendLine($"  <span class=\"character {colorClass}\">{displayCharacter}</span>");
-                if (!string.IsNullOrEmpty(directionText))
+                if (characterId == "SceneNote")
                 {
-                    sb.AppendLine($"  <span class=\"direction\">({directionText})</span>");
+                    // Add scene note to the screenplay
+                    sb.AppendLine($"<div class=\"scene-note\">{sourceText}</div>");
                 }
-                sb.AppendLine($"  <span class=\"dialogue\">{sourceText}</span>");
-                sb.AppendLine("</div>");
-            }
-            else if (component.Schema.ComponentType == EntityConstants.EmptyComponentType)
-            {
-                // Add scene note to the screenplay
-                var commentText = component.GetString("/comment");
-                sb.AppendLine($"<div class=\"scene-note\">{commentText}</div>");
+                else
+                {
+                    sb.AppendLine($"<div class=\"{lineClass}\">");
+                    sb.AppendLine($"  <span class=\"character {colorClass}\">{displayCharacter}</span>");
+                    if (!string.IsNullOrEmpty(directionText))
+                    {
+                        sb.AppendLine($"  <span class=\"direction\">({directionText})</span>");
+                    }
+                    sb.AppendLine($"  <span class=\"dialogue\">{sourceText}</span>");
+                    sb.AppendLine("</div>");
+                }
             }
         }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
@@ -600,11 +600,23 @@ public class ScreenplayLoader
             {
                 if (line.CharacterId == "SceneNote")
                 {
-                    var emptyComponent = new JsonObject();
-                    emptyComponent["_type"] = ".Empty#1";
-                    emptyComponent["comment"] = line.SourceText;
+                    var lineComponent = new JsonObject();
+                    lineComponent["_type"] = "Screenplay.Line#1";
+                    lineComponent["lineType"] = line.LineType;
+                    lineComponent["dialogueKey"] = line.DialogueKey;
+                    lineComponent["characterId"] = line.CharacterId;
+                    lineComponent["speakingTo"] = string.Empty;
+                    lineComponent["sourceText"] = line.SourceText;
+                    lineComponent["contextNotes"] = string.Empty;
+                    lineComponent["direction"] = string.Empty;
+                    lineComponent["gameArea"] = string.Empty;
+                    lineComponent["timeConstraint"] = string.Empty;
+                    lineComponent["soundProcessing"] = string.Empty;
+                    lineComponent["platform"] = string.Empty;
+                    lineComponent["linePriority"] = string.Empty;
+                    lineComponent["productionStatus"] = string.Empty;
 
-                    components.Add(emptyComponent);
+                    components.Add(lineComponent);
                 }
                 else
                 {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
@@ -573,6 +573,7 @@ public class ScreenplayLoader
                 {
                     var lineComponent = new JsonObject();
                     lineComponent["_type"] = "Screenplay.Line#1";
+                    lineComponent["lineType"] = "NPC"; // Todo: Use correct type
                     lineComponent["dialogueKey"] = line.DialogueKey;
                     lineComponent["characterId"] = line.CharacterId;
                     lineComponent["speakingTo"] = line.SpeakingTo;

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -175,7 +175,7 @@ public class ScreenplaySaver
             }
 
             var sceneComponent = components[0];
-            if (sceneComponent.Schema.ComponentType != SceneEditor.ComponentType)
+            if (!sceneComponent.IsComponentType(SceneEditor.ComponentType))
             {
                 return Result<List<SceneData>>.Fail($"Root component is not a Scene component for scene file '{sceneFile}'");
             }
@@ -195,7 +195,7 @@ public class ScreenplaySaver
             processedNamespaces.Add(ns);
 
             var dialogueComponents = components
-                .Where(c => c.Schema.ComponentType == LineEditor.ComponentType)
+                .Where(c => c.IsComponentType(LineEditor.ComponentType))
                 .ToList();
 
             var sceneData = new SceneData(sceneResource, category, ns, sceneComponent, dialogueComponents);
@@ -291,7 +291,7 @@ public class ScreenplaySaver
         sheet.Cell(row, 2).Value = ns;
         sheet.Cell(row, 2).Style.Fill.BackgroundColor = XLColor.FromHtml(nsColor);
 
-        if (component.Schema.ComponentType == LineEditor.ComponentType)
+        if (component.IsComponentType(LineEditor.ComponentType))
         {
             //
             // Acquire core line information

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -10,6 +10,19 @@ namespace Celbridge.Screenplay.Services;
 
 public class ScreenplaySaver
 {
+    private record PlayerLine()
+    {
+        public string LineId { get; init; } = string.Empty;
+        public string SpeakingTo { get; init; } = string.Empty;
+        public string ContextNotes { get; init; } = string.Empty;
+        public string GameArea { get; init; } = string.Empty;
+        public string TimeConstraint { get; init; } = string.Empty;
+        public string SoundProcessing { get; init; } = string.Empty;
+        public string Platform { get; init; } = string.Empty;
+        public string LinePriority { get; init; } = string.Empty;
+        public string ProductionStatus { get; init; } = string.Empty;
+    };
+
     private const string CinematicColor = "f6d6ad";
     private const string ConversationColor = "f4b6c2";
     private const string BarkColor = "ccc0da";
@@ -182,8 +195,7 @@ public class ScreenplaySaver
             processedNamespaces.Add(ns);
 
             var dialogueComponents = components
-                .Where(c => c.Schema.ComponentType == LineEditor.ComponentType ||
-                            c.Schema.ComponentType == EntityConstants.EmptyComponentType)
+                .Where(c => c.Schema.ComponentType == LineEditor.ComponentType)
                 .ToList();
 
             var sceneData = new SceneData(sceneResource, category, ns, sceneComponent, dialogueComponents);
@@ -235,13 +247,14 @@ public class ScreenplaySaver
             var categoryColor = GetCategoryColor(sceneData.Category);
             var nsColor = namespaceIndex++ % 2 == 1 ? NamespaceColorA : NamespaceColorB;
 
-            var playerLineId = string.Empty;
+            PlayerLine? playerLine = null;
+
             int sceneNoteIndex = 1;
 
             foreach (var dialogue in sceneData.DialogueComponents)
             {
                 // playerLineId and sceneNoteIndex may be modified when we write a row
-                WriteDialogueRow(
+                var writeResult = WriteDialogueRow(
                     editedSheet, 
                     rowIndex, 
                     sceneData.
@@ -250,8 +263,13 @@ public class ScreenplaySaver
                     categoryColor, 
                     nsColor, 
                     dialogue, 
-                    ref playerLineId, 
+                    ref playerLine, // Use the returned player line (if any) on the next iteration
                     ref sceneNoteIndex);
+
+                if (writeResult.IsFailure)
+                {
+                    return Result.Fail($"Failed to write dialogue row {rowIndex}");
+                }
 
                 rowIndex++;
             }
@@ -265,7 +283,7 @@ public class ScreenplaySaver
         return Result.Ok();
     }
 
-    private void WriteDialogueRow(IXLWorksheet sheet, int row, string category, string ns, string categoryColor, string nsColor, IComponentProxy component, ref string playerLineId, ref int sceneNoteIndex)
+    private Result WriteDialogueRow(IXLWorksheet sheet, int row, string category, string ns, string categoryColor, string nsColor, IComponentProxy component, ref PlayerLine? playerLine, ref int sceneNoteIndex)
     {
         sheet.Cell(row, 1).Value = category;
         sheet.Cell(row, 1).Style.Fill.BackgroundColor = XLColor.FromHtml(categoryColor);
@@ -275,57 +293,122 @@ public class ScreenplaySaver
 
         if (component.Schema.ComponentType == LineEditor.ComponentType)
         {
-            var characterId = component.GetString(LineEditor.CharacterId);
+            //
+            // Acquire core line information
+            //
+
+            var lineType = component.GetString(LineEditor.LineType);
             var dialogueKey = component.GetString(LineEditor.DialogueKey);
-            var lineId = dialogueKey[(dialogueKey.LastIndexOf('-') + 1)..];
-
-            sheet.Cell(row, 3).Value = dialogueKey;
-            sheet.Cell(row, 4).Value = characterId;
-
-            if (characterId == "Player")
-            {
-                playerLineId = lineId;
-                FillCells(sheet, row, new[] { 3, 4 }, PlayerColor);
-            }
-            else if (lineId == playerLineId)
-            {
-                FillCells(sheet, row, new[] { 3, 4 }, PlayerVariantColor);
-            }
-            else
-            {
-                playerLineId = string.Empty;
-            }
-
+            var characterId = component.GetString(LineEditor.CharacterId);
             var sourceText = component.GetString(LineEditor.SourceText);
+            var speakingTo = component.GetString(LineEditor.SpeakingTo);
+            var contextNotes = component.GetString(LineEditor.ContextNotes);
+            var direction = component.GetString(LineEditor.Direction);
+            var gameArea = component.GetString(LineEditor.GameArea);
+            var timeConstraint = component.GetString(LineEditor.TimeConstraint);
+            var soundProcessing = component.GetString(LineEditor.SoundProcessing);
+            var platform = component.GetString(LineEditor.Platform);
+            var linePriority = component.GetString(LineEditor.LinePriority);
+            var productionStatus = component.GetString(LineEditor.ProductionStatus);
+
+            var lineId = dialogueKey[(dialogueKey.LastIndexOf('-') + 1)..];
+            var isSceneNote = false;
+
+            // Excel uses a single apostrophe to indicate raw text.
+            // This causes problems if the first word in a sentence is a contraction, e.g. 'Fraid so.
+            // Todo: Should we do this for all free text entry fields?
             if (sourceText.StartsWith("'") && !sourceText.StartsWith("''"))
             {
+                // Escape single leading apostrophes by replacing with double apostrophes.
                 sourceText = $"'{sourceText}";
             }
 
-            sheet.Cell(row, 5).Value = component.GetString(LineEditor.SpeakingTo);
+            //
+            // Handle different Line Types
+            //
+
+            if (lineType == "Player")
+            {
+                // Start a new player line
+                // Record the properties to be copied for player variant lines
+                playerLine = new PlayerLine()
+                {
+                    LineId = lineId,
+                    SpeakingTo = speakingTo,
+                    ContextNotes = contextNotes,
+                    GameArea = gameArea,
+                    TimeConstraint = timeConstraint,
+                    SoundProcessing = soundProcessing,
+                    Platform = platform,
+                    LinePriority = linePriority,
+                    ProductionStatus = productionStatus
+                };
+
+                FillCells(sheet, row, new[] { 3, 4 }, PlayerColor);
+            }
+            else if (lineType == "PlayerVariant")
+            {
+                Guard.IsNotNull(playerLine);
+                    
+                // For Player Variant lines these fields all duplication the parent Player Line
+                lineId = playerLine.LineId;
+                speakingTo = playerLine.SpeakingTo;
+                contextNotes = playerLine.ContextNotes;
+                gameArea = playerLine.GameArea;
+                timeConstraint = playerLine.TimeConstraint;
+                soundProcessing = playerLine.SoundProcessing;
+                platform = playerLine.Platform;
+                linePriority = playerLine.LinePriority;
+                productionStatus = playerLine.ProductionStatus;
+
+                dialogueKey = $"{characterId}-{ns}-{lineId}";
+
+                FillCells(sheet, row, new[] { 3, 4 }, PlayerVariantColor);
+            }
+            else if (lineType == "SceneNote")
+            {
+                playerLine = null;
+
+                isSceneNote = true;
+                characterId = "SceneNote";
+
+                // Override the dialogue key for scene notes
+                // Todo: Do we still need to do this? Could we just treat them as regular dialogue lines now?
+                dialogueKey = $"SceneNote-{ns}-Note{sceneNoteIndex++}";
+                FillCells(sheet, row, Enumerable.Range(3, 12), SceneNoteColor);
+            }
+            else if (lineType == "NPC")
+            {
+                playerLine = null;
+            }
+            else
+            {
+                return Result.Fail($"Invalid line type '{lineType}'");
+            }
+
+            //
+            // Populate the spreadsheet
+            //
+
+            sheet.Cell(row, 3).Value = dialogueKey;
+            sheet.Cell(row, 4).Value = characterId;
             sheet.Cell(row, 6).Value = sourceText;
-            sheet.Cell(row, 7).Value = component.GetString(LineEditor.ContextNotes);
-            sheet.Cell(row, 8).Value = component.GetString(LineEditor.Direction);
-            sheet.Cell(row, 9).Value = component.GetString(LineEditor.GameArea);
-            sheet.Cell(row, 10).Value = component.GetString(LineEditor.TimeConstraint);
-            sheet.Cell(row, 11).Value = component.GetString(LineEditor.SoundProcessing);
-            sheet.Cell(row, 12).Value = component.GetString(LineEditor.Platform);
-            sheet.Cell(row, 13).Value = component.GetString(LineEditor.LinePriority);
-            sheet.Cell(row, 14).Value = component.GetString(LineEditor.ProductionStatus);
+
+            if (!isSceneNote)
+            {
+                sheet.Cell(row, 5).Value = speakingTo;
+                sheet.Cell(row, 7).Value = contextNotes;
+                sheet.Cell(row, 8).Value = direction;
+                sheet.Cell(row, 9).Value = gameArea;
+                sheet.Cell(row, 10).Value = timeConstraint;
+                sheet.Cell(row, 11).Value = soundProcessing;
+                sheet.Cell(row, 12).Value = platform;
+                sheet.Cell(row, 13).Value = linePriority;
+                sheet.Cell(row, 14).Value = productionStatus;
+            }
         }
-        else if (component.Schema.ComponentType == EntityConstants.EmptyComponentType)
-        {
-            var commentText = component.GetString("/comment");
-            var noteKey = $"SceneNote-{ns}-Note{sceneNoteIndex++}";
 
-            sheet.Cell(row, 3).Value = noteKey;
-            sheet.Cell(row, 4).Value = "SceneNote";
-            sheet.Cell(row, 6).Value = commentText;
-
-            FillCells(sheet, row, Enumerable.Range(3, 12), SceneNoteColor);
-
-            playerLineId = string.Empty;
-        }
+        return Result.Ok();
     }
 
     private void AppendBarkDialogue(IXLWorksheet originalSheet, IXLWorksheet targetSheet, int startRow)

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -10,6 +10,8 @@ namespace Celbridge.Screenplay.Services;
 
 public class ScreenplaySaver
 {
+    // Stores the properties from a Player line so that they can be propogated to the 
+    // following PlayerVariant lines.
     private record PlayerLine()
     {
         public string LineId { get; init; } = string.Empty;
@@ -294,7 +296,7 @@ public class ScreenplaySaver
         if (component.IsComponentType(LineEditor.ComponentType))
         {
             //
-            // Acquire core line information
+            // Acquire line properties from the Line component
             //
 
             var lineType = component.GetString(LineEditor.LineType);
@@ -350,7 +352,7 @@ public class ScreenplaySaver
             {
                 Guard.IsNotNull(playerLine);
                     
-                // For Player Variant lines these fields all duplication the parent Player Line
+                // For Player Variant lines these fields should all match the parent Player Line
                 lineId = playerLine.LineId;
                 speakingTo = playerLine.SpeakingTo;
                 contextNotes = playerLine.ContextNotes;

--- a/Celbridge/Modules/Celbridge.Spreadsheet/Services/SpreadsheetActivity.cs
+++ b/Celbridge/Modules/Celbridge.Spreadsheet/Services/SpreadsheetActivity.cs
@@ -115,7 +115,7 @@ public class SpreadsheetActivity : IActivity
                 continue;
             }
 
-            var isSpreadsheetComponent = component.Schema.GetBooleanAttribute("isSpreadsheetComponent");
+            var isSpreadsheetComponent = component.SchemaReader.GetBooleanAttribute("isSpreadsheetComponent");
 
             if (isSpreadsheetComponent)
             {

--- a/Celbridge/Modules/Celbridge.Spreadsheet/Services/SpreadsheetActivity.cs
+++ b/Celbridge/Modules/Celbridge.Spreadsheet/Services/SpreadsheetActivity.cs
@@ -89,7 +89,7 @@ public class SpreadsheetActivity : IActivity
         //
 
         var rootComponent = components[0];
-        if (rootComponent.Schema.ComponentType == SpreadsheetEditor.ComponentType)
+        if (rootComponent.IsComponentType(SpreadsheetEditor.ComponentType))
         {
             entityAnnotation.SetIsRecognized(0);
         }
@@ -109,7 +109,7 @@ public class SpreadsheetActivity : IActivity
         {
             var component = components[i];
 
-            if (component.Schema.ComponentType == EntityConstants.EmptyComponentType)
+            if (component.IsComponentType(EntityConstants.EmptyComponentType))
             {
                 // Skip empty components
                 continue;

--- a/Celbridge/Workspace/Celbridge.Activities/Services/ActivityService.cs
+++ b/Celbridge/Workspace/Celbridge.Activities/Services/ActivityService.cs
@@ -115,7 +115,7 @@ public class ActivityService : IActivityService, IDisposable
         {
             // Empty components are always valid in any position.
             var component = components[i];
-            if (component.Schema.ComponentType == EntityConstants.EmptyComponentType)
+            if (component.IsComponentType(EntityConstants.EmptyComponentType))
             {
                 entityAnnotation.SetIsRecognized(i);
             }
@@ -145,7 +145,7 @@ public class ActivityService : IActivityService, IDisposable
             for (int i = 0; i < components.Count; i++)
             {
                 var component = components[i];
-                if (component.Schema.ComponentType != EntityConstants.EmptyComponentType)
+                if (!component.IsComponentType(EntityConstants.EmptyComponentType))
                 {
                     entityAnnotation.AddComponentError(i, new AnnotationError(
                         AnnotationErrorSeverity.Critical,

--- a/Celbridge/Workspace/Celbridge.Activities/Services/ActivityService.cs
+++ b/Celbridge/Workspace/Celbridge.Activities/Services/ActivityService.cs
@@ -99,7 +99,7 @@ public class ActivityService : IActivityService, IDisposable
 
         // Get the root component and check that it has a "rootActivity" attribute
         var rootComponent = components[0];
-        var activityName = rootComponent.Schema.GetStringAttribute("rootActivity");
+        var activityName = rootComponent.SchemaReader.GetStringAttribute("rootActivity");
         if (string.IsNullOrEmpty(activityName))
         {
             hasValidRootComponent = false;
@@ -122,7 +122,7 @@ public class ActivityService : IActivityService, IDisposable
             else if (i > 0)
             {
                 // Check if this is a root component that's in the wrong position
-                var rootActivity = component.Schema.GetStringAttribute("rootActivity");
+                var rootActivity = component.SchemaReader.GetStringAttribute("rootActivity");
                 if (!string.IsNullOrEmpty(rootActivity))
                 {
                     hasValidRootComponent = false;

--- a/Celbridge/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/ViewModels/TextEditorDocumentViewModel.cs
@@ -114,7 +114,7 @@ public partial class TextEditorDocumentViewModel : ObservableObject
             {
                 var editor = getEditorResult.Value;
 
-                var isPreviewController = editor.Component.Schema.GetBooleanAttribute("isPreviewController");
+                var isPreviewController = editor.Component.SchemaReader.GetBooleanAttribute("isPreviewController");
                 if (isPreviewController)
                 {
                     var getPropertyResult = editor.GetProperty(DocumentConstants.EditorModeProperty);

--- a/Celbridge/Workspace/Celbridge.Entities/Models/ComponentProxy.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Models/ComponentProxy.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Celbridge.Entities.Services;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Workspace;
@@ -46,6 +45,11 @@ public class ComponentProxy : IComponentProxy
         SchemaReader = serviceProvider.GetRequiredService<IComponentSchemaReaderFactory>().Create(schema);
 
         _messengerService.Register<ComponentChangedMessage>(this, OnComponentChangedMessage);
+    }
+
+    public bool IsComponentType(string componentType)
+    {
+        return (SchemaReader.Schema.ComponentType == componentType);
     }
 
     // Property accessors

--- a/Celbridge/Workspace/Celbridge.Entities/Models/ComponentProxy.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Models/ComponentProxy.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Celbridge.Entities.Services;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Workspace;
@@ -18,7 +19,7 @@ public class ComponentProxy : IComponentProxy
     {
         get
         {
-            var rootActivity = Schema.GetStringAttribute("rootActivity");
+            var rootActivity = SchemaReader.GetStringAttribute("rootActivity");
             return !string.IsNullOrEmpty(rootActivity);
         }
     }
@@ -26,6 +27,8 @@ public class ComponentProxy : IComponentProxy
     public ComponentKey Key { get; }
 
     public ComponentSchema Schema { get; }
+
+    public IComponentSchemaReader SchemaReader { get; }
 
     public event Action<string>? ComponentPropertyChanged;
 
@@ -38,6 +41,9 @@ public class ComponentProxy : IComponentProxy
 
         Key = componentKey;
         Schema = schema;
+
+        // Create a schema reader for easier access to schema attributes
+        SchemaReader = serviceProvider.GetRequiredService<IComponentSchemaReaderFactory>().Create(schema);
 
         _messengerService.Register<ComponentChangedMessage>(this, OnComponentChangedMessage);
     }

--- a/Celbridge/Workspace/Celbridge.Entities/ServiceConfiguration.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/ServiceConfiguration.cs
@@ -18,6 +18,7 @@ public static class ServiceConfiguration
         services.AddTransient<EntityRegistry>();
         services.AddTransient<IEntityAnnotation, EntityAnnotation>();
         services.AddTransient<IComponentEditorHelper, ComponentEditorHelper>();
+        services.AddTransient<IComponentSchemaReaderFactory, ComponentSchemaReaderFactory>();
 
         //
         // Register commands

--- a/Celbridge/Workspace/Celbridge.Entities/Services/ComponentProxyService.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/ComponentProxyService.cs
@@ -164,7 +164,7 @@ public class ComponentProxyService
         }
 
         // Return only the components of the specified type
-        var filtered = components.Where(c => c.Schema.ComponentType == componentType).ToList();
+        var filtered = components.Where(c => c.IsComponentType(componentType)).ToList();
         return Result<IReadOnlyList<IComponentProxy>>.Ok(filtered);
     }
 }

--- a/Celbridge/Workspace/Celbridge.Entities/Services/ComponentSchemaReader.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/ComponentSchemaReader.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+
+namespace Celbridge.Entities.Services;
+
+public class ComponentSchemaReaderFactory : IComponentSchemaReaderFactory
+{
+    public IComponentSchemaReader Create(ComponentSchema schema)
+    {
+        return new ComponentSchemaReader(schema);
+    }
+}
+
+public class ComponentSchemaReader : IComponentSchemaReader
+{
+    private readonly ComponentSchema _schema;
+
+    public ComponentSchemaReader(ComponentSchema schema)
+    {
+        _schema = schema;
+    }
+
+    public bool HasTag(string tag) => _schema.Tags.Contains(tag);
+
+    public Result<ComponentPropertyInfo> GetPropertyInfo(string propertyName)
+    {
+        var name = propertyName.TrimStart('/');
+        foreach (var property in _schema.Properties)
+        {
+            if (property.PropertyName.Equals(name, StringComparison.Ordinal))
+            {
+                return Result<ComponentPropertyInfo>.Ok(property);
+            }
+        }
+
+        return Result<ComponentPropertyInfo>.Fail();
+    }
+
+    public bool GetBooleanAttribute(string attributeName, string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return _schema.Attributes.TryGetValue(attributeName, out var attributeValue) && bool.TryParse(attributeValue, out var result) && result;
+        }
+
+        var getInfoResult = GetPropertyInfo(propertyName);
+        if (getInfoResult.IsFailure)
+        {
+            return false;
+        }
+        var propertyInfo = getInfoResult.Value;
+
+        if (propertyInfo.Attributes.TryGetValue(attributeName, out var propertyAttributeValue))
+        {
+            return bool.TryParse(propertyAttributeValue, out var result) && result;
+        }
+
+        return false;
+    }
+
+    public string GetStringAttribute(string attributeName, string propertyName)
+    {
+        var attributes = GetAttributes(propertyName);
+
+        if (attributes is not null &&
+            attributes.TryGetValue(attributeName, out var propertyAttributeValue))
+        {
+            return propertyAttributeValue;
+        }
+
+        return string.Empty;
+    }
+
+    public int GetIntAttribute(string attributeName, string propertyName)
+    {
+        var attributes = GetAttributes(propertyName);
+        if (attributes is null)
+        {
+            return 0;
+        }
+
+        return attributes.TryGetValue(attributeName, out var propertyValue) && int.TryParse(propertyValue, out var propertyIntValue) ? propertyIntValue : 0;
+    }
+
+    public double GetDoubleAttribute(string attributeName, string propertyName)
+    {
+        var attributes = GetAttributes(propertyName);
+        if (attributes is null)
+        {
+            return 0;
+        }
+
+        return attributes.TryGetValue(attributeName, out var propertyValue) && double.TryParse(propertyValue, out var propertyDoubleValue) ? propertyDoubleValue : 0;
+    }
+
+    public Result<T> GetObjectAttribute<T>(string attributeName, string propertyName) where T : notnull
+    {
+        var attributes = GetAttributes(propertyName);
+        if (attributes is null)
+        {
+            return Result<T>.Fail();
+        }
+
+        if (attributes.TryGetValue(attributeName, out var value))
+        {
+            try
+            {
+                var obj = JsonSerializer.Deserialize<T>(value);
+                if (obj is not null)
+                {
+                    return Result<T>.Ok(obj);
+                }
+            }
+            catch (JsonException ex)
+            {
+                return Result<T>.Fail($"Failed to deserialize object attribute: '{attributeName}'")
+                    .WithException(ex);
+            }
+        }
+
+        return Result<T>.Fail($"Failed to deserialize object attribute: '{attributeName}'");
+    }
+
+    private IReadOnlyDictionary<string, string>? GetAttributes(string propertyPath)
+    {
+        if (string.IsNullOrEmpty(propertyPath))
+        {
+            return _schema.Attributes;
+        }
+        else
+        {
+            var getInfoResult = GetPropertyInfo(propertyPath);
+            if (getInfoResult.IsFailure)
+            {
+                return null;
+            }
+            var propertyInfo = getInfoResult.Value;
+
+            return propertyInfo.Attributes;
+        }
+    }
+}

--- a/Celbridge/Workspace/Celbridge.Entities/Services/ComponentSchemaReader.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/ComponentSchemaReader.cs
@@ -12,19 +12,19 @@ public class ComponentSchemaReaderFactory : IComponentSchemaReaderFactory
 
 public class ComponentSchemaReader : IComponentSchemaReader
 {
-    private readonly ComponentSchema _schema;
+    public ComponentSchema Schema { get; init; }
 
     public ComponentSchemaReader(ComponentSchema schema)
     {
-        _schema = schema;
+        Schema = schema;
     }
 
-    public bool HasTag(string tag) => _schema.Tags.Contains(tag);
+    public bool HasTag(string tag) => Schema.Tags.Contains(tag);
 
     public Result<ComponentPropertyInfo> GetPropertyInfo(string propertyName)
     {
         var name = propertyName.TrimStart('/');
-        foreach (var property in _schema.Properties)
+        foreach (var property in Schema.Properties)
         {
             if (property.PropertyName.Equals(name, StringComparison.Ordinal))
             {
@@ -39,7 +39,7 @@ public class ComponentSchemaReader : IComponentSchemaReader
     {
         if (string.IsNullOrEmpty(propertyName))
         {
-            return _schema.Attributes.TryGetValue(attributeName, out var attributeValue) && bool.TryParse(attributeValue, out var result) && result;
+            return Schema.Attributes.TryGetValue(attributeName, out var attributeValue) && bool.TryParse(attributeValue, out var result) && result;
         }
 
         var getInfoResult = GetPropertyInfo(propertyName);
@@ -124,7 +124,7 @@ public class ComponentSchemaReader : IComponentSchemaReader
     {
         if (string.IsNullOrEmpty(propertyPath))
         {
-            return _schema.Attributes;
+            return Schema.Attributes;
         }
         else
         {

--- a/Celbridge/Workspace/Celbridge.Entities/Services/EntityService.cs
+++ b/Celbridge/Workspace/Celbridge.Entities/Services/EntityService.cs
@@ -635,7 +635,7 @@ public class EntityService : IEntityService, IDisposable
     public Result<IComponentEditor> CreateComponentEditor(IComponentProxy componentProxy)
     {
         // Acquire the config for this component
-        var componentType = componentProxy.Schema.ComponentType;
+        var componentType = componentProxy.SchemaReader.Schema.ComponentType;
         var getConfigResult = _configRegistry.GetComponentConfig(componentType);
         if (getConfigResult.IsFailure)
         {

--- a/Celbridge/Workspace/Celbridge.Inspector/Services/InspectorService.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Services/InspectorService.cs
@@ -90,7 +90,7 @@ public class InspectorService : IInspectorService, IDisposable
         Guard.IsNotNull(componentEditor.Component);
 
         // Get the form config from the component editor
-        var formName = componentEditor.Component.Schema.ComponentType;
+        var formName = componentEditor.Component.SchemaReader.Schema.ComponentType;
         var formConfig = componentEditor.GetComponentForm();
 
         // Create the form, using the component type as the form name for error reporting.

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentListViewModel.cs
@@ -429,7 +429,7 @@ public partial class ComponentListViewModel : InspectorViewModel
                         var formConfig = editor.GetComponentRootForm();
                         if (!string.IsNullOrEmpty(formConfig))
                         {
-                            var formName = editor.Component.Schema.ComponentType;
+                            var formName = editor.Component.SchemaReader.Schema.ComponentType;
                             var createResult = _formService.CreateForm(formName, formConfig, editor);
                             if (createResult.IsSuccess)
                             {

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentValueEditorViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentValueEditorViewModel.cs
@@ -127,7 +127,7 @@ public partial class ComponentValueEditorViewModel : ObservableObject
         var component = getComponentResult.Value;
 
         // Populate the Component Type in the panel header
-        ComponentType = component.Schema.ComponentType;
+        ComponentType = component.SchemaReader.Schema.ComponentType;
 
         // Acquire a ComponentEditor for this component
         var acquireEditorResult = _inspectorService.AcquireComponentEditor(componentKey);

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentValueEditorViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/ComponentValueEditorViewModel.cs
@@ -183,7 +183,7 @@ public partial class ComponentValueEditorViewModel : ObservableObject
             {
                 var entityAnnotation = getAnnotationResult.Value;
 
-                if (entityAnnotation.ComponentAnnotationCount >= componentKey.ComponentIndex)
+                if (componentKey.ComponentIndex < entityAnnotation.ComponentAnnotationCount)
                 {
                     var componentAnnotation = entityAnnotation.GetComponentAnnotation(componentKey.ComponentIndex);
 


### PR DESCRIPTION
The user assigns an explicit LineType for each Line in a scene. The LineType is used for import, export, validation, and filtering available fields in the inspector form. Also changed SceneNotes to use the "SceneNote" line type instead of the Empty component.

- Move schema query methods to new ComponentSchemaReader utility
- Add IComponentProxy.IsComponentType() convenience method
- Combo Box form element: Support two way binding values and property enums
- Add LineType property to Line component (Player, PlayerVariant, NPC, SceneNote)
- Set default properties for new Line components
- Hide irrelevant properties for PlayerVariant and SceneNote lines.
- Filter the available character id options based on the selected Line Type.
- Use LineType == SceneNote instead of Empty component to declare scene notes
- Update ScreenplayLoader and ScreenplaySaver to work with new component layout
