### PR TITLE
Edit files with no extension as text documents

### DIFF
--- a/app/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/app/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -148,7 +148,8 @@ public class DocumentsService : IDocumentsService, IDisposable
         var extension = Path.GetExtension(fileResource).ToLowerInvariant();
         if (string.IsNullOrEmpty(extension))
         {
-            return DocumentViewType.UnsupportedFormat;
+            // Assume files with no extension are text documents
+            return DocumentViewType.TextDocument;
         }
 
         return _fileTypeHelper.GetDocumentViewType(extension);


### PR DESCRIPTION
Files with no extension are opened as text files. Fixes #528

Note: The ticket also mentioned .bat files, but I was able to open and edit these without issue. 