### PR TITLE
Select filename part in Add, Duplicate and Rename dialogs

### DIFF
--- a/app/Workspace/Celbridge.Explorer/Commands/AddResourceDialogCommand.cs
+++ b/app/Workspace/Celbridge.Explorer/Commands/AddResourceDialogCommand.cs
@@ -77,11 +77,15 @@ public class AddResourceDialogCommand : CommandBase, IAddResourceDialogCommand
 
         var enterNameString = _stringLocalizer.GetString("ResourceTree_EnterName");
 
+        // Select only the filename part without the extension
+        var extensionIndex = defaultText.LastIndexOf('.');
+        var selectionRange = extensionIndex > 0 ? 0..extensionIndex : ..;
+
         var showResult = await _dialogService.ShowInputTextDialogAsync(
             titleString,
             enterNameString,
             defaultText,
-            ..,
+            selectionRange,
             validator);
 
         if (showResult.IsSuccess)

--- a/app/Workspace/Celbridge.Explorer/Commands/DuplicateResourceDialogCommand.cs
+++ b/app/Workspace/Celbridge.Explorer/Commands/DuplicateResourceDialogCommand.cs
@@ -55,18 +55,9 @@ public class DuplicateResourceDialogCommand : CommandBase, IDuplicateResourceDia
 
         var resourceName = resource.Name;
 
-        Range selectedRange;
-        switch (resource)
-        {
-            case IFileResource:
-                selectedRange = new Range(0, Path.GetFileNameWithoutExtension(resourceName).Length); // Don't select extension
-                break;
-            case IFolderResource:
-                selectedRange = new Range(0, resourceName.Length);
-                break;
-            default:
-                throw new ArgumentException();
-        }
+        // Select only the filename part without the extension
+        var extensionIndex = resourceName.LastIndexOf('.');
+        var selectedRange = extensionIndex > 0 ? 0..extensionIndex : ..;
 
         var duplicateResourceString = _stringLocalizer.GetString("ResourceTree_DuplicateResource", resourceName);
 

--- a/app/Workspace/Celbridge.Explorer/Commands/RenameResourceDialogCommand.cs
+++ b/app/Workspace/Celbridge.Explorer/Commands/RenameResourceDialogCommand.cs
@@ -56,18 +56,9 @@ public class RenameResourceDialogCommand : CommandBase, IRenameResourceDialogCom
 
         var resourceName = resource.Name;
 
-        Range selectedRange;
-        switch (resource)
-        {
-            case IFileResource:
-                selectedRange = new Range(0, Path.GetFileNameWithoutExtension(resourceName).Length); // Don't select extension
-                break;
-            case IFolderResource:
-                selectedRange = new Range(0, resourceName.Length);
-                break;
-            default:
-                throw new ArgumentException();
-        }
+        // Select only the filename part without the extension
+        var extensionIndex = resourceName.LastIndexOf('.');
+        var selectedRange = extensionIndex > 0 ? 0..extensionIndex : ..;
 
         var renameResourceString = _stringLocalizer.GetString("ResourceTree_RenameResource", resourceName);
 


### PR DESCRIPTION
The Add, Duplicate and Rename resource dialogs default to selecting just the filename rather than the entire string including the file extension. Most of the time the user only wants to change the filename rather than the file extension, so this change avoids first having to adjust the caret / selected text.

Fixes #495 