### PR TITLE
SpreadJS integration for Excel editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,4 +407,4 @@ solution-config.props
 /Celbridge/Build
 
 # SpreadJS library
-SpreadJS/lib
+/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/lib

--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,6 @@ solution-config.props
 
 .idea/
 /Celbridge/Build
+
+# SpreadJS library
+SpreadJS/lib

--- a/Celbridge/Workspace/Celbridge.Documents/Views/SpreadsheetDocumentView.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/SpreadsheetDocumentView.cs
@@ -82,7 +82,7 @@ public sealed partial class SpreadsheetDocumentView : DocumentView
             var webView = new WebView2();
             await webView.EnsureCoreWebView2Async();
 
-            webView.CoreWebView2.SetVirtualHostNameToFolderMapping("SpreadJS", 
+            webView.CoreWebView2.SetVirtualHostNameToFolderMapping("spreadjs.celbridge", 
                 "Celbridge.Documents/Web/SpreadJS", 
                 CoreWebView2HostResourceAccessKind.Allow);
 
@@ -100,7 +100,7 @@ public sealed partial class SpreadsheetDocumentView : DocumentView
             catch (Exception)
             {
                 // The SpreadJS license file is not present, display an error message an exit.
-                webView.CoreWebView2.Navigate("https://SpreadJS/error.html");
+                webView.CoreWebView2.Navigate("https://spreadjs.celbridge/error.html");
                 _webView = webView;
                 this.Content = _webView;
                 return;
@@ -110,7 +110,7 @@ public sealed partial class SpreadsheetDocumentView : DocumentView
 
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.isWebView = true;");
 
-            webView.CoreWebView2.Navigate("https://SpreadJS/index.html");
+            webView.CoreWebView2.Navigate("https://spreadjs.celbridge/index.html");
 
             bool isEditorReady = false;
             TypedEventHandler<WebView2, CoreWebView2WebMessageReceivedEventArgs> onWebMessageReceived = (sender, e) =>

--- a/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/error.html
+++ b/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/error.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Excel Editor Unavailable</title>
+    <style>
+        body {
+            background: white;
+            color: black;
+            font-family: sans-serif;
+            padding: 2em;
+        }
+    </style>
+</head>
+<body>
+    <h1>Excel Editor Unavailable</h1>
+    <p>The Excel editor is not available because it uses <a href="https://www.mescius.eu/en/spreadjs">SpreadJS</a> which is a commercial product that requires a valid license.</p>
+</body>
+</html>

--- a/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/error.html
+++ b/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/error.html
@@ -14,6 +14,6 @@
 </head>
 <body>
     <h1>Excel Editor Unavailable</h1>
-    <p>The Excel editor is not available because it uses <a href="https://www.mescius.eu/en/spreadjs">SpreadJS</a> which is a commercial product that requires a valid license.</p>
+    <p>The Excel editor is not available because it uses <a href="https://developer.mescius.com/spreadjs">SpreadJS</a> which is a commercial product that requires a valid license.</p>
 </body>
 </html>

--- a/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/index.html
+++ b/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/index.html
@@ -8,10 +8,45 @@
 
     <link rel="stylesheet" href="lib/spreadjs/css/gc.spread.sheets.excel2013white.18.1.4.css" />
     <link rel="stylesheet" href="lib/designer/css/gc.spread.sheets.designer.18.1.4.min.css" />
+
+    <style>
+        /* remove all spacing around the SpreadJS container */
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden; /* avoid scrollbars from 100vh, optional */
+        }
+
+        /* make the designer fill the viewport exactly */
+        #gc-designer-container {
+            position: fixed;
+            inset: 0;
+        }
+
+        .spreadjs-badge {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            z-index: 10000;
+            pointer-events: none;
+            font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        }
+
+        .spreadjs-badge a {
+            pointer-events: auto;
+            text-decoration: none;
+        }
+    </style>
+
 </head>
 
 <body unselectable="on">
     <div id="gc-designer-container" role="application" style="width:100%; height:100vh;"></div>
+
+    <div class="spreadjs-badge" aria-label="Powered by SpreadJS">
+        Powered by <a href="https://developer.mescius.com/spreadjs" target="_blank" rel="noopener">SpreadJS</a>
+    </div>
 
     <script src="lib/spreadjs/scripts/gc.spread.sheets.all.18.1.4.min.js"></script>
     <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.shapes.18.1.4.min.js"></script>

--- a/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/index.html
+++ b/Celbridge/Workspace/Celbridge.Documents/Web/SpreadJS/index.html
@@ -6,34 +6,32 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Celbridge Spreadsheet</title>
 
-    <!-- Mescius CDN styles -->
-    <link rel="stylesheet" href="https://cdn.mescius.com/spreadjs/hosted/css/gc.spread.sheets.excel2013white.18.1.4.css" />
-    <link rel="stylesheet" href="https://cdn.mescius.com/spreadjs/hosted/css/gc.spread.sheets.designer.18.1.4.min.css" />
-    <link rel="stylesheet" href="custom.css" />
+    <link rel="stylesheet" href="lib/spreadjs/css/gc.spread.sheets.excel2013white.18.1.4.css" />
+    <link rel="stylesheet" href="lib/designer/css/gc.spread.sheets.designer.18.1.4.min.css" />
 </head>
 
 <body unselectable="on">
     <div id="gc-designer-container" role="application" style="width:100%; height:100vh;"></div>
 
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/gc.spread.sheets.all.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.shapes.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.charts.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.datacharts.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.slicers.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.print.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.barcode.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.pdf.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.pivot.pivottables.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.tablesheet.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.ganttsheet.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.formulapanel.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.report.reportsheet.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/plugins/gc.spread.sheets.io.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/gc.spread.sheets.all.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.shapes.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.charts.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.datacharts.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.slicers.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.print.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.barcode.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.pdf.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.pivot.pivottables.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.tablesheet.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.ganttsheet.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.formulapanel.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.report.reportsheet.18.1.4.min.js"></script>
+    <script src="lib/spreadjs/scripts/plugins/gc.spread.sheets.io.18.1.4.min.js"></script>
 
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/gc.spread.sheets.designer.resource.en.18.1.4.min.js"></script>
-    <script src="https://cdn.mescius.com/spreadjs/hosted/scripts/gc.spread.sheets.designer.all.18.1.4.min.js"></script>
+    <script src="lib/designer/scripts/gc.spread.sheets.designer.resource.en.18.1.4.min.js"></script>
+    <script src="lib/designer/scripts/gc.spread.sheets.designer.all.18.1.4.min.js"></script>
 
-    <script src="https://celbridge-app-static-files.celbridge.org/libs/spreadjs/license.js"></script>
+    <script src="lib/license.js"></script>
 
     <script>
         function listenForWebViewMessages() {

--- a/Celbridge/Workspace/Celbridge.Python/Services/PythonInstaller.cs
+++ b/Celbridge/Workspace/Celbridge.Python/Services/PythonInstaller.cs
@@ -8,7 +8,6 @@ public static class PythonInstaller
 {
     private const string PythonFolderName = "Python";
     private const string PythonZipAssetPath = "ms-appx:///Assets/EmbeddedPython/python-3.13.6-embed-amd64.zip";
-    private const string PipZipAssetPath = "ms-appx:///Assets/EmbeddedPython/pip.zip";
 
     public static async Task<Result<string>> InstallPythonAsync()
     {


### PR DESCRIPTION
This integration enables the user to edit Excel spreadsheets as a document type using SpreadJS via a WebView2.

SpreadJS is a commercial Javascript library, which requires a valid license that we are not permitted to distribute publicly. Instead, we bundle the SpreadJS library and license details when building the installer for Celbridge. 

N.B. This means that the Excel editing feature only works in the installer version of Celbridge.

