### PR TITLE
Convert the InspectorPanel from C# Markup to XAML

### DIFF
--- a/Celbridge/Workspace/Celbridge.Inspector/Views/InspectorPanel.xaml
+++ b/Celbridge/Workspace/Celbridge.Inspector/Views/InspectorPanel.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="Celbridge.Inspector.Views.InspectorPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:local="using:Celbridge.Inspector.Views"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+  <Grid>
+
+    <Grid.RowDefinitions>
+      <RowDefinition Height="40"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <Grid BorderBrush="{ThemeResource PanelBorderBrush}"
+          BorderThickness="0,0,0,1">
+      
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+
+      <TextBlock Grid.Column="0"
+                 Margin="6,0,0,0"
+                 VerticalAlignment="Center"
+                 Text="{x:Bind TitleString.Value, Mode=OneWay}" />
+    </Grid>
+    
+    <local:EntityEditor x:Name="EntityEditor"
+                        Grid.Row="1"
+                        Margin="4" />
+  </Grid>
+</UserControl>

--- a/examples/celbridge/entities/04_spreadsheets/readme.md.json
+++ b/examples/celbridge/entities/04_spreadsheets/readme.md.json
@@ -2,7 +2,7 @@
   "_entityVersion": 1,
   "_components": [
     {
-      "editorMode": "EditorAndPreview",
+      "editorMode": "Preview",
       "_type": "Markdown.Markdown#1"
     }
   ]


### PR DESCRIPTION
We've decided to standardize on XAML rather than C# Markup as we've encountered a lot issues with obscure binding syntax and weird incompatibilities compared to the equivalent XAML code.