### PR TITLE
Fix collapse explorer panel button position

### DIFF
--- a/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -39,8 +39,6 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         //
         this.DataContext = ViewModel;
 
-        UpdateTabstripEnds();
-
         // Listen for property changes on the ViewModel
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
@@ -92,15 +90,14 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     private void DocumentsPanel_Loaded(object sender, RoutedEventArgs e)
     {
         ViewModel.OnViewLoaded();
+
+        UpdateTabstripEnds();
     }
 
     private void DocumentsPanel_Unloaded(object sender, RoutedEventArgs e)
     {
         ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
         ViewModel.OnViewUnloaded();
-
-        Loaded -= DocumentsPanel_Loaded;
-        Unloaded -= DocumentsPanel_Unloaded;
     }
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -125,7 +122,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         else
         {
             TabView.TabStripHeader = new Grid()
-                .Width(96);
+                .Width(48);
         }
 
         if (ViewModel.IsInspectorPanelVisible)

--- a/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml
+++ b/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml
@@ -68,7 +68,7 @@
               Command="{x:Bind ViewModel.ToggleExplorerPanelCommand}"
               HorizontalAlignment="Left"
               VerticalAlignment="Top"
-              Margin="48,8,0,0">
+              Margin="4">
         <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                   Glyph="&#xE76C;"/>
       </Button>


### PR DESCRIPTION
Don't unregister callbacks in DocumentsPanel_Unloaded. Unloaded gets called now when switching between navigator bar views.

Fixes #503
