### PR TITLE
Mark modified rows and update header in scenes sheet

### DIFF
--- a/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
+++ b/Celbridge/Modules/Celbridge.Screenplay/Services/ScreenplaySaver.cs
@@ -478,6 +478,7 @@ public class ScreenplaySaver
         var lastRow = scenesSheet.LastRowUsed()?.RowNumber() ?? 1;
         var range = scenesSheet.Range(2, 1, lastRow, 5);
 
+        bool modified = false;
         foreach (var row in range.Rows())
         {
             var @namespace = row.Cell(2).GetString();
@@ -486,7 +487,18 @@ public class ScreenplaySaver
             {
                 var modifiedCell = row.Cell(5);
                 modifiedCell.SetValue("True");
+                modified = true;
             }
+        }
+
+        if (modified)
+        {
+            // Set header cell in column D to "Modified" and copy the style from the cell to its left
+            var headerCell = scenesSheet.Cell(1, 5);
+            headerCell.Value = "Modified";
+
+            var leftCell = scenesSheet.Cell(1, 4);
+            headerCell.Style = leftCell.Style;
         }
     }
 


### PR DESCRIPTION
Introduced a 'modified' flag to track changes in the scenes sheet. When any row is marked as modified, the header in column D is updated to 'Modified' and its style is copied from the adjacent cell to maintain consistency.