### PR TITLE
Add a Panel Layout flyout to configure panel layout

### DIFF
--- a/app/BaseLibrary/Settings/IEditorSettings.cs
+++ b/app/BaseLibrary/Settings/IEditorSettings.cs
@@ -73,6 +73,11 @@ public interface IEditorSettings : INotifyPropertyChanged
     void Reset();
 
     /// <summary>
+    /// Resets the panel layout to default visibility and sizes.
+    /// </summary>
+    void ResetPanelLayout();
+
+    /// <summary>
     /// Gets or Sets the Application User Interface Theme value.
     /// </summary>
     ApplicationColorTheme Theme { get; set; }

--- a/app/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/app/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -561,4 +561,19 @@ Do you wish to continue?</value>
   <data name="PanelToolbar_ToggleInspectorTooltip" xml:space="preserve">
     <value>Toggle Inspector panel (F4: toggle all)</value>
   </data>
+  <data name="PanelToolbar_CustomizeLayoutTooltip" xml:space="preserve">
+    <value>Customize layout</value>
+  </data>
+  <data name="PanelToolbar_ExplorerPanelLabel" xml:space="preserve">
+    <value>Explorer panel</value>
+  </data>
+  <data name="PanelToolbar_ConsolePanelLabel" xml:space="preserve">
+    <value>Console panel</value>
+  </data>
+  <data name="PanelToolbar_InspectorPanelLabel" xml:space="preserve">
+    <value>Inspector panel</value>
+  </data>
+  <data name="PanelToolbar_ResetLayoutButton" xml:space="preserve">
+    <value>Reset layout</value>
+  </data>
 </root>

--- a/app/CoreServices/Celbridge.Settings/Services/EditorSettings.cs
+++ b/app/CoreServices/Celbridge.Settings/Services/EditorSettings.cs
@@ -1,9 +1,12 @@
-using Celbridge.UserInterface;
-
 namespace Celbridge.Settings.Services;
 
 public class EditorSettings : ObservableSettings, IEditorSettings
 {
+    private const float DefaultContextPanelWidth = 300f;
+    private const float DefaultInspectorPanelWidth = 300f;
+    private const float DefaultConsolePanelHeight = 350f;
+    private const float DefaultDetailPanelHeight = 250f;
+
     public EditorSettings(ISettingsGroup settingsGroup)
         : base(settingsGroup, nameof(EditorSettings))
     {}
@@ -16,7 +19,7 @@ public class EditorSettings : ObservableSettings, IEditorSettings
 
     public float ContextPanelWidth
     {
-        get => GetValue<float>(nameof(ContextPanelWidth), 300);
+        get => GetValue<float>(nameof(ContextPanelWidth), DefaultContextPanelWidth);
         set => SetValue(nameof(ContextPanelWidth), value);
     }
 
@@ -28,7 +31,7 @@ public class EditorSettings : ObservableSettings, IEditorSettings
 
     public float InspectorPanelWidth
     {
-        get => GetValue<float>(nameof(InspectorPanelWidth), 300);
+        get => GetValue<float>(nameof(InspectorPanelWidth), DefaultInspectorPanelWidth);
         set => SetValue(nameof(InspectorPanelWidth), value);
     }
 
@@ -40,13 +43,13 @@ public class EditorSettings : ObservableSettings, IEditorSettings
 
     public float ConsolePanelHeight
     {
-        get => GetValue<float>(nameof(ConsolePanelHeight), 350);
+        get => GetValue<float>(nameof(ConsolePanelHeight), DefaultConsolePanelHeight);
         set => SetValue(nameof(ConsolePanelHeight), value);
     }
 
     public float DetailPanelHeight
     {
-        get => GetValue<float>(nameof(DetailPanelHeight), 250);
+        get => GetValue<float>(nameof(DetailPanelHeight), DefaultDetailPanelHeight);
         set => SetValue(nameof(DetailPanelHeight), value);
     }
 
@@ -120,5 +123,15 @@ public class EditorSettings : ObservableSettings, IEditorSettings
     {
         get => GetValue<string>(nameof(PreviousNewFileExtension), ".py");
         set => SetValue(nameof(PreviousNewFileExtension), value);
+    }
+
+    public void ResetPanelLayout()
+    {
+        IsContextPanelVisible = true;
+        ContextPanelWidth = DefaultContextPanelWidth;
+        IsInspectorPanelVisible = true;
+        InspectorPanelWidth = DefaultInspectorPanelWidth;
+        IsConsolePanelVisible = true;
+        ConsolePanelHeight = DefaultConsolePanelHeight;
     }
 }

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ConsolePanelIcon.xaml
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ConsolePanelIcon.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+    x:Class="Celbridge.UserInterface.Views.PanelIcons.ConsolePanelIcon"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <Viewbox Width="16" Height="16">
+        <Grid Width="16" Height="16">
+            <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
+                       StrokeThickness="1.2" 
+                       RadiusX="2" RadiusY="2"/>
+            <Rectangle x:Name="PanelFill"
+                       Width="14" Height="5" 
+                       HorizontalAlignment="Center" 
+                       VerticalAlignment="Bottom"
+                       Margin="0,0,0,1"
+                       Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+            <Line x:Name="PanelDivider"
+                  X1="1" Y1="10" X2="15" Y2="10"
+                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                  StrokeThickness="1.2"
+                  Visibility="Collapsed"/>
+        </Grid>
+    </Viewbox>
+</UserControl>

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ConsolePanelIcon.xaml.cs
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ConsolePanelIcon.xaml.cs
@@ -1,0 +1,31 @@
+namespace Celbridge.UserInterface.Views.PanelIcons;
+
+public sealed partial class ConsolePanelIcon : UserControl
+{
+    public static readonly DependencyProperty IsActivePanelProperty =
+        DependencyProperty.Register(
+            nameof(IsActivePanel),
+            typeof(bool),
+            typeof(ConsolePanelIcon),
+            new PropertyMetadata(false, OnIsActivePanelChanged));
+
+    public bool IsActivePanel
+    {
+        get => (bool)GetValue(IsActivePanelProperty);
+        set => SetValue(IsActivePanelProperty, value);
+    }
+
+    public ConsolePanelIcon()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnIsActivePanelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var icon = (ConsolePanelIcon)d;
+        var isActive = (bool)e.NewValue;
+        
+        icon.PanelFill.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
+        icon.PanelDivider.Visibility = isActive ? Visibility.Collapsed : Visibility.Visible;
+    }
+}

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ExplorerPanelIcon.xaml
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ExplorerPanelIcon.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+    x:Class="Celbridge.UserInterface.Views.PanelIcons.ExplorerPanelIcon"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <Viewbox Width="16" Height="16">
+        <Grid Width="16" Height="16">
+            <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
+                       StrokeThickness="1.2" 
+                       RadiusX="2" RadiusY="2"/>
+            <Rectangle x:Name="PanelFill"
+                       Width="5" Height="14" 
+                       HorizontalAlignment="Left" 
+                       VerticalAlignment="Center"
+                       Margin="1,0,0,0"
+                       Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+            <Line x:Name="PanelDivider"
+                  X1="6" Y1="1" X2="6" Y2="15"
+                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                  StrokeThickness="1.2"
+                  Visibility="Collapsed"/>
+        </Grid>
+    </Viewbox>
+</UserControl>

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ExplorerPanelIcon.xaml.cs
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/ExplorerPanelIcon.xaml.cs
@@ -1,0 +1,31 @@
+namespace Celbridge.UserInterface.Views.PanelIcons;
+
+public sealed partial class ExplorerPanelIcon : UserControl
+{
+    public static readonly DependencyProperty IsActivePanelProperty =
+        DependencyProperty.Register(
+            nameof(IsActivePanel),
+            typeof(bool),
+            typeof(ExplorerPanelIcon),
+            new PropertyMetadata(false, OnIsActivePanelChanged));
+
+    public bool IsActivePanel
+    {
+        get => (bool)GetValue(IsActivePanelProperty);
+        set => SetValue(IsActivePanelProperty, value);
+    }
+
+    public ExplorerPanelIcon()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnIsActivePanelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var icon = (ExplorerPanelIcon)d;
+        var isActive = (bool)e.NewValue;
+        
+        icon.PanelFill.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
+        icon.PanelDivider.Visibility = isActive ? Visibility.Collapsed : Visibility.Visible;
+    }
+}

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/InspectorPanelIcon.xaml
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/InspectorPanelIcon.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+    x:Class="Celbridge.UserInterface.Views.PanelIcons.InspectorPanelIcon"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <Viewbox Width="16" Height="16">
+        <Grid Width="16" Height="16">
+            <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
+                       StrokeThickness="1.2" 
+                       RadiusX="2" RadiusY="2"/>
+            <Rectangle x:Name="PanelFill"
+                       Width="5" Height="14" 
+                       HorizontalAlignment="Right" 
+                       VerticalAlignment="Center"
+                       Margin="0,0,1,0"
+                       Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+            <Line x:Name="PanelDivider"
+                  X1="10" Y1="1" X2="10" Y2="15"
+                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                  StrokeThickness="1.2"
+                  Visibility="Collapsed"/>
+        </Grid>
+    </Viewbox>
+</UserControl>

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/InspectorPanelIcon.xaml.cs
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelIcons/InspectorPanelIcon.xaml.cs
@@ -1,0 +1,31 @@
+namespace Celbridge.UserInterface.Views.PanelIcons;
+
+public sealed partial class InspectorPanelIcon : UserControl
+{
+    public static readonly DependencyProperty IsActivePanelProperty =
+        DependencyProperty.Register(
+            nameof(IsActivePanel),
+            typeof(bool),
+            typeof(InspectorPanelIcon),
+            new PropertyMetadata(false, OnIsActivePanelChanged));
+
+    public bool IsActivePanel
+    {
+        get => (bool)GetValue(IsActivePanelProperty);
+        set => SetValue(IsActivePanelProperty, value);
+    }
+
+    public InspectorPanelIcon()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnIsActivePanelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var icon = (InspectorPanelIcon)d;
+        var isActive = (bool)e.NewValue;
+        
+        icon.PanelFill.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
+        icon.PanelDivider.Visibility = isActive ? Visibility.Collapsed : Visibility.Visible;
+    }
+}

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelToggleToolbar.xaml
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelToggleToolbar.xaml
@@ -2,12 +2,91 @@
     x:Class="Celbridge.UserInterface.Views.PanelToggleToolbar"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:icons="using:Celbridge.UserInterface.Views.PanelIcons">
 
     <StackPanel x:Name="PanelVisibilityToolbar"
                 Orientation="Horizontal"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center">
+        
+        <!-- Panel Layout Button with Flyout -->
+        <Button x:Name="PanelLayoutButton"
+                Click="PanelLayoutButton_Click"
+                DoubleTapped="Button_DoubleTapped"
+                Margin="2,2,0,0"
+                Padding="6"
+                Background="Transparent"
+                BorderThickness="0">
+            <Button.Flyout>
+                <Flyout x:Name="PanelLayoutFlyout" Placement="Bottom">
+                    <StackPanel Width="250" Spacing="8">
+                        <!-- Explorer Panel Toggle -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                <icons:ExplorerPanelIcon/>
+                                <TextBlock x:Name="ExplorerPanelLabel" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <CheckBox x:Name="ExplorerPanelToggle"
+                                      Grid.Column="1"
+                                      Checked="ExplorerPanelToggle_Changed"
+                                      Unchecked="ExplorerPanelToggle_Changed"
+                                      MinWidth="0"/>
+                        </Grid>
+
+                        <!-- Console Panel Toggle -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                <icons:ConsolePanelIcon/>
+                                <TextBlock x:Name="ConsolePanelLabel" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <CheckBox x:Name="ConsolePanelToggle"
+                                      Grid.Column="1"
+                                      Checked="ConsolePanelToggle_Changed"
+                                      Unchecked="ConsolePanelToggle_Changed"
+                                      MinWidth="0"/>
+                        </Grid>
+
+                        <!-- Inspector Panel Toggle -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                <icons:InspectorPanelIcon/>
+                                <TextBlock x:Name="InspectorPanelLabel" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <CheckBox x:Name="InspectorPanelToggle"
+                                      Grid.Column="1"
+                                      Checked="InspectorPanelToggle_Changed"
+                                      Unchecked="InspectorPanelToggle_Changed"
+                                      MinWidth="0"/>
+                        </Grid>
+
+                        <MenuFlyoutSeparator/>
+
+                        <!-- Reset Layout Button -->
+                        <Button x:Name="ResetLayoutButton"
+                                Click="ResetLayoutButton_Click"
+                                HorizontalAlignment="Stretch">
+                            <TextBlock x:Name="ResetLayoutButtonText"/>
+                        </Button>
+                    </StackPanel>
+                </Flyout>
+            </Button.Flyout>
+            <FontIcon FontFamily="{StaticResource FluentSystemIconsFamily}"
+                      Glyph="&#xF06F7;"
+                      FontSize="18" />
+        </Button>
         
         <!-- Explorer Panel Toggle (Left sidebar icon) -->
         <Button x:Name="ToggleExplorerPanelButton"
@@ -20,27 +99,7 @@
             <Button.KeyboardAccelerators>
                 <KeyboardAccelerator Key="F4" Invoked="ToggleAllPanelsAccelerator_Invoked" />
             </Button.KeyboardAccelerators>
-            <Viewbox Width="16" Height="16">
-                <Grid Width="16" Height="16">
-                    <!-- Outer frame -->
-                    <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
-                               StrokeThickness="1.2" 
-                               RadiusX="2" RadiusY="2"/>
-                    <!-- Left panel - filled when active -->
-                    <Rectangle x:Name="ExplorerPanelFill"
-                               Width="5" Height="14" 
-                               HorizontalAlignment="Left" 
-                               VerticalAlignment="Center"
-                               Margin="1,0,0,0"
-                               Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-                    <!-- Left panel divider - shown when collapsed -->
-                    <Line x:Name="ExplorerPanelDivider"
-                          X1="6" Y1="1" X2="6" Y2="15"
-                          Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                          StrokeThickness="1.2"
-                          Visibility="Collapsed"/>
-                </Grid>
-            </Viewbox>
+            <icons:ExplorerPanelIcon x:Name="ExplorerPanelIcon"/>
         </Button>
         
         <!-- Console Panel Toggle (Bottom panel icon) -->
@@ -51,27 +110,7 @@
                 Padding="6"
                 Background="Transparent"
                 BorderThickness="0">
-            <Viewbox Width="16" Height="16">
-                <Grid Width="16" Height="16">
-                    <!-- Outer frame -->
-                    <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
-                               StrokeThickness="1.2" 
-                               RadiusX="2" RadiusY="2"/>
-                    <!-- Bottom panel - filled when active -->
-                    <Rectangle x:Name="ConsolePanelFill"
-                               Width="14" Height="5" 
-                               HorizontalAlignment="Center" 
-                               VerticalAlignment="Bottom"
-                               Margin="0,0,0,1"
-                               Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-                    <!-- Bottom panel divider - shown when collapsed -->
-                    <Line x:Name="ConsolePanelDivider"
-                          X1="1" Y1="10" X2="15" Y2="10"
-                          Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                          StrokeThickness="1.2"
-                          Visibility="Collapsed"/>
-                </Grid>
-            </Viewbox>
+            <icons:ConsolePanelIcon x:Name="ConsolePanelIcon"/>
         </Button>
         
         <!-- Inspector Panel Toggle (Right sidebar icon) -->
@@ -82,27 +121,7 @@
                 Padding="6"
                 Background="Transparent"
                 BorderThickness="0">
-            <Viewbox Width="16" Height="16">
-                <Grid Width="16" Height="16">
-                    <!-- Outer frame -->
-                    <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" 
-                               StrokeThickness="1.2" 
-                               RadiusX="2" RadiusY="2"/>
-                    <!-- Right panel - filled when active -->
-                    <Rectangle x:Name="InspectorPanelFill"
-                               Width="5" Height="14" 
-                               HorizontalAlignment="Right" 
-                               VerticalAlignment="Center"
-                               Margin="0,0,1,0"
-                               Fill="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-                    <!-- Right panel divider - shown when collapsed -->
-                    <Line x:Name="InspectorPanelDivider"
-                          X1="10" Y1="1" X2="10" Y2="15"
-                          Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                          StrokeThickness="1.2"
-                          Visibility="Collapsed"/>
-                </Grid>
-            </Viewbox>
+            <icons:InspectorPanelIcon x:Name="InspectorPanelIcon"/>
         </Button>
         
     </StackPanel>

--- a/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelToggleToolbar.xaml.cs
+++ b/app/CoreServices/Celbridge.UserInterface/Views/Controls/PanelToggleToolbar.xaml.cs
@@ -1,7 +1,6 @@
 using Celbridge.Commands;
 using Celbridge.Settings;
 using Celbridge.Workspace;
-using Microsoft.UI.Xaml.Shapes;
 using System.ComponentModel;
 
 namespace Celbridge.UserInterface.Views;
@@ -27,7 +26,9 @@ public sealed partial class PanelToggleToolbar : UserControl
     private void PanelToggleToolbar_Loaded(object sender, RoutedEventArgs e)
     {
         ApplyTooltips();
+        ApplyLabels();
         UpdatePanelIcons();
+        UpdateCheckBoxes();
         _editorSettings.PropertyChanged += EditorSettings_PropertyChanged;
     }
 
@@ -40,6 +41,10 @@ public sealed partial class PanelToggleToolbar : UserControl
 
     private void ApplyTooltips()
     {
+        var layoutTooltip = _stringLocalizer.GetString("PanelToolbar_CustomizeLayoutTooltip");
+        ToolTipService.SetToolTip(PanelLayoutButton, layoutTooltip);
+        ToolTipService.SetPlacement(PanelLayoutButton, PlacementMode.Bottom);
+
         var explorerTooltip = _stringLocalizer.GetString("PanelToolbar_ToggleExplorerTooltip");
         ToolTipService.SetToolTip(ToggleExplorerPanelButton, explorerTooltip);
         ToolTipService.SetPlacement(ToggleExplorerPanelButton, PlacementMode.Bottom);
@@ -53,6 +58,14 @@ public sealed partial class PanelToggleToolbar : UserControl
         ToolTipService.SetPlacement(ToggleInspectorPanelButton, PlacementMode.Bottom);
     }
 
+    private void ApplyLabels()
+    {
+        ExplorerPanelLabel.Text = _stringLocalizer.GetString("PanelToolbar_ExplorerPanelLabel");
+        ConsolePanelLabel.Text = _stringLocalizer.GetString("PanelToolbar_ConsolePanelLabel");
+        InspectorPanelLabel.Text = _stringLocalizer.GetString("PanelToolbar_InspectorPanelLabel");
+        ResetLayoutButtonText.Text = _stringLocalizer.GetString("PanelToolbar_ResetLayoutButton");
+    }
+
     private void EditorSettings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         switch (e.PropertyName)
@@ -60,24 +73,27 @@ public sealed partial class PanelToggleToolbar : UserControl
             case nameof(IEditorSettings.IsContextPanelVisible):
             case nameof(IEditorSettings.IsInspectorPanelVisible):
             case nameof(IEditorSettings.IsConsolePanelVisible):
+            case nameof(IEditorSettings.ContextPanelWidth):
+            case nameof(IEditorSettings.InspectorPanelWidth):
+            case nameof(IEditorSettings.ConsolePanelHeight):
                 UpdatePanelIcons();
+                UpdateCheckBoxes();
                 break;
         }
     }
 
+    private void UpdateCheckBoxes()
+    {
+        ExplorerPanelToggle.IsChecked = _editorSettings.IsContextPanelVisible;
+        ConsolePanelToggle.IsChecked = _editorSettings.IsConsolePanelVisible;
+        InspectorPanelToggle.IsChecked = _editorSettings.IsInspectorPanelVisible;
+    }
+
     private void UpdatePanelIcons()
     {
-        // Update explorer panel icon
-        ExplorerPanelFill.Visibility = _editorSettings.IsContextPanelVisible ? Visibility.Visible : Visibility.Collapsed;
-        ExplorerPanelDivider.Visibility = _editorSettings.IsContextPanelVisible ? Visibility.Collapsed : Visibility.Visible;
-
-        // Update tools panel icon
-        ConsolePanelFill.Visibility = _editorSettings.IsConsolePanelVisible ? Visibility.Visible : Visibility.Collapsed;
-        ConsolePanelDivider.Visibility = _editorSettings.IsConsolePanelVisible ? Visibility.Collapsed : Visibility.Visible;
-
-        // Update inspector panel icon
-        InspectorPanelFill.Visibility = _editorSettings.IsInspectorPanelVisible ? Visibility.Visible : Visibility.Collapsed;
-        InspectorPanelDivider.Visibility = _editorSettings.IsInspectorPanelVisible ? Visibility.Collapsed : Visibility.Visible;
+        ExplorerPanelIcon.IsActivePanel = _editorSettings.IsContextPanelVisible;
+        ConsolePanelIcon.IsActivePanel = _editorSettings.IsConsolePanelVisible;
+        InspectorPanelIcon.IsActivePanel = _editorSettings.IsInspectorPanelVisible;
     }
 
     private void ToggleExplorerPanelButton_Click(object sender, RoutedEventArgs e)
@@ -104,5 +120,40 @@ public sealed partial class PanelToggleToolbar : UserControl
     private void Button_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
     {
         e.Handled = true;
+    }
+
+    private void PanelLayoutButton_Click(object sender, RoutedEventArgs e)
+    {
+        PanelLayoutFlyout.ShowAt(PanelLayoutButton);
+    }
+
+    private void ExplorerPanelToggle_Changed(object sender, RoutedEventArgs e)
+    {
+        if (ExplorerPanelToggle.IsChecked != _editorSettings.IsContextPanelVisible)
+        {
+            _editorSettings.IsContextPanelVisible = ExplorerPanelToggle.IsChecked == true;
+        }
+    }
+
+    private void ConsolePanelToggle_Changed(object sender, RoutedEventArgs e)
+    {
+        if (ConsolePanelToggle.IsChecked != _editorSettings.IsConsolePanelVisible)
+        {
+            _editorSettings.IsConsolePanelVisible = ConsolePanelToggle.IsChecked == true;
+        }
+    }
+
+    private void InspectorPanelToggle_Changed(object sender, RoutedEventArgs e)
+    {
+        if (InspectorPanelToggle.IsChecked != _editorSettings.IsInspectorPanelVisible)
+        {
+            _editorSettings.IsInspectorPanelVisible = InspectorPanelToggle.IsChecked == true;
+        }
+    }
+
+    private void ResetLayoutButton_Click(object sender, RoutedEventArgs e)
+    {
+        _editorSettings.ResetPanelLayout();
+        PanelLayoutFlyout.Hide();
     }
 }

--- a/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
+++ b/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
@@ -155,6 +155,24 @@ public sealed partial class WorkspacePage : Celbridge.UserInterface.Views.Persis
             case nameof(ViewModel.IsConsolePanelVisible):
                 UpdatePanels();
                 break;
+            case nameof(ViewModel.ContextPanelWidth):
+                if (ViewModel.IsContextPanelVisible && ViewModel.ContextPanelWidth > 0)
+                {
+                    ContextPanelColumn.Width = new GridLength(ViewModel.ContextPanelWidth);
+                }
+                break;
+            case nameof(ViewModel.InspectorPanelWidth):
+                if (ViewModel.IsInspectorPanelVisible && ViewModel.InspectorPanelWidth > 0)
+                {
+                    InspectorPanelColumn.Width = new GridLength(ViewModel.InspectorPanelWidth);
+                }
+                break;
+            case nameof(ViewModel.ConsolePanelHeight):
+                if (ViewModel.IsConsolePanelVisible && ViewModel.ConsolePanelHeight > 0)
+                {
+                    ConsolePanelRow.Height = new GridLength(ViewModel.ConsolePanelHeight);
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
Add a button to configure and reset the panel layout. Refactor the panel icons to be separate reusable User Controls.