### PR TITLE
Compose dialogue key dynamically instead of storing it as a property

### DIFF
--- a/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/Services/Forms/PropertyBinder.cs
@@ -67,7 +67,12 @@ public class PropertyBinder<T> where T : notnull
         }
 
         _formPropertyPath = configValue.GetString()!;
-        SynchonizeProperties();
+        var syncResult = SynchonizeProperties();
+        if (syncResult.IsFailure)
+        {
+            return Result.Fail("Failed to synchonize properties")
+                .WithErrors(syncResult);
+        }
 
         if (HasBinding)
         {

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
@@ -73,18 +73,18 @@ public partial class TextBlockElement : FormElement
                 .WithErrors(boldResult);
         }
 
-        var textWrappingResult = ApplyTextWrappingConfig(config, textBlock);
-        if (textWrappingResult.IsFailure)
-        {
-            return Result<FrameworkElement>.Fail($"Failed to apply 'textWrapping' config property")
-                .WithErrors(textWrappingResult);
-        }
-
         var textResult = ApplyTextConfig(config, textBlock);
         if (textResult.IsFailure)
         {
             return Result<FrameworkElement>.Fail($"Failed to apply 'text' config property")
                 .WithErrors(textResult);
+        }
+
+        var textWrappingResult = ApplyTextWrappingConfig(config, textBlock);
+        if (textWrappingResult.IsFailure)
+        {
+            return Result<FrameworkElement>.Fail($"Failed to apply 'textWrapping' config property")
+                .WithErrors(textWrappingResult);
         }
 
         return Result<FrameworkElement>.Ok(textBlock);
@@ -134,33 +134,6 @@ public partial class TextBlockElement : FormElement
         return Result.Ok();
     }
 
-    private Result ApplyTextWrappingConfig(JsonElement config, TextBlock textBlock)
-    {
-        if (config.TryGetProperty("textWrapping", out var textWrappingValue))
-        {
-            // Check the type
-            if (textWrappingValue.ValueKind != JsonValueKind.String)
-            {
-                return Result.Fail("'textWrapping' property must be a string.");
-            }
-
-            // Apply the property
-            if (!Enum.TryParse(textWrappingValue.GetString(), out TextWrapping textWrapping))
-            {
-                return Result.Fail("Failed to parse 'textWrapping' property.");
-            }
-
-            textBlock.TextWrapping = textWrapping;
-        }
-        else
-        {
-            // Enable text wrapping by default
-            textBlock.TextWrapping = TextWrapping.Wrap;
-        }
-
-        return Result.Ok();
-    }
-
     private Result ApplyTextConfig(JsonElement config, TextBlock textBlock)
     {
         if (config.TryGetProperty("text", out var configValue))
@@ -184,6 +157,33 @@ public partial class TextBlockElement : FormElement
             {
                 return Result.Fail($"'text' config is not valid");
             }
+        }
+
+        return Result.Ok();
+    }
+
+    private Result ApplyTextWrappingConfig(JsonElement config, TextBlock textBlock)
+    {
+        if (config.TryGetProperty("textWrapping", out var textWrappingValue))
+        {
+            // Check the type
+            if (textWrappingValue.ValueKind != JsonValueKind.String)
+            {
+                return Result.Fail("'textWrapping' property must be a string.");
+            }
+
+            // Apply the property
+            if (!Enum.TryParse(textWrappingValue.GetString(), out TextWrapping textWrapping))
+            {
+                return Result.Fail("Failed to parse 'textWrapping' property.");
+            }
+
+            textBlock.TextWrapping = textWrapping;
+        }
+        else
+        {
+            // Enable text wrapping by default
+            textBlock.TextWrapping = TextWrapping.Wrap;
         }
 
         return Result.Ok();

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBlockElement.cs
@@ -34,7 +34,8 @@ public partial class TextBlockElement : FormElement
         {
             "text",
             "italic",
-            "bold"
+            "bold",
+            "textWrapping"
         });
 
         if (validateResult.IsFailure)
@@ -58,9 +59,6 @@ public partial class TextBlockElement : FormElement
         // Apply element-specific config properties
         //
 
-        // Todo: Set this via a config property
-        textBlock.TextWrapping = TextWrapping.Wrap;
-
         var italicResult = ApplyItalicConfig(config, textBlock);
         if (italicResult.IsFailure)
         {
@@ -73,6 +71,13 @@ public partial class TextBlockElement : FormElement
         {
             return Result<FrameworkElement>.Fail($"Failed to apply 'bold' config property")
                 .WithErrors(boldResult);
+        }
+
+        var textWrappingResult = ApplyTextWrappingConfig(config, textBlock);
+        if (textWrappingResult.IsFailure)
+        {
+            return Result<FrameworkElement>.Fail($"Failed to apply 'textWrapping' config property")
+                .WithErrors(textWrappingResult);
         }
 
         var textResult = ApplyTextConfig(config, textBlock);
@@ -124,6 +129,33 @@ public partial class TextBlockElement : FormElement
             {
                 textBlock.FontWeight = FontWeights.Bold;
             }
+        }
+
+        return Result.Ok();
+    }
+
+    private Result ApplyTextWrappingConfig(JsonElement config, TextBlock textBlock)
+    {
+        if (config.TryGetProperty("textWrapping", out var textWrappingValue))
+        {
+            // Check the type
+            if (textWrappingValue.ValueKind != JsonValueKind.String)
+            {
+                return Result.Fail("'textWrapping' property must be a string.");
+            }
+
+            // Apply the property
+            if (!Enum.TryParse(textWrappingValue.GetString(), out TextWrapping textWrapping))
+            {
+                return Result.Fail("Failed to parse 'textWrapping' property.");
+            }
+
+            textBlock.TextWrapping = textWrapping;
+        }
+        else
+        {
+            // Enable text wrapping by default
+            textBlock.TextWrapping = TextWrapping.Wrap;
         }
 
         return Result.Ok();

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -63,7 +63,8 @@ public partial class TextBoxElement : FormElement
             "placeholderText",
             "checkSpelling",
             "isReadOnly",
-            "autoTrim"
+            "autoTrim",
+            "textWrapping"
         });
 
         if (validateResult.IsFailure)
@@ -93,9 +94,6 @@ public partial class TextBoxElement : FormElement
             return Result<FrameworkElement>.Fail($"Failed to apply 'isEnabled' config")
                 .WithErrors(isEnabledResult);
         }
-
-        // Todo: Set this via a config property
-        textBox.TextWrapping = TextWrapping.Wrap;
 
         var headerResult = ApplyHeaderConfig(config, textBox);
         if (headerResult.IsFailure)
@@ -137,6 +135,13 @@ public partial class TextBoxElement : FormElement
         {
             return Result<FrameworkElement>.Fail($"Failed to apply 'autoTrim' config property")
                 .WithErrors(autoTrimResult);
+        }
+
+        var textWrappingResult = ApplyTextWrappingConfig(config, textBox);
+        if (textWrappingResult.IsFailure)
+        {
+            return Result<FrameworkElement>.Fail($"Failed to apply 'textWrapping' config property")
+                .WithErrors(textWrappingResult);
         }
 
         return Result<FrameworkElement>.Ok(textBox);
@@ -326,6 +331,33 @@ public partial class TextBoxElement : FormElement
                 // If auto trim is enabled then trim the text displayed in the TextBox
                 textBox.Text = textBox.Text.Trim();
             };
+        }
+
+        return Result.Ok();
+    }
+
+    private Result ApplyTextWrappingConfig(JsonElement config, TextBox textBox)
+    {
+        if (config.TryGetProperty("textWrapping", out var textWrappingValue))
+        {
+            // Check the type
+            if (textWrappingValue.ValueKind != JsonValueKind.String)
+            {
+                return Result.Fail("'textWrapping' property must be a string.");
+            }
+
+            // Apply the property
+            if (!Enum.TryParse(textWrappingValue.GetString(), out TextWrapping textWrapping))
+            {
+                return Result.Fail("Failed to parse 'textWrapping' property.");
+            }
+
+            textBox.TextWrapping = textWrapping;
+        }
+        else
+        {
+            // Enable text wrapping by default
+            textBox.TextWrapping = TextWrapping.Wrap;
         }
 
         return Result.Ok();

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
@@ -13,9 +13,6 @@
       "type": "string",
       "enum": [ "Player", "PlayerVariant", "NPC", "SceneNote" ]
     },
-    "dialogueKey": {
-      "type": "string"
-    },
     "lineId": {
       "type": "string"
     },
@@ -57,7 +54,6 @@
   "required": [
     "_type",
     "lineType",
-    "dialogueKey",
     "characterId",
     "sourceText",
     "contextNotes",
@@ -73,7 +69,6 @@
 
   "prototype": {
     "lineType": "Player",
-    "dialogueKey": "",
     "characterId": "Player",
     "sourceText": "",
     "contextNotes": "",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
@@ -54,6 +54,7 @@
   "required": [
     "_type",
     "lineType",
+    "lineId",
     "characterId",
     "sourceText",
     "contextNotes",
@@ -69,6 +70,7 @@
 
   "prototype": {
     "lineType": "Player",
+    "lineId": "",
     "characterId": "Player",
     "sourceText": "",
     "contextNotes": "",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Components/LineComponent.json
@@ -16,6 +16,9 @@
     "dialogueKey": {
       "type": "string"
     },
+    "lineId": {
+      "type": "string"
+    },
     "characterId": {
       "type": "string"
     },

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -17,10 +17,10 @@
           {
             "element": "Button",
             "verticalAlignment": "Bottom",
-            "tooltip": "Generate a new line id for this dialogue line",
+            "tooltip": "Generate a new dialogue key for this dialogue line",
             "icon": "Refresh",
-            "buttonId": "GenerateLineId",
-            "visibility": "/lineIdVisibility"
+            "buttonId": "GenerateDialogueKey",
+            "visibility": "/generateDialogueKeyVisibility"
           }
         ]
       }

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -4,19 +4,14 @@
     "orientation": "Horizontal",
     "children": [
       {
-        "element": "ComboBox",
-        "header": "Line Type",
-        "selectedValue": "/lineType"
-      },
-      {
         "element": "StackPanel",
         "orientation": "Horizontal",
-        "visibility": "/lineIdVisibility",
         "children": [
           {
             "element": "TextBox",
-            "header": "Line Id",
-            "text": "/lineId",
+            "header": "Dialogue Key",
+            "text": "/dialogueKey",
+            "textWrapping":  "NoWrap",
             "isReadOnly": true
           },
           {
@@ -24,17 +19,17 @@
             "verticalAlignment": "Bottom",
             "tooltip": "Generate a new line id for this dialogue line",
             "icon": "Refresh",
-            "buttonId": "GenerateLineId"
+            "buttonId": "GenerateLineId",
+            "visibility": "/lineIdVisibility"
           }
         ]
       }
     ]
   },
   {
-    "element": "TextBox",
-    "header": "Dialogue Key",
-    "text": "/dialogueKey",
-    "isReadOnly": true
+    "element": "ComboBox",
+    "header": "Line Type",
+    "selectedValue": "/lineType"
   },
   {
     "element": "ComboBox",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -11,6 +11,7 @@
       {
         "element": "StackPanel",
         "orientation": "Horizontal",
+        "visibility": "/lineIdVisibility",
         "children": [
           {
             "element": "TextBox",
@@ -30,23 +31,10 @@
     ]
   },
   {
-    "element": "StackPanel",
-    "orientation": "Horizontal",
-    "children": [
-      {
-        "element": "TextBox",
-        "header": "Dialogue Key",
-        "text": "/dialogueKey",
-        "isReadOnly": true
-      },
-      {
-        "element": "Button",
-        "verticalAlignment": "Bottom",
-        "tooltip": "Assign a new dialogue key for this dialogue line",
-        "icon": "Refresh",
-        "buttonId": "UpdateDialogueKey"
-      }
-    ]
+    "element": "TextBox",
+    "header": "Dialogue Key",
+    "text": "/dialogueKey",
+    "isReadOnly": true
   },
   {
     "element": "ComboBox",

--- a/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
+++ b/Celbridge/Modules/Celbridge.Screenplay/Assets/Forms/LineForm.json
@@ -1,8 +1,33 @@
 [
   {
-    "element": "ComboBox",
-    "header": "Line Type",
-    "selectedValue": "/lineType"
+    "element": "StackPanel",
+    "orientation": "Horizontal",
+    "children": [
+      {
+        "element": "ComboBox",
+        "header": "Line Type",
+        "selectedValue": "/lineType"
+      },
+      {
+        "element": "StackPanel",
+        "orientation": "Horizontal",
+        "children": [
+          {
+            "element": "TextBox",
+            "header": "Line Id",
+            "text": "/lineId",
+            "isReadOnly": true
+          },
+          {
+            "element": "Button",
+            "verticalAlignment": "Bottom",
+            "tooltip": "Generate a new line id for this dialogue line",
+            "icon": "Refresh",
+            "buttonId": "GenerateLineId"
+          }
+        ]
+      }
+    ]
   },
   {
     "element": "StackPanel",

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -225,6 +225,7 @@ public class LineEditor : ComponentEditorBase
             // Update virtual properties when the line type changes
             // The character ids list will be filtered depending on the line type.
             NotifyFormPropertyChanged("/characterIds");
+            NotifyFormPropertyChanged("/characterId");
             NotifyFormPropertyChanged("/characterIdVisibility");
             NotifyFormPropertyChanged("/variantVisibility");
             NotifyFormPropertyChanged("/directionVisibility");

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -501,7 +501,7 @@ public class LineEditor : ComponentEditorBase
         if (lineType != "PlayerVariant")
         {
             // Line is not a Player Variant
-            return Result<string>.Ok(string.Empty);
+            return Result<string>.Ok(JsonSerializer.Serialize(string.Empty));
         }
 
         var getParentResult = GetPlayerVariantParent();

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -257,7 +257,7 @@ public class LineEditor : ComponentEditorBase
                 }
             }
         }
-        else if (propertyPath == "/lineId")
+        else if (propertyPath == "/lineId" || propertyPath == "/characterId")
         {
             NotifyFormPropertyChanged("/dialogueKey");
         }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -182,13 +182,13 @@ public class LineEditor : ComponentEditorBase
         {
             if (Component.GetString(LineType) == "PlayerVariant")
             {
-                // Get the parent Player Line
-                var getParentResult = GetPlayerVariantParent();
+                // Get the Player line that's the parent of this Player Variant line
+                var getParentResult = GetParentPlayerLine();
                 if (getParentResult.IsSuccess)
                 {
                     // Return the parent's Line Id
-                    var parentLine = getParentResult.Value;
-                    var lineId = parentLine.GetString(LineId);
+                    var playerLine = getParentResult.Value;
+                    var lineId = playerLine.GetString(LineId);
                     if (!string.IsNullOrEmpty(lineId))
                     {
                         return Result<string>.Ok(JsonSerializer.Serialize(lineId));
@@ -506,7 +506,7 @@ public class LineEditor : ComponentEditorBase
             return Result<string>.Ok(JsonSerializer.Serialize(string.Empty));
         }
 
-        var getParentResult = GetPlayerVariantParent();
+        var getParentResult = GetParentPlayerLine();
         if (getParentResult.IsSuccess)
         {
             var parentLine = getParentResult.Value;
@@ -519,7 +519,7 @@ public class LineEditor : ComponentEditorBase
         return Result<string>.Ok(JsonSerializer.Serialize(string.Empty));
     }
 
-    private Result<IComponentProxy> GetPlayerVariantParent()
+    private Result<IComponentProxy> GetParentPlayerLine()
     {
         var lineType = Component.GetString(LineEditor.LineType);
         if (lineType != "PlayerVariant")

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -167,7 +167,7 @@ public class LineEditor : ComponentEditorBase
         {
             return GetDirectionPlaceholderText();
         }
-        else if (propertyPath == "/lineIdVisibility")
+        else if (propertyPath == "/generateDialogueKeyVisibility")
         {
             if (Component.GetString(LineType) == "PlayerVariant")
             {
@@ -212,9 +212,9 @@ public class LineEditor : ComponentEditorBase
 
     public override void OnButtonClicked(string buttonId)
     {
-        if (buttonId == "GenerateLineId")
+        if (buttonId == "GenerateDialogueKey")
         {
-            UpdateLineId();
+            GenerateDialogueKey();
         }
     }
 
@@ -229,7 +229,7 @@ public class LineEditor : ComponentEditorBase
             NotifyFormPropertyChanged("/variantVisibility");
             NotifyFormPropertyChanged("/directionVisibility");
             NotifyFormPropertyChanged("/dialogueKey");
-            NotifyFormPropertyChanged("/lineIdVisibility");
+            NotifyFormPropertyChanged("/generateDialogueKeyVisibility");
 
             // Get the filtered list of character ids            
             var getResult = GetProperty("/characterIds");
@@ -410,22 +410,23 @@ public class LineEditor : ComponentEditorBase
         return Result<string>.Ok(dialogueKey);
     }
 
-    private void UpdateLineId()
+    private void GenerateDialogueKey()
     {
-        var generateResult = GenerateUniqueLineId();
-        if (generateResult.IsFailure)
+        // Generate a new dialogue key by assigning a new unique line id.
+
+        var getLineIdResult = GetUniqueLineId();
+        if (getLineIdResult.IsFailure)
         {
             // Todo: Show an alert if generating line id fails
-            _logger.LogError($"Failed to generate line id. {generateResult.Error}");
+            _logger.LogError($"Failed to get a unique line id. {getLineIdResult.Error}");
             return;
         }
-        var newLineId = generateResult.Value;
+        var lineId = getLineIdResult.Value;
 
-        Component.SetProperty(LineId, JsonSerializer.Serialize(newLineId));
+        Component.SetProperty(LineId, JsonSerializer.Serialize(lineId));
     }
 
-
-    private Result<string> GenerateUniqueLineId()
+    private Result<string> GetUniqueLineId()
     {
         //
         // Get all components on this entity

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -300,9 +300,10 @@ public class ScreenplayActivity : IActivity
                     }
                     else
                     {
-                        // Flag this as a player variant line
-                        // Inherit the lineId from the parent Player Line
+                        // Flag this as a player variant line.
                         isPlayerVariantLine = true;
+
+                        // Inherit the parent Player line's Line Id.
                         resolvedLineId = playerLineId;
                     }
                 }
@@ -320,7 +321,7 @@ public class ScreenplayActivity : IActivity
 
             if (lineType == "PlayerVariant")
             {
-                // Check for character ids that have been specified multiple time.
+                // Each Player Variant within the group must specific a different character id.
                 var dialogueKey = $"{characterId}-{@namespace}-{resolvedLineId}";
                 if (activePlayerVariants.Contains(dialogueKey))
                 {
@@ -340,8 +341,8 @@ public class ScreenplayActivity : IActivity
                     // Todo: Is this error mode still possible?
                     entityAnnotation.AddComponentError(i, new AnnotationError(
                         AnnotationErrorSeverity.Error,
-                        "Invalid line id",
-                        "The line id is not correctly formed."));
+                        "Invalid dialogue key",
+                        "The line id is not valid. Generate a new dialogue key to fix this."));
                 }
 
                 // Check that each line id is unique.
@@ -349,8 +350,8 @@ public class ScreenplayActivity : IActivity
                 {
                     entityAnnotation.AddComponentError(i, new AnnotationError(
                         AnnotationErrorSeverity.Error,
-                        "Duplicate line id",
-                        "Line ids must be unique for each line. Update the line id to generate a new one."));
+                        "Invalid dialogue key",
+                        "Every line must have a unique line id. Generate a new dialogue key to fix this."));
                 }
                 else
                 {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -321,7 +321,7 @@ public class ScreenplayActivity : IActivity
 
             if (lineType == "PlayerVariant")
             {
-                // Each Player Variant within the group must specific a different character id.
+                // Each Player Variant within the group must specify a different character id.
                 var dialogueKey = $"{characterId}-{@namespace}-{resolvedLineId}";
                 if (activePlayerVariants.Contains(dialogueKey))
                 {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
@@ -440,6 +440,8 @@ public class ScreenplayLoader
                     return Result.Fail($"Character '{characterId}' not found in characters list at row {row_index}");
                 }
             }
+
+            // Todo: Check that the dialogue key is valid and that there are no duplicates
         }
 
         return Result.Ok();
@@ -606,12 +608,23 @@ public class ScreenplayLoader
             // The line list may be empty if this is a newly created scene.
             foreach (var line in lineList)
             {
+                var dialogueKey = line.DialogueKey;
+
+                // Extract the line id
+                var lineIdIndex = dialogueKey.LastIndexOf('-');
+
+                // Todo: Move these checks to the validation step
+                Guard.IsFalse(lineIdIndex == -1);
+                Guard.IsFalse(dialogueKey.Length == lineIdIndex + 1);
+                var lineId = dialogueKey.Substring(lineIdIndex + 1);
+
                 if (line.CharacterId == "SceneNote")
                 {
                     var lineComponent = new JsonObject();
                     lineComponent["_type"] = "Screenplay.Line#1";
                     lineComponent["lineType"] = line.LineType;
-                    lineComponent["dialogueKey"] = line.DialogueKey;
+                    lineComponent["lineId"] = lineId;
+                    lineComponent["dialogueKey"] = dialogueKey;
                     lineComponent["characterId"] = line.CharacterId;
                     lineComponent["speakingTo"] = string.Empty;
                     lineComponent["sourceText"] = line.SourceText;
@@ -631,7 +644,8 @@ public class ScreenplayLoader
                     var lineComponent = new JsonObject();
                     lineComponent["_type"] = "Screenplay.Line#1";
                     lineComponent["lineType"] = line.LineType;
-                    lineComponent["dialogueKey"] = line.DialogueKey;
+                    lineComponent["lineId"] = lineId;
+                    lineComponent["dialogueKey"] = dialogueKey;
                     lineComponent["characterId"] = line.CharacterId;
                     lineComponent["speakingTo"] = line.SpeakingTo;
                     lineComponent["sourceText"] = line.SourceText;

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
@@ -452,22 +452,22 @@ public class ScreenplayLoader
             // Check that the dialogue key is valid.
             // Bark lines have already been excluded so all dialogue keys should have exactly 3 parts.
             var dialogueKey = line.DialogueKey;
-            var keyparts = dialogueKey.Split('-');
-            if (keyparts.Length != 3 && keyparts.Length != 4)
+            var keyParts = dialogueKey.Split('-');
+            if (keyParts.Length != 3 || keyParts.Any((p) => p.Length == 0))
             {
                 return Result.Fail($"DialogueKey '{dialogueKey}' does not contain 3 parts at row {row_index}");
             }
 
-            if (characterId != keyparts[0])
+            if (characterId != keyParts[0])
             {
                 return Result.Fail($"DialogueKey '{dialogueKey}' does not match character id '{characterId}' at row {row_index}");
             }
-            if (line.Namespace != keyparts[1])
+            if (line.Namespace != keyParts[1])
             {
                 return Result.Fail($"DialogueKey '{dialogueKey}' does not match namespace '{line.Namespace}' at row {row_index}");
             }
 
-            var lineId = keyparts[2];
+            var lineId = keyParts[2];
             if (string.IsNullOrEmpty(lineId))
             {
                 return Result.Fail($"Line id is empty at row {row_index}");

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayLoader.cs
@@ -624,7 +624,6 @@ public class ScreenplayLoader
                     lineComponent["_type"] = "Screenplay.Line#1";
                     lineComponent["lineType"] = line.LineType;
                     lineComponent["lineId"] = lineId;
-                    lineComponent["dialogueKey"] = dialogueKey;
                     lineComponent["characterId"] = line.CharacterId;
                     lineComponent["speakingTo"] = string.Empty;
                     lineComponent["sourceText"] = line.SourceText;
@@ -645,7 +644,6 @@ public class ScreenplayLoader
                     lineComponent["_type"] = "Screenplay.Line#1";
                     lineComponent["lineType"] = line.LineType;
                     lineComponent["lineId"] = lineId;
-                    lineComponent["dialogueKey"] = dialogueKey;
                     lineComponent["characterId"] = line.CharacterId;
                     lineComponent["speakingTo"] = line.SpeakingTo;
                     lineComponent["sourceText"] = line.SourceText;

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -358,7 +358,7 @@ public class ScreenplaySaver
                 // For Player Variant lines these fields should all match the parent Player Line
                 lineId = playerLine.LineId;
                 speakingTo = playerLine.SpeakingTo;
-                contextNotes = playerLine.ContextNotes;
+                // contextNotes = playerLine.ContextNotes;
                 gameArea = playerLine.GameArea;
                 timeConstraint = playerLine.TimeConstraint;
                 soundProcessing = playerLine.SoundProcessing;
@@ -366,11 +366,11 @@ public class ScreenplaySaver
                 linePriority = playerLine.LinePriority;
                 productionStatus = playerLine.ProductionStatus;
 
-                if (string.IsNullOrEmpty(direction))
-                {
-                    // Use the direction from the Player ine if no direction is specified for the PlayerVariant
-                    direction = playerLine.Direction;
-                }
+                //if (string.IsNullOrEmpty(direction))
+                //{
+                //    // Use the direction from the Player ine if no direction is specified for the PlayerVariant
+                //    direction = playerLine.Direction;
+                //}
 
                 // Override the dialogue key for Player Variants
                 dialogueKey = $"{characterId}-{ns}-{lineId}";

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -301,7 +301,7 @@ public class ScreenplaySaver
             //
 
             var lineType = component.GetString(LineEditor.LineType);
-            var dialogueKey = component.GetString(LineEditor.DialogueKey);
+            var lineId = component.GetString(LineEditor.LineId);
             var characterId = component.GetString(LineEditor.CharacterId);
             var sourceText = component.GetString(LineEditor.SourceText);
             var speakingTo = component.GetString(LineEditor.SpeakingTo);
@@ -314,7 +314,8 @@ public class ScreenplaySaver
             var linePriority = component.GetString(LineEditor.LinePriority);
             var productionStatus = component.GetString(LineEditor.ProductionStatus);
 
-            var lineId = dialogueKey[(dialogueKey.LastIndexOf('-') + 1)..];
+            var dialogueKey = $"{characterId}-{ns}-{lineId}";
+
             var isSceneNote = false;
 
             // Excel uses a single apostrophe to indicate raw text.
@@ -371,6 +372,7 @@ public class ScreenplaySaver
                     direction = playerLine.Direction;
                 }
 
+                // Override the dialogue key for Player Variants
                 dialogueKey = $"{characterId}-{ns}-{lineId}";
 
                 FillCells(sheet, row, new[] { 3, 4 }, PlayerVariantColor);
@@ -385,6 +387,7 @@ public class ScreenplaySaver
                 // Override the dialogue key for scene notes
                 // Todo: Do we still need to do this? Could we just treat them as regular dialogue lines now?
                 dialogueKey = $"SceneNote-{ns}-Note{sceneNoteIndex++}";
+
                 FillCells(sheet, row, Enumerable.Range(3, 12), SceneNoteColor);
             }
             else if (lineType == "NPC")


### PR DESCRIPTION
Each dialogue line now stores a Line Id property rather than the full Dialogue Key. The Dialogue Key for any line can easily be constructed by composing the Namespace, Character Id & Line Id properties together.

This design allows Player Variant lines to "inherit" their Line Id from their parent Player line. The "Generate Dialogue Key" button now only needs to assign a new unique Line Id property, and the Dialogue Key automatically updates.

This PR also adds a "textWrapping" config property for TextBlocks and TextBoxes. The component cache is now always cleared every time the Resource Registry is updated to ensure component data is always fresh.