### PR TITLE
Player Variant lines "inherit" the Direction property from their parent Player Line

### DIFF
--- a/Celbridge/Modules/Celbridge.Core/Assets/Forms/EmptyForm.json
+++ b/Celbridge/Modules/Celbridge.Core/Assets/Forms/EmptyForm.json
@@ -3,7 +3,7 @@
     "element": "TextBox",
     "header": "Comment",
     "text": "/comment",
-    "placeholder": "Enter a comment",
+    "placeholderText": "Enter a comment",
     "checkSpelling": false
   }
 ]

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -51,6 +51,7 @@
   {
     "element": "TextBox",
     "visibility": "/directionVisibility",
+    "placeholderText": "/directionPlaceholderText",
     "header": "Direction",
     "text": "/direction"
   },

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -588,6 +588,11 @@ public class ScreenplayActivity : IActivity
         sb.AppendLine($"<div class=\"scene\">{namespaceText}</div>");
         sb.AppendLine($"<div class=\"scene-note\">{contextText}</div>");
 
+        // If the Direction property of a Player Variant line is empty, it defaults to the 
+        // Direction of its parent Player Line. We store the Player Line direction when we process it so
+        // that we can output it for Player Variant Lines if needed.
+        string playerDirection = string.Empty;
+
         foreach (var component in components)
         {
             if (component.IsComponentType(LineEditor.ComponentType))
@@ -625,7 +630,25 @@ public class ScreenplayActivity : IActivity
                 string lineClass = isPlayerVariant ? "line variant" : "line";
                 string colorClass = isPlayer || isPlayerVariant ? "player-color" : "npc-color";
 
-                var directionText = WebUtility.HtmlEncode(component.GetString(LineEditor.Direction));
+                var direction = component.GetString(LineEditor.Direction);
+
+                if (isPlayer)
+                {
+                    // Record the Player direction to display as placeholder direction in PlayerVariant lines
+                    playerDirection = direction;
+                }
+                else if (!isPlayerVariant)
+                {
+                    playerDirection = string.Empty;
+                }
+
+                // Display the recorded Player direction if the PlayerVariant direction is empty
+                if (isPlayerVariant && string.IsNullOrEmpty(direction))
+                {
+                    direction = playerDirection;
+                }
+
+                var directionText = WebUtility.HtmlEncode(direction);
 
                 if (characterId == "SceneNote")
                 {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -17,6 +17,7 @@ public class ScreenplaySaver
         public string LineId { get; init; } = string.Empty;
         public string SpeakingTo { get; init; } = string.Empty;
         public string ContextNotes { get; init; } = string.Empty;
+        public string Direction { get; init; } = string.Empty;
         public string GameArea { get; init; } = string.Empty;
         public string TimeConstraint { get; init; } = string.Empty;
         public string SoundProcessing { get; init; } = string.Empty;
@@ -338,6 +339,7 @@ public class ScreenplaySaver
                     LineId = lineId,
                     SpeakingTo = speakingTo,
                     ContextNotes = contextNotes,
+                    Direction = direction,
                     GameArea = gameArea,
                     TimeConstraint = timeConstraint,
                     SoundProcessing = soundProcessing,
@@ -362,6 +364,12 @@ public class ScreenplaySaver
                 platform = playerLine.Platform;
                 linePriority = playerLine.LinePriority;
                 productionStatus = playerLine.ProductionStatus;
+
+                if (string.IsNullOrEmpty(direction))
+                {
+                    // Use the direction from the Player ine if no direction is specified for the PlayerVariant
+                    direction = playerLine.Direction;
+                }
 
                 dialogueKey = $"{characterId}-{ns}-{lineId}";
 


### PR DESCRIPTION
Display parent's Direction property if a Player Variant line's Direction is empty.
Display the inherited Direction property for Variant Lines in the HTML preview.
Output the inherited Direction property when saving the screenplay to Excel.