### PR TITLE
Ask user to confirm if screenplay load will overwrite modified scenes

### DIFF
--- a/Celbridge/BaseLibrary/Workspace/IWorkspaceSettings.cs
+++ b/Celbridge/BaseLibrary/Workspace/IWorkspaceSettings.cs
@@ -31,4 +31,10 @@ public interface IWorkspaceSettings
     /// Returns default(T) if the key was not found or if the property could not be deserialized to type T.
     /// </summary>
     Task<T?> GetPropertyAsync<T>(string key);
+
+    /// <summary>
+    /// Deletes the specified property.
+    /// Returns true if the property existed prior to deletion.
+    /// </summary>
+    Task<bool> DeletePropertyAsync(string key);
 }

--- a/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -429,4 +429,13 @@
   <data name="Screenplay_LoadFailedMessage" xml:space="preserve">
     <value>An error occurred while loading the screenplay Excel file.</value>
   </data>
+  <data name="Screenplay_ConfirmLoadTitle" xml:space="preserve">
+    <value>Confirm Load</value>
+  </data>
+  <data name="Screenplay_ConfirmLoadMessage" xml:space="preserve">
+    <value>Loading will overwrite modified scene files:
+{0}
+
+Do you wish to continue?</value>
+  </data>
 </root>

--- a/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
@@ -1,46 +1,25 @@
 using Celbridge.Activities;
 using Celbridge.Commands;
-using Celbridge.Dialog;
-using Celbridge.Explorer;
 using Celbridge.Screenplay.Services;
 using Celbridge.Workspace;
-using System.Text;
 
 namespace Celbridge.Screenplay.Commands;
 
 public class LoadScreenplayCommand : CommandBase
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IDialogService _dialogService;
-    private readonly IWorkspaceSettings _workspaceSettings;
-    private readonly IResourceRegistry _resourceRegistry;
     private readonly IActivityService _activityService;
 
     public override CommandFlags CommandFlags => CommandFlags.UpdateResources;
 
     public ResourceKey WorkbookResource { get; set; } = ResourceKey.Empty;
 
-    public LoadScreenplayCommand(
-        IServiceProvider serviceProvider,
-        IDialogService dialogService,
-        IWorkspaceWrapper workspaceWrapper)
+    public LoadScreenplayCommand(IWorkspaceWrapper workspaceWrapper)
     {
-        _serviceProvider = serviceProvider;
-        _dialogService = dialogService;
-        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
-        _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
         _activityService = workspaceWrapper.WorkspaceService.ActivityService;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
-        // Check if load will overwrite any modified scenes
-        var confirmed = await ConfirmLoad();
-        if (!confirmed)
-        {
-            return Result.Ok();            
-        }
-
         var getActivityResult = _activityService.GetActivity(nameof(ScreenplayActivity));
         if (getActivityResult.IsFailure)
         {
@@ -62,70 +41,6 @@ public class LoadScreenplayCommand : CommandBase
                 .WithErrors(loadResult);
         }
 
-        // Reset list of modified scenes
-        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
-
         return Result.Ok();
-    }
-
-    private async Task<bool> ConfirmLoad()
-    {
-        // Get the list of modified scenes from the workspace settings
-        var modifiedScenes = await _workspaceSettings.GetPropertyAsync<HashSet<string>>(ScreenplayConstants.ModifiedScenesKey);
-        if (modifiedScenes is null ||
-            modifiedScenes.Count == 0)
-        {
-            return true;
-        }
-
-        // Construct a sorted list containing the filename of each scene 
-        var sceneResources = new List<string>();
-        foreach (var sceneResource in modifiedScenes)
-        {
-            var getResourceResult = _resourceRegistry.GetResource(sceneResource);
-            if (getResourceResult.IsFailure)
-            {
-                // Ignore this scene resource because it no longer exists (e.g. user deleted it)
-                continue;
-            }
-
-            var sceneFilename = Path.GetFileNameWithoutExtension(sceneResource);
-            if (!string.IsNullOrEmpty(sceneFilename))
-            {
-                sceneResources.Add(sceneFilename);
-            }
-        }
-        sceneResources.Sort();
-
-        if (sceneResources.Count == 0)
-        {
-            // No existing scene resources will be affected by the load, so it can proceed.
-            return true;
-        }
-
-        var maxScenes = 5;
-        var sb = new StringBuilder();
-        for (int i = 0; i < sceneResources.Count; i++)
-        {
-            var scene = sceneResources[i];
-            if (i > maxScenes)
-            {
-                sb.Append($"...");
-                break;
-            }
-            sb.AppendLine(scene.ToString());
-        }
-        var sceneList = sb.ToString();
-
-        // Ask the user to confirm that they want to overwrite the modified scenes
-        var message = $"Loading will overwrite modified scene files:\n{sceneList}\n\n Do you wish to continue?";
-        var confirmResult = await _dialogService.ShowConfirmationDialogAsync("Confirm Load", message);
-        if (confirmResult.IsFailure)
-        {
-            return false;
-        }
-        var confirmed = confirmResult.Value;
-
-        return confirmed;
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
@@ -1,3 +1,4 @@
+using Celbridge.Activities;
 using Celbridge.Commands;
 using Celbridge.Dialog;
 using Celbridge.Explorer;
@@ -13,6 +14,7 @@ public class LoadScreenplayCommand : CommandBase
     private readonly IDialogService _dialogService;
     private readonly IWorkspaceSettings _workspaceSettings;
     private readonly IResourceRegistry _resourceRegistry;
+    private readonly IActivityService _activityService;
 
     public override CommandFlags CommandFlags => CommandFlags.UpdateResources;
 
@@ -27,13 +29,11 @@ public class LoadScreenplayCommand : CommandBase
         _dialogService = dialogService;
         _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
         _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
+        _activityService = workspaceWrapper.WorkspaceService.ActivityService;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
-        var workspaceWrapper = _serviceProvider.AcquireService<IWorkspaceWrapper>();
-        var activityService = workspaceWrapper.WorkspaceService.ActivityService;
-
         // Check if load will overwrite any modified scenes
         var confirmed = await ConfirmLoad();
         if (!confirmed)
@@ -41,7 +41,7 @@ public class LoadScreenplayCommand : CommandBase
             return Result.Ok();            
         }
 
-        var getActivityResult = activityService.GetActivity(nameof(ScreenplayActivity));
+        var getActivityResult = _activityService.GetActivity(nameof(ScreenplayActivity));
         if (getActivityResult.IsFailure)
         {
             return Result.Fail($"Failed to get Screenplay activity")
@@ -63,7 +63,6 @@ public class LoadScreenplayCommand : CommandBase
         }
 
         // Reset list of modified scenes
-        // Todo: Do this in save command as well
         await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
 
         return Result.Ok();

--- a/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Commands/LoadScreenplayCommand.cs
@@ -1,26 +1,45 @@
 using Celbridge.Commands;
+using Celbridge.Dialog;
+using Celbridge.Explorer;
 using Celbridge.Screenplay.Services;
 using Celbridge.Workspace;
+using System.Text;
 
 namespace Celbridge.Screenplay.Commands;
 
 public class LoadScreenplayCommand : CommandBase
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly IDialogService _dialogService;
+    private readonly IWorkspaceSettings _workspaceSettings;
+    private readonly IResourceRegistry _resourceRegistry;
 
     public override CommandFlags CommandFlags => CommandFlags.UpdateResources;
 
     public ResourceKey WorkbookResource { get; set; } = ResourceKey.Empty;
 
-    public LoadScreenplayCommand(IServiceProvider serviceProvider)
+    public LoadScreenplayCommand(
+        IServiceProvider serviceProvider,
+        IDialogService dialogService,
+        IWorkspaceWrapper workspaceWrapper)
     {
         _serviceProvider = serviceProvider;
+        _dialogService = dialogService;
+        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
+        _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
         var workspaceWrapper = _serviceProvider.AcquireService<IWorkspaceWrapper>();
         var activityService = workspaceWrapper.WorkspaceService.ActivityService;
+
+        // Check if load will overwrite any modified scenes
+        var confirmed = await ConfirmLoad();
+        if (!confirmed)
+        {
+            return Result.Ok();            
+        }
 
         var getActivityResult = activityService.GetActivity(nameof(ScreenplayActivity));
         if (getActivityResult.IsFailure)
@@ -43,6 +62,71 @@ public class LoadScreenplayCommand : CommandBase
                 .WithErrors(loadResult);
         }
 
+        // Reset list of modified scenes
+        // Todo: Do this in save command as well
+        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
+
         return Result.Ok();
+    }
+
+    private async Task<bool> ConfirmLoad()
+    {
+        // Get the list of modified scenes from the workspace settings
+        var modifiedScenes = await _workspaceSettings.GetPropertyAsync<HashSet<string>>(ScreenplayConstants.ModifiedScenesKey);
+        if (modifiedScenes is null ||
+            modifiedScenes.Count == 0)
+        {
+            return true;
+        }
+
+        // Construct a sorted list containing the filename of each scene 
+        var sceneResources = new List<string>();
+        foreach (var sceneResource in modifiedScenes)
+        {
+            var getResourceResult = _resourceRegistry.GetResource(sceneResource);
+            if (getResourceResult.IsFailure)
+            {
+                // Ignore this scene resource because it no longer exists (e.g. user deleted it)
+                continue;
+            }
+
+            var sceneFilename = Path.GetFileNameWithoutExtension(sceneResource);
+            if (!string.IsNullOrEmpty(sceneFilename))
+            {
+                sceneResources.Add(sceneFilename);
+            }
+        }
+        sceneResources.Sort();
+
+        if (sceneResources.Count == 0)
+        {
+            // No existing scene resources will be affected by the load, so it can proceed.
+            return true;
+        }
+
+        var maxScenes = 5;
+        var sb = new StringBuilder();
+        for (int i = 0; i < sceneResources.Count; i++)
+        {
+            var scene = sceneResources[i];
+            if (i > maxScenes)
+            {
+                sb.Append($"...");
+                break;
+            }
+            sb.AppendLine(scene.ToString());
+        }
+        var sceneList = sb.ToString();
+
+        // Ask the user to confirm that they want to overwrite the modified scenes
+        var message = $"Loading will overwrite modified scene files:\n{sceneList}\n\n Do you wish to continue?";
+        var confirmResult = await _dialogService.ShowConfirmationDialogAsync("Confirm Load", message);
+        if (confirmResult.IsFailure)
+        {
+            return false;
+        }
+        var confirmed = confirmResult.Value;
+
+        return confirmed;
     }
 }

--- a/Celbridge/Modules/Celbridge.Screenplay/Commands/SaveScreenplayCommand.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Commands/SaveScreenplayCommand.cs
@@ -1,3 +1,4 @@
+using Celbridge.Activities;
 using Celbridge.Commands;
 using Celbridge.Screenplay.Services;
 using Celbridge.Workspace;
@@ -6,25 +7,18 @@ namespace Celbridge.Screenplay.Commands;
 
 public class SaveScreenplayCommand : CommandBase
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IWorkspaceSettings _workspaceSettings;
+    private readonly IActivityService _activityService;
 
     public ResourceKey WorkbookResource { get; set; } = ResourceKey.Empty;
 
-    public SaveScreenplayCommand(
-        IServiceProvider serviceProvider,
-        IWorkspaceWrapper workspaceWrapper)
+    public SaveScreenplayCommand(IWorkspaceWrapper workspaceWrapper)
     {
-        _serviceProvider = serviceProvider;
-        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
+        _activityService = workspaceWrapper.WorkspaceService.ActivityService;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
-        var workspaceWrapper = _serviceProvider.AcquireService<IWorkspaceWrapper>();
-        var activityService = workspaceWrapper.WorkspaceService.ActivityService;
-
-        var getActivityResult = activityService.GetActivity(nameof(ScreenplayActivity));
+        var getActivityResult = _activityService.GetActivity(nameof(ScreenplayActivity));
         if (getActivityResult.IsFailure)
         {
             return Result.Fail($"Failed to get Screenplay activity")
@@ -44,9 +38,6 @@ public class SaveScreenplayCommand : CommandBase
             return Result.Fail($"Failed to save screenplay to workbook")
                 .WithErrors(saveResult);
         }
-
-        // All modified scenes have now been saved, so reset the modified scenes list
-        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
 
         return Result.Ok();
     }

--- a/Celbridge/Modules/Celbridge.Screenplay/Commands/SaveScreenplayCommand.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Commands/SaveScreenplayCommand.cs
@@ -7,12 +7,16 @@ namespace Celbridge.Screenplay.Commands;
 public class SaveScreenplayCommand : CommandBase
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkspaceSettings _workspaceSettings;
 
     public ResourceKey WorkbookResource { get; set; } = ResourceKey.Empty;
 
-    public SaveScreenplayCommand(IServiceProvider serviceProvider)
+    public SaveScreenplayCommand(
+        IServiceProvider serviceProvider,
+        IWorkspaceWrapper workspaceWrapper)
     {
         _serviceProvider = serviceProvider;
+        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
     }
 
     public override async Task<Result> ExecuteAsync()
@@ -41,7 +45,8 @@ public class SaveScreenplayCommand : CommandBase
                 .WithErrors(saveResult);
         }
 
-        await Task.CompletedTask;
+        // All modified scenes have now been saved, so reset the modified scenes list
+        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
 
         return Result.Ok();
     }

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -32,6 +32,7 @@ public class LineEditor : ComponentEditorBase
     private readonly ILogger<LineEditor> _logger;
     private readonly IEntityService _entityService;
     private readonly IActivityService _activityService;
+    private readonly IWorkspaceSettings _workspaceSettings;
 
     public LineEditor(
         ILogger<LineEditor> logger,
@@ -40,6 +41,7 @@ public class LineEditor : ComponentEditorBase
         _logger = logger;
         _entityService = workspaceWrapper.WorkspaceService.EntityService;
         _activityService = workspaceWrapper.WorkspaceService.ActivityService;
+        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
     }
 
     public override string GetComponentConfig()
@@ -219,7 +221,9 @@ public class LineEditor : ComponentEditorBase
     }
 
     protected override void OnFormPropertyChanged(string propertyPath)
-    { 
+    {
+        _ = RecordModifiedScene();
+
         if (propertyPath == "/lineType")
         {
             // Update virtual properties when the line type changes
@@ -262,6 +266,23 @@ public class LineEditor : ComponentEditorBase
         {
             NotifyFormPropertyChanged("/dialogueKey");
         }
+    }
+
+    /// <summary>
+    /// Add the scene to the modified scenes list.
+    /// </summary>
+    private async Task RecordModifiedScene()
+    {
+        var modifiedScenes = await _workspaceSettings.GetPropertyAsync<HashSet<string>>(ScreenplayConstants.ModifiedScenesKey);
+        if (modifiedScenes is null)
+        {
+            modifiedScenes = new HashSet<string>();
+        }
+
+        var resource = Component.Key.Resource;
+        modifiedScenes.Add(resource);
+
+        await _workspaceSettings.SetPropertyAsync(ScreenplayConstants.ModifiedScenesKey, modifiedScenes);
     }
 
     private Result<List<string>> GetFilteredCharacterIds()
@@ -316,19 +337,14 @@ public class LineEditor : ComponentEditorBase
 
     private Result<List<Character>> GetAllCharacters()
     {
-        // Get the scene component on this entity
-        var sceneComponentKey = new ComponentKey(Component.Key.Resource, 0);
-        var getComponentResult = _entityService.GetComponent(sceneComponentKey);
-        if (getComponentResult.IsFailure)
+        // Get the scene component
+        var getSceneResult = GetSceneComponent();
+        if (getSceneResult.IsFailure)
         {
-            return Result<List<Character>>.Fail($"Failed to get scene component: '{sceneComponentKey}'")
-                .WithErrors(getComponentResult);
+            return Result<List<Character>>.Fail($"Failed to get scene component")
+                .WithErrors(getSceneResult);
         }
-        var sceneComponent = getComponentResult.Value;
-        if (!sceneComponent.IsComponentType(SceneEditor.ComponentType))
-        {
-            return Result<List<Character>>.Fail($"Root component is not a Scene component");
-        }
+        var sceneComponent = getSceneResult.Value;
 
         // Get the dialogue file resource from the scene component
         ResourceKey excelFileResource = sceneComponent.GetString("/dialogueFile");
@@ -353,6 +369,26 @@ public class LineEditor : ComponentEditorBase
         var characters = charactersResult.Value;
 
         return Result<List<Character>>.Ok(characters);
+    }
+
+    private Result<IComponentProxy> GetSceneComponent()
+    {
+        // Get the scene component on this entity
+        var sceneComponentKey = new ComponentKey(Component.Key.Resource, 0);
+        var getComponentResult = _entityService.GetComponent(sceneComponentKey);
+        if (getComponentResult.IsFailure)
+        {
+            return Result<IComponentProxy>.Fail($"Failed to get scene component: '{sceneComponentKey}'")
+                .WithErrors(getComponentResult);
+        }
+
+        var sceneComponent = getComponentResult.Value;
+        if (!sceneComponent.IsComponentType(SceneEditor.ComponentType))
+        {
+            return Result<IComponentProxy>.Fail($"Root component is not a Scene component");
+        }
+
+        return Result<IComponentProxy>.Ok(sceneComponent);
     }
 
     /// <summary>

--- a/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/ComponentEditors/LineEditor.cs
@@ -280,8 +280,13 @@ public class LineEditor : ComponentEditorBase
         }
 
         var resource = Component.Key.Resource;
-        modifiedScenes.Add(resource);
+        if (modifiedScenes.Contains(resource))
+        {
+            // Scene is already marked as modified, early out.
+            return;
+        }
 
+        modifiedScenes.Add(resource);
         await _workspaceSettings.SetPropertyAsync(ScreenplayConstants.ModifiedScenesKey, modifiedScenes);
     }
 

--- a/Celbridge/Modules/Celbridge.Screenplay/Models/Scene.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Models/Scene.cs
@@ -1,4 +1,3 @@
-
 namespace Celbridge.Screenplay.Models;
 
 public record Scene(string Category, string Namespace, string Context, string AssetPath, List<DialogueLine> Lines)

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -407,8 +407,7 @@ public class ScreenplayActivity : IActivity
 
     public async Task<Result> LoadScreenplayAsync(ResourceKey screenplayResource)
     {
-        // Check if load will overwrite any modified scenes.
-        // Confirm with user if it's ok to proceed.
+        // If the load will overwrite modified scenes, ask the user if it's ok to proceed.
         var confirmed = await ConfirmLoadScreenplay();
         if (!confirmed)
         {

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -415,8 +415,8 @@ public class ScreenplayActivity : IActivity
         }
 
         // Display a progress dialog
-        var dialogueTitleText = _localizerService.GetString("Screenplay_LoadingScreenplayTitle");
-        var progressToken = _dialogService.AcquireProgressDialog(dialogueTitleText);
+        var dialogTitleText = _localizerService.GetString("Screenplay_LoadingScreenplayTitle");
+        var progressToken = _dialogService.AcquireProgressDialog(dialogTitleText);
 
         // Give the progress dialog a chance to display
         await Task.Delay(100);
@@ -616,12 +616,13 @@ public class ScreenplayActivity : IActivity
             }
             sb.AppendLine(scene.ToString());
         }
-        var sceneList = sb.ToString();
+        var sceneListText = sb.ToString();
 
         // Ask the user to confirm that they want to overwrite the modified scenes
-        // Todo: Localize this string
-        var message = $"Loading will overwrite modified scene files:\n{sceneList}\n\n Do you wish to continue?";
-        var confirmResult = await _dialogService.ShowConfirmationDialogAsync("Confirm Load", message);
+        var dialogTitleText = _localizerService.GetString("Screenplay_ConfirmLoadTitle");
+        var dialogMessageText = _localizerService.GetString("Screenplay_ConfirmLoadMessage", sceneListText);
+
+        var confirmResult = await _dialogService.ShowConfirmationDialogAsync(dialogTitleText, dialogMessageText);
         if (confirmResult.IsFailure)
         {
             return false;

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayActivity.cs
@@ -2,6 +2,7 @@ using Celbridge.Activities;
 using Celbridge.Dialog;
 using Celbridge.Documents;
 using Celbridge.Entities;
+using Celbridge.Explorer;
 using Celbridge.Localization;
 using Celbridge.Screenplay.Components;
 using Celbridge.Screenplay.Models;
@@ -22,6 +23,8 @@ public class ScreenplayActivity : IActivity
     private readonly IDialogService _dialogService;
     private readonly IEntityService _entityService;
     private readonly IDocumentsService _documentsService;
+    private readonly IWorkspaceSettings _workspaceSettings;
+    private readonly IResourceRegistry _resourceRegistry;
 
     public ScreenplayActivity(
         IServiceProvider serviceProvider,
@@ -34,6 +37,8 @@ public class ScreenplayActivity : IActivity
         _dialogService = dialogService;
         _entityService = workspaceWrapper.WorkspaceService.EntityService;
         _documentsService = workspaceWrapper.WorkspaceService.DocumentsService;
+        _workspaceSettings = workspaceWrapper.WorkspaceService.WorkspaceSettings;
+        _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
     }
 
     public async Task<Result> ActivateAsync()
@@ -402,6 +407,14 @@ public class ScreenplayActivity : IActivity
 
     public async Task<Result> LoadScreenplayAsync(ResourceKey screenplayResource)
     {
+        // Check if load will overwrite any modified scenes.
+        // Confirm with user if it's ok to proceed.
+        var confirmed = await ConfirmLoadScreenplay();
+        if (!confirmed)
+        {
+            return Result.Ok();
+        }
+
         // Display a progress dialog
         var dialogueTitleText = _localizerService.GetString("Screenplay_LoadingScreenplayTitle");
         var progressToken = _dialogService.AcquireProgressDialog(dialogueTitleText);
@@ -424,6 +437,9 @@ public class ScreenplayActivity : IActivity
             return Result.Fail($"Failed to load screenplay data from Workbook")
                 .WithErrors(loadResult);
         }
+
+        // Reset list of modified scenes
+        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
 
         return Result.Ok();
     }
@@ -452,6 +468,9 @@ public class ScreenplayActivity : IActivity
             return Result.Fail($"Failed to save screenplay data to Workbook")
                 .WithErrors(saveResult);
         }
+
+        // All modified scenes have now been saved, so reset the modified scenes list
+        await _workspaceSettings.DeletePropertyAsync(ScreenplayConstants.ModifiedScenesKey);
 
         return Result.Ok();
     }
@@ -549,6 +568,68 @@ public class ScreenplayActivity : IActivity
         }
 
         return Result<List<Character>>.Ok(characters);
+    }
+
+    private async Task<bool> ConfirmLoadScreenplay()
+    {
+        // Get the list of modified scenes from the workspace settings
+        var modifiedScenes = await _workspaceSettings.GetPropertyAsync<HashSet<string>>(ScreenplayConstants.ModifiedScenesKey);
+        if (modifiedScenes is null ||
+            modifiedScenes.Count == 0)
+        {
+            return true;
+        }
+
+        // Construct a sorted list containing the filename of each scene 
+        var sceneResources = new List<string>();
+        foreach (var sceneResource in modifiedScenes)
+        {
+            var getResourceResult = _resourceRegistry.GetResource(sceneResource);
+            if (getResourceResult.IsFailure)
+            {
+                // Ignore this scene resource because it no longer exists (e.g. user deleted it)
+                continue;
+            }
+
+            var sceneFilename = Path.GetFileNameWithoutExtension(sceneResource);
+            if (!string.IsNullOrEmpty(sceneFilename))
+            {
+                sceneResources.Add(sceneFilename);
+            }
+        }
+        sceneResources.Sort();
+
+        if (sceneResources.Count == 0)
+        {
+            // No existing scene resources will be affected by the load, so it can proceed.
+            return true;
+        }
+
+        var maxScenes = 5;
+        var sb = new StringBuilder();
+        for (int i = 0; i < sceneResources.Count; i++)
+        {
+            var scene = sceneResources[i];
+            if (i > maxScenes)
+            {
+                sb.Append($"...");
+                break;
+            }
+            sb.AppendLine(scene.ToString());
+        }
+        var sceneList = sb.ToString();
+
+        // Ask the user to confirm that they want to overwrite the modified scenes
+        // Todo: Localize this string
+        var message = $"Loading will overwrite modified scene files:\n{sceneList}\n\n Do you wish to continue?";
+        var confirmResult = await _dialogService.ShowConfirmationDialogAsync("Confirm Load", message);
+        if (confirmResult.IsFailure)
+        {
+            return false;
+        }
+        var confirmed = confirmResult.Value;
+
+        return confirmed;
     }
 
     private Result<string> GenerateScreenplayHTML(ResourceKey sceneResource)

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayConstants.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayConstants.cs
@@ -1,0 +1,6 @@
+namespace Celbridge.Screenplay.Services;
+
+public static class ScreenplayConstants
+{
+    public const string ModifiedScenesKey = "ModifiedScenes";
+}

--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayConstants.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplayConstants.cs
@@ -2,5 +2,8 @@ namespace Celbridge.Screenplay.Services;
 
 public static class ScreenplayConstants
 {
+    /// <summary>
+    /// Workspace settings key for modified scenes list.
+    /// </summary>
     public const string ModifiedScenesKey = "ModifiedScenes";
 }

--- a/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceSettings.cs
+++ b/Celbridge/Workspace/Celbridge.Workspace/Services/WorkspaceSettings.cs
@@ -77,6 +77,24 @@ public class WorkspaceSettings : IDisposable, IWorkspaceSettings
         }
     }
 
+    public async Task<bool> DeletePropertyAsync(string key)
+    {
+        try
+        {
+            var rowsDeleted = await _connection.DeleteAsync<WorkspaceProperty>(key);
+            if (rowsDeleted <= 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to delete workspace property for key {key}", ex);
+        }
+    }
+
     public async Task<T?> GetPropertyAsync<T>(string key)
     {
         var defaultValue = default(T);


### PR DESCRIPTION
Track modified scene files via a workspace setting.
If the user loads a screenplay while there are modified scenes in the list, confirm before completing the load.