### PR TITLE
Fix IsEnabled logic for DropDownTextBox and TextBox elements

### DIFF
--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/DropDownTextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/DropDownTextBoxElement.cs
@@ -142,7 +142,7 @@ public partial class DropDownTextBoxElement : FormElement
         if (buttonTextResult.IsFailure)
         {
             return Result<FrameworkElement>.Fail($"Failed to apply 'buttonText' config property")
-                .WithErrors(iconResult);
+                .WithErrors(buttonTextResult);
         }        
 
         var valuesResult = ApplyValuesConfig(config, dropDownTextBox);
@@ -179,7 +179,7 @@ public partial class DropDownTextBoxElement : FormElement
             }
             else if (configValue.ValueKind == JsonValueKind.True)
             {
-                dropDownTextBox.IsEnabled = false;
+                dropDownTextBox.IsEnabled = true;
             }
             else if (configValue.ValueKind == JsonValueKind.False)
             {

--- a/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Celbridge/CoreServices/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -164,7 +164,7 @@ public partial class TextBoxElement : FormElement
             }
             else if (configValue.ValueKind == JsonValueKind.True)
             {
-                textBox.IsEnabled = false;
+                textBox.IsEnabled = true;
             }
             else if (configValue.ValueKind == JsonValueKind.False)
             {


### PR DESCRIPTION
Corrects the logic for setting the IsEnabled property when the config value is true, ensuring that controls are enabled as expected. Also fixes error propagation in DropDownTextBoxElement to use the correct result object.