### PR TITLE
Use .webapp extension to communicate intent more clearly

### DIFF
--- a/Celbridge/BaseLibrary/Documents/DocumentViewType.cs
+++ b/Celbridge/BaseLibrary/Documents/DocumentViewType.cs
@@ -18,9 +18,9 @@ public enum DocumentViewType
     TextDocument,
 
     /// <summary>
-    /// A web page document with the .web extension.
+    /// A web app document with the .webapp extension.
     /// </summary>
-    WebPageDocument,
+    WebAppDocument,
 
     /// <summary>
     /// A non-text file resource viewed via a web view.

--- a/Celbridge/BaseLibrary/Explorer/IAddResourceDialogCommand.cs
+++ b/Celbridge/BaseLibrary/Explorer/IAddResourceDialogCommand.cs
@@ -1,4 +1,4 @@
-﻿using Celbridge.Commands;
+using Celbridge.Commands;
 
 namespace Celbridge.Explorer;
 
@@ -11,6 +11,11 @@ public interface IAddResourceDialogCommand : IExecutableCommand
     /// The type of resource to add.
     /// </summary>
     ResourceType ResourceType { get; set; }
+
+    /// <summary>
+    /// The file format of the resource to add (.txt, .xlsx, .md, etc.)
+    /// </summary>
+    ResourceFormat ResourceFormat { get; set; }
 
     /// <summary>
     /// Resource key for the folder which will contain the new resource.

--- a/Celbridge/BaseLibrary/Explorer/ResourceFormat.cs
+++ b/Celbridge/BaseLibrary/Explorer/ResourceFormat.cs
@@ -1,0 +1,37 @@
+namespace Celbridge.Explorer;
+
+/// <summary>
+/// File formats that can be added as resources via the explorer window.
+/// </summary>
+public enum ResourceFormat
+{
+    /// <summary>
+    /// A file "format" corresponding to a folder resource.
+    /// </summary>
+    Folder,
+
+    /// <summary>
+    /// Any text file format (e.g. .txt, .cs, .json, .xml, etc.)
+    /// </summary>
+    Text,
+
+    /// <summary>
+    /// An Excel spreadsheet document with the .xlsx extension
+    /// </summary>
+    Excel,
+
+    /// <summary>
+    /// A markdown document with the .md extension
+    /// </summary>
+    Markdown,
+
+    /// <summary>
+    /// A Python script file with the .py extension
+    /// </summary>
+    Python,
+
+    /// <summary>
+    /// A web app document with the .webapp extension
+    /// </summary>
+    WebApp
+}

--- a/Celbridge/BaseLibrary/Explorer/ResourceType.cs
+++ b/Celbridge/BaseLibrary/Explorer/ResourceType.cs
@@ -1,7 +1,7 @@
-﻿namespace Celbridge.Explorer;
+namespace Celbridge.Explorer;
 
 /// <summary>
-/// Types of resource that can be added to a project.
+/// Types of resource that can a project can contain.
 /// </summary>
 public enum ResourceType
 {

--- a/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Celbridge/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -132,8 +132,20 @@
   <data name="DocumentsPanel_Title" xml:space="preserve">
     <value>Documents</value>
   </data>
-  <data name="ResourceTree_File" xml:space="preserve">
-    <value>File</value>
+  <data name="ResourceTree_AddFile_TextFile" xml:space="preserve">
+    <value>Text file (.txt, .json, .html, ...)</value>
+  </data>
+  <data name="ResourceTree_AddFile_WebApp" xml:space="preserve">
+    <value>Web application file  (.webapp)</value>
+  </data>
+  <data name="ResourceTree_AddFile_Excel" xml:space="preserve">
+    <value>Excel file (.xlsx)</value>
+  </data>
+  <data name="ResourceTree_AddFile_Markdown" xml:space="preserve">
+    <value>Markdown file (.md)</value>
+  </data>
+  <data name="ResourceTree_AddFile_PythonScript" xml:space="preserve">
+    <value>Python script (.py)</value>
   </data>
   <data name="ResourceTree_Folder" xml:space="preserve">
     <value>Folder</value>

--- a/Celbridge/Workspace/Celbridge.Documents/ServiceConfiguration.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/ServiceConfiguration.cs
@@ -22,7 +22,7 @@ public static class ServiceConfiguration
 
         services.AddTransient<IDocumentsPanel, DocumentsPanel>();
         services.AddTransient<TextBoxDocumentView>();
-        services.AddTransient<WebPageDocumentView>();
+        services.AddTransient<WebAppDocumentView>();
         services.AddTransient<MonacoEditorView>();
         services.AddTransient<FileViewerDocumentView>();
         services.AddTransient<EditorPreviewView>();
@@ -36,7 +36,7 @@ public static class ServiceConfiguration
         services.AddTransient<DocumentsPanelViewModel>();
         services.AddTransient<DocumentTabViewModel>();
         services.AddTransient<DefaultDocumentViewModel>();
-        services.AddTransient<WebPageDocumentViewModel>();
+        services.AddTransient<WebAppDocumentViewModel>();
         services.AddTransient<MonacoEditorViewModel>();
         services.AddTransient<FileViewerDocumentViewModel>();
         services.AddTransient<EditorPreviewViewModel>();

--- a/Celbridge/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -443,8 +443,8 @@ public class DocumentsService : IDocumentsService, IDisposable
                 documentView = _serviceProvider.GetRequiredService<TextEditorDocumentView>();
                 break;
 
-            case DocumentViewType.WebPageDocument:
-                documentView = _serviceProvider.GetRequiredService<WebPageDocumentView>();
+            case DocumentViewType.WebAppDocument:
+                documentView = _serviceProvider.GetRequiredService<WebAppDocumentView>();
                 break;
 
             case DocumentViewType.FileViewer:
@@ -455,8 +455,8 @@ public class DocumentsService : IDocumentsService, IDisposable
                 documentView = _serviceProvider.GetRequiredService<SpreadsheetDocumentView>();
                 break;
 #else
-            case DocumentViewType.WebPageDocument:
-                documentView = _serviceProvider.GetRequiredService<WebPageDocumentView>();
+            case DocumentViewType.WebAppDocument:
+                documentView = _serviceProvider.GetRequiredService<WebAppDocumentView>();
                 break;
             case DocumentViewType.TextDocument:
             case DocumentViewType.FileViewer:

--- a/Celbridge/Workspace/Celbridge.Documents/Services/FileTypeHelper.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Services/FileTypeHelper.cs
@@ -30,9 +30,10 @@ public class FileTypeHelper
 
     public DocumentViewType GetDocumentViewType(string fileExtension)
     {
-        if (fileExtension == ".web")
+        if (fileExtension == ".webapp" ||
+            fileExtension == ".web") // Todo: Remove this - legacy support
         {
-            return DocumentViewType.WebPageDocument;
+            return DocumentViewType.WebAppDocument;
         }
 
         if (fileExtension == ".xlsx")

--- a/Celbridge/Workspace/Celbridge.Documents/ViewModels/WebPageDocumentViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/ViewModels/WebPageDocumentViewModel.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Celbridge.Documents.ViewModels;
 
-public partial class WebPageDocumentViewModel : DocumentViewModel
+public partial class WebAppDocumentViewModel : DocumentViewModel
 {
     private readonly ICommandService _commandService;
 
@@ -13,12 +13,12 @@ public partial class WebPageDocumentViewModel : DocumentViewModel
     private string _sourceUrl = string.Empty;
 
     // Code gen requires a parameterless constructor
-    public WebPageDocumentViewModel()
+    public WebAppDocumentViewModel()
     {
         throw new NotImplementedException();
     }
 
-    public WebPageDocumentViewModel(ICommandService commandService)
+    public WebAppDocumentViewModel(ICommandService commandService)
     {
         _commandService = commandService;
     }
@@ -31,7 +31,7 @@ public partial class WebPageDocumentViewModel : DocumentViewModel
 
             if (string.IsNullOrEmpty(text))
             {
-                // No data populated yet in the .web file, default to empty url
+                // No data populated yet in the .webapp file, default to empty url
                 SourceUrl = string.Empty;
                 return Result.Ok();
             }
@@ -57,7 +57,7 @@ public partial class WebPageDocumentViewModel : DocumentViewModel
                 .WithException(ex);
         }
 
-        return Result.Fail($"Failed to local content from .web file: {FileResource}");
+        return Result.Fail($"Failed to local content from .webapp file: {FileResource}");
     }
 
     public void OpenBrowser(string url)

--- a/Celbridge/Workspace/Celbridge.Documents/Views/WebAppDocumentView.cs
+++ b/Celbridge/Workspace/Celbridge.Documents/Views/WebAppDocumentView.cs
@@ -11,20 +11,20 @@ using Path = System.IO.Path;
 
 namespace Celbridge.Documents.Views;
 
-public sealed partial class WebPageDocumentView : DocumentView
+public sealed partial class WebAppDocumentView : DocumentView
 {
-    private ILogger<WebPageDocumentView> _logger;
+    private ILogger<WebAppDocumentView> _logger;
     private ICommandService _commandService;
     private IUtilityService _utilityService;
     private IResourceRegistry _resourceRegistry;
 
-    public WebPageDocumentViewModel ViewModel { get; }
+    public WebAppDocumentViewModel ViewModel { get; }
 
     private WebView2 _webView;
 
-    public WebPageDocumentView(
+    public WebAppDocumentView(
         IServiceProvider serviceProvider,
-        ILogger<WebPageDocumentView> logger,
+        ILogger<WebAppDocumentView> logger,
         ICommandService commandService,
         IUtilityService utilityService,
         IWorkspaceWrapper workspaceWrapper)
@@ -33,7 +33,7 @@ public sealed partial class WebPageDocumentView : DocumentView
         _commandService = commandService;
         _utilityService = utilityService;
 
-        ViewModel = serviceProvider.GetRequiredService<WebPageDocumentViewModel>();
+        ViewModel = serviceProvider.GetRequiredService<WebAppDocumentViewModel>();
 
         _resourceRegistry = workspaceWrapper.WorkspaceService.ExplorerService.ResourceRegistry;
 

--- a/Celbridge/Workspace/Celbridge.Explorer/Services/ResourceUtils.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Services/ResourceUtils.cs
@@ -156,32 +156,36 @@ public class ResourceUtils
         return Result.Ok();
     }
 
-    public static Result<string> ExtractUrlFromWebFile(string webFilePath)
+    public static Result<string> ExtractUrlFromWebAppFile(string webAppPath)
     {
         try
         {
-            if (string.IsNullOrEmpty(webFilePath))
+            if (string.IsNullOrEmpty(webAppPath))
             {
-                return Result<string>.Fail($"Failed to get path for file resource: {webFilePath}");
+                return Result<string>.Fail($"Failed to get path for file resource: {webAppPath}");
             }
 
-            if (!File.Exists(webFilePath))
+            if (!File.Exists(webAppPath))
             {
-                return Result<string>.Fail($"File does not exist: {webFilePath}");
+                return Result<string>.Fail($"File does not exist: {webAppPath}");
             }
 
-            if (Path.GetExtension(webFilePath) != ".web")
+            var fileExtension = Path.GetExtension(webAppPath);
+
+            if (fileExtension != ".webapp" &&
+                fileExtension == ".web") // Todo: Remove this - legacy support
+
             {
-                return Result<string>.Fail($"File does not have the .web extension: {webFilePath}");
+                return Result<string>.Fail($"File does not have the .webapp extension: {webAppPath}");
             }
 
-            var json = File.ReadAllText(webFilePath);
+            var json = File.ReadAllText(webAppPath);
             var jsonObj = JObject.Parse(json);
 
             var urlToken = jsonObj["sourceUrl"];
             if (urlToken is null)
             {
-                return Result<string>.Fail($"Failed to find 'sourceUrl' property in .web JSON data: {webFilePath}");
+                return Result<string>.Fail($"Failed to find 'sourceUrl' property in .webapp JSON data: {webAppPath}");
             }
 
             // Todo: This logic is repeated in multiple places, move it to the utility service
@@ -202,7 +206,7 @@ public class ResourceUtils
         }
         catch (Exception ex)
         {
-            return Result<string>.Fail($"An exception occurred when extracting the url from a .web file")
+            return Result<string>.Fail($"An exception occurred when extracting the url from a .webapp file")
                 .WithException(ex); ;
         }
     }

--- a/Celbridge/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -225,7 +225,7 @@ public partial class ResourceTreeViewModel : ObservableObject
         });
     }
 
-    public void ShowAddResourceDialog(ResourceType resourceType, IFolderResource? destFolder)
+    public void ShowAddResourceDialog(ResourceType resourceType, ResourceFormat resourceFormat, IFolderResource? destFolder)
     {
         var resourceRegistry = _explorerService.ResourceRegistry;
 
@@ -240,7 +240,8 @@ public partial class ResourceTreeViewModel : ObservableObject
         // Execute a command to show the add resource dialog
         _commandService.Execute<IAddResourceDialogCommand>(command =>
         {
-            command.ResourceType = resourceType;
+            command.ResourceType = resourceType; // File or folder
+            command.ResourceFormat = resourceFormat; // Folder, .txt, .md, .py, etc.
             command.DestFolderResource = destFolderResource;
         });
     }

--- a/Celbridge/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -288,11 +288,14 @@ public partial class ResourceTreeViewModel : ObservableObject
         var resourceRegistry = _explorerService.ResourceRegistry;
         var resourceKey = resource is null ? ResourceKey.Empty : resourceRegistry.GetResourceKey(resource);
 
-        if (Path.GetExtension(resourceKey) == ".web")
+        var fileExtension = Path.GetExtension(resourceKey);
+
+        if (fileExtension == ".webapp" ||
+            fileExtension == ".web") // Todo: Remove this - legacy support
         {
             var webFilePath = resourceRegistry.GetResourcePath(resourceKey);
 
-            var extractResult = ResourceUtils.ExtractUrlFromWebFile(webFilePath);
+            var extractResult = ResourceUtils.ExtractUrlFromWebAppFile(webFilePath);
             if (extractResult.IsFailure)
             {
                 _logger.LogError(extractResult.Error);

--- a/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml
+++ b/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Celbridge.Explorer.Views"
+    xmlns:explorer="using:Celbridge.Explorer"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -25,9 +26,21 @@
         <MenuFlyoutItem Text="{x:Bind FolderString}"
                         Icon="Folder"
                         Click="ResourceContextMenu_AddFolder" />
-        <MenuFlyoutItem Text="{x:Bind FileString}"
-                        Icon="Add"
+        <MenuFlyoutItem Text="{x:Bind AddPythonScriptString}"
+                        Tag="{x:Bind explorer:ResourceFormat.Python}"
                         Click="ResourceContextMenu_AddFile" />
+        <MenuFlyoutItem Text="{x:Bind AddExcelString}"
+                        Tag="{x:Bind explorer:ResourceFormat.Excel}"
+                        Click="ResourceContextMenu_AddFile" />
+        <MenuFlyoutItem Text="{x:Bind AddMarkdownString}"
+                        Tag="{x:Bind explorer:ResourceFormat.Markdown}"
+                        Click="ResourceContextMenu_AddFile" />
+        <MenuFlyoutItem Text="{x:Bind AddWebAppString}"
+                        Tag="{x:Bind explorer:ResourceFormat.WebApp}"
+                        Click="ResourceContextMenu_AddFile" />
+        <MenuFlyoutItem Text="{x:Bind AddTextFileString}"
+                        Tag="{x:Bind explorer:ResourceFormat.Text}"
+                        Click="ResourceContextMenu_AddFile" />        
       </MenuFlyoutSubItem>
       <MenuFlyoutSubItem Text="{x:Bind EditString}">
         <MenuFlyoutItem Text="{x:Bind CutString}"

--- a/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
@@ -8,7 +8,6 @@ using Windows.UI.Core;
 
 namespace Celbridge.Explorer.Views;
 
-
 public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
 {
     private readonly IStringLocalizer _stringLocalizer;

--- a/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
+++ b/Celbridge/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
@@ -8,6 +8,7 @@ using Windows.UI.Core;
 
 namespace Celbridge.Explorer.Views;
 
+
 public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
 {
     private readonly IStringLocalizer _stringLocalizer;
@@ -18,7 +19,11 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
     private LocalizedString OpenString => _stringLocalizer.GetString("ResourceTree_Open");
     private LocalizedString AddString => _stringLocalizer.GetString("ResourceTree_Add");
     private LocalizedString FolderString => _stringLocalizer.GetString("ResourceTree_Folder");
-    private LocalizedString FileString => _stringLocalizer.GetString("ResourceTree_File");
+    private LocalizedString AddExcelString => _stringLocalizer.GetString("ResourceTree_AddFile_Excel");
+    private LocalizedString AddMarkdownString => _stringLocalizer.GetString("ResourceTree_AddFile_Markdown");
+    private LocalizedString AddPythonScriptString => _stringLocalizer.GetString("ResourceTree_AddFile_PythonScript");
+    private LocalizedString AddWebAppString => _stringLocalizer.GetString("ResourceTree_AddFile_WebApp");
+    private LocalizedString AddTextFileString => _stringLocalizer.GetString("ResourceTree_AddFile_TextFile");
     private LocalizedString EditString => _stringLocalizer.GetString("ResourceTree_Edit");
     private LocalizedString CutString => _stringLocalizer.GetString("ResourceTree_Cut");
     private LocalizedString CopyString => _stringLocalizer.GetString("ResourceTree_Copy");
@@ -304,19 +309,19 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
         if (resource is IFolderResource destFolder)
         {
             // Add a folder to the selected folder
-            ViewModel.ShowAddResourceDialog(ResourceType.Folder, destFolder);
+            ViewModel.ShowAddResourceDialog(ResourceType.Folder, ResourceFormat.Folder, destFolder);
         }
         else if (resource is IFileResource destFile)
         {
             // Add a folder to the folder containing the selected file
             Guard.IsNotNull(destFile.ParentFolder);
 
-            ViewModel.ShowAddResourceDialog(ResourceType.Folder, destFile.ParentFolder);
+            ViewModel.ShowAddResourceDialog(ResourceType.Folder, ResourceFormat.Folder, destFile.ParentFolder);
         }
         else
         {
             // Add a folder resource to the root folder
-            ViewModel.ShowAddResourceDialog(ResourceType.Folder, null);
+            ViewModel.ShowAddResourceDialog(ResourceType.Folder, ResourceFormat.Folder, null);
         }
     }
 
@@ -324,22 +329,30 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
     {
         var resource = AcquireContextMenuResource(sender);
 
+        var format = ResourceFormat.Text;
+        var tagObject = (sender as MenuFlyoutItem)?.Tag;
+        if (tagObject is ResourceFormat selectedFileType)
+        {
+            format = selectedFileType;
+        }
+
         if (resource is IFolderResource destFolder)
         {
             // Add a file to the selected folder
-            ViewModel.ShowAddResourceDialog(ResourceType.File, destFolder);
+            ViewModel.ShowAddResourceDialog(ResourceType.File, format, destFolder);
+            return;
         }
         else if (resource is IFileResource destFile)
         {
-            // Add a file to the folder containing the selected file
             Guard.IsNotNull(destFile.ParentFolder);
 
-            ViewModel.ShowAddResourceDialog(ResourceType.File, destFile.ParentFolder);
+            // Add a file to the folder containing the selected file
+            ViewModel.ShowAddResourceDialog(ResourceType.File, format, destFile.ParentFolder);
         }
         else
         {
             // Add a file resource to the root folder
-            ViewModel.ShowAddResourceDialog(ResourceType.File, null);
+            ViewModel.ShowAddResourceDialog(ResourceType.File, format, null);
         }
     }
 

--- a/Celbridge/Workspace/Celbridge.Inspector/Services/InspectorFactory.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/Services/InspectorFactory.cs
@@ -80,10 +80,11 @@ public class InspectorFactory : IInspectorFactory
 
     private Result<IInspector> CreateFileInspector(ResourceKey resource)
     {
-        var extension = Path.GetExtension(resource);
+        var fileExtension = Path.GetExtension(resource);
 
         IInspector? inspector = null;
-        if (extension == ".web")
+        if (fileExtension == ".webapp" ||
+            fileExtension == ".web") // Todo: Remove this - legacy support
         {
             inspector = CreateInspector<WebInspector, WebInspectorViewModel>(resource);
         }

--- a/Celbridge/Workspace/Celbridge.Inspector/ViewModels/WebInspectorViewModel.cs
+++ b/Celbridge/Workspace/Celbridge.Inspector/ViewModels/WebInspectorViewModel.cs
@@ -90,7 +90,7 @@ public partial class WebInspectorViewModel : InspectorViewModel
 
             if (string.IsNullOrEmpty(json))
             {
-                // No data populated yet in the .web file, default to empty url
+                // No data populated yet in the .webapp file, default to empty url
                 return Result<string>.Ok(string.Empty);
             }
 


### PR DESCRIPTION
The purpose of .webapp files is to make it easy to integrate web applications with Celbridge. The previous .web file extension was shorter, but .webapp makes the intended usage much clearer.

This PR also adds separate context menu items for the most commonly added file types in Celbridge (.md, .xlsx, .webapp, .py, .txt)