### PR TITLE
Add copy resource key and file path context menu options

### DIFF
--- a/app/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/app/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -558,4 +558,10 @@ Do you wish to continue?</value>
   <data name="ResourceTree_AddFolder" xml:space="preserve">
     <value>Add folder</value>
   </data>
+  <data name="ResourceTree_CopyResourceKey" xml:space="preserve">
+    <value>Copy resource key</value>
+  </data>
+  <data name="ResourceTree_CopyFilePath" xml:space="preserve">
+    <value>Copy file path</value>
+  </data>
 </root>

--- a/app/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/app/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -19,11 +19,11 @@
             <MenuFlyoutItem x:Name="CloseToTheRightMenuItem" Click="ContextMenu_CloseToTheRight" />
             <MenuFlyoutItem x:Name="CloseToTheLeftMenuItem" Click="ContextMenu_CloseToTheLeft" />
             <MenuFlyoutItem x:Name="CloseAllMenuItem" Click="ContextMenu_CloseAll" />
+            <MenuFlyoutItem x:Name="SelectFileMenuItem" Click="ContextMenu_SelectFile" />
             <MenuFlyoutSeparator />
             <MenuFlyoutItem x:Name="CopyResourceKeyMenuItem" Click="ContextMenu_CopyResourceKey" />
             <MenuFlyoutItem x:Name="CopyFilePathMenuItem" Click="ContextMenu_CopyFilePath" />
             <MenuFlyoutSeparator />
-            <MenuFlyoutItem x:Name="SelectFileMenuItem" Click="ContextMenu_SelectFile" />
             <MenuFlyoutItem x:Name="OpenFileExplorerMenuItem" Click="ContextMenu_OpenFileExplorer" />
             <MenuFlyoutItem x:Name="OpenApplicationMenuItem" Click="ContextMenu_OpenApplication" />
         </MenuFlyout>

--- a/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.DataTransfer;
 using Celbridge.Documents.ViewModels;
 using Celbridge.Explorer;
 using Celbridge.Messaging;
@@ -803,18 +804,22 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         var fileResource = tab.ViewModel.FileResource;
         var resourceKey = fileResource.ToString();
 
-        var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
-        dataPackage.SetText(resourceKey);
-        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+        _commandService.Execute<ICopyTextToClipboardCommand>(command =>
+        {
+            command.Text = resourceKey;
+            command.TransferMode = DataTransferMode.Copy;
+        });
     }
 
     private void CopyFilePathForTab(DocumentTab tab)
     {
         var filePath = tab.ViewModel.FilePath;
 
-        var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
-        dataPackage.SetText(filePath);
-        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+        _commandService.Execute<ICopyTextToClipboardCommand>(command =>
+        {
+            command.Text = filePath;
+            command.TransferMode = DataTransferMode.Copy;
+        });
     }
 
     private void OpenFileExplorerForTab(DocumentTab tab)

--- a/app/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/app/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -430,6 +430,30 @@ public partial class ResourceTreeViewModel : ObservableObject
         });
     }
 
+    public void CopyResourceKeyToClipboard(IResource resource)
+    {
+        var resourceRegistry = _explorerService.ResourceRegistry;
+        var resourceKey = resourceRegistry.GetResourceKey(resource);
+
+        _commandService.Execute<ICopyTextToClipboardCommand>(command =>
+        {
+            command.Text = resourceKey;
+            command.TransferMode = DataTransferMode.Copy;
+        });
+    }
+
+    public void CopyFilePathToClipboard(IResource resource)
+    {
+        var resourceRegistry = _explorerService.ResourceRegistry;
+        var filePath = resourceRegistry.GetResourcePath(resource);
+
+        _commandService.Execute<ICopyTextToClipboardCommand>(command =>
+        {
+            command.Text = filePath;
+            command.TransferMode = DataTransferMode.Copy;
+        });
+    }
+
     public async Task<Result> ImportResources(List<string> sourcePaths, IResource? destResource)
     {
         if (destResource is null)

--- a/app/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml
+++ b/app/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml
@@ -67,6 +67,13 @@
                       Click="ResourceContextMenu_Rename"
                       IsEnabled="{x:Bind ViewModel.IsResourceSelected, Mode=OneWay}" />
       <MenuFlyoutSeparator />
+      <MenuFlyoutItem Text="{x:Bind CopyResourceKeyString}"
+                      Click="ResourceContextMenu_CopyResourceKey"
+                      IsEnabled="{x:Bind ViewModel.IsResourceSelected, Mode=OneWay}" />
+      <MenuFlyoutItem Text="{x:Bind CopyFilePathString}"
+                      Click="ResourceContextMenu_CopyFilePath"
+                      IsEnabled="{x:Bind ViewModel.IsResourceSelected, Mode=OneWay}" />
+      <MenuFlyoutSeparator />
       <MenuFlyoutItem Text="{x:Bind OpenFileExplorerString}"
                       Click="ResourceContextMenu_OpenFileExplorer"/>
       <MenuFlyoutItem Text="{x:Bind OpenApplicationString}"

--- a/app/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
+++ b/app/Workspace/Celbridge.Explorer/Views/ResourceTreeView.xaml.cs
@@ -25,6 +25,8 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
     private string RenameString => _stringLocalizer.GetString("ResourceTree_Rename");
     private string OpenFileExplorerString => _stringLocalizer.GetString("ResourceTree_OpenFileExplorer");
     private string OpenApplicationString => _stringLocalizer.GetString("ResourceTree_OpenApplication");
+    private string CopyResourceKeyString => _stringLocalizer.GetString("ResourceTree_CopyResourceKey");
+    private string CopyFilePathString => _stringLocalizer.GetString("ResourceTree_CopyFilePath");
 
     // Toolbar tooltip strings
     private string AddFileTooltipString => _stringLocalizer.GetString("ResourceTreeToolbar_AddFileTooltip");
@@ -400,6 +402,22 @@ public sealed partial class ResourceTreeView : UserControl, IResourceTreeView
         var resource = AcquireContextMenuResource(sender);
 
         ViewModel.OpenResourceInApplication(resource);
+    }
+
+    private void ResourceContextMenu_CopyResourceKey(object sender, RoutedEventArgs e)
+    {
+        var resource = AcquireContextMenuResource(sender);
+        Guard.IsNotNull(resource);
+
+        ViewModel.CopyResourceKeyToClipboard(resource);
+    }
+
+    private void ResourceContextMenu_CopyFilePath(object sender, RoutedEventArgs e)
+    {
+        var resource = AcquireContextMenuResource(sender);
+        Guard.IsNotNull(resource);
+
+        ViewModel.CopyFilePathToClipboard(resource);
     }
 
     private void ResourcesTreeView_Expanding(TreeView sender, TreeViewExpandingEventArgs args)


### PR DESCRIPTION
Add "Copy resource key" and "Copy file path" options to the Resource panel context menu. The "Open in application" option is now disabled for folders and when no resource is selected.