### PR TITLE
Remove open document button in Markdown inspector

### DIFF
--- a/app/Modules/Celbridge.Markdown/Assets/Forms/MarkdownRootForm.json
+++ b/app/Modules/Celbridge.Markdown/Assets/Forms/MarkdownRootForm.json
@@ -6,12 +6,6 @@
     "children": [
       {
         "element": "Button",
-        "tooltip": "Open document",
-        "icon": "OpenFile",
-        "buttonId": "OpenDocument"
-      },
-      {
-        "element": "Button",
         "isEnabled": "/editorEnabled",
         "tooltip": "Editor view",
         "icon": "DockLeft",

--- a/app/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
+++ b/app/Modules/Celbridge.Markdown/ComponentEditors/MarkdownEditor.cs
@@ -1,34 +1,23 @@
-using Celbridge.Commands;
+using System.Text.Json;
 using Celbridge.Documents;
 using Celbridge.Entities;
-using Celbridge.Logging;
-using System.Text.Json;
 
 namespace Celbridge.Markdown.ComponentEditors;
 
 public class MarkdownEditor : ComponentEditorBase
 {
-    private readonly ILogger<MarkdownEditor> _logger;
-    private readonly ICommandService _commandService;
-
     private const string ConfigPath = "Celbridge.Markdown.Assets.Components.MarkdownComponent.json";
     private const string ComponentFormPath = "Celbridge.Markdown.Assets.Forms.MarkdownForm.json";
     private const string ComponentRootFormPath = "Celbridge.Markdown.Assets.Forms.MarkdownRootForm.json";
 
-    private const string OpenDocumentButtonId = "OpenDocument";
     private const string EditorButtonId = "Editor";
     private const string EditorAndPreviewButtonId = "EditorAndPreview";
     private const string PreviewButtonId = "Preview";
 
     public const string ComponentType = "Markdown.Markdown";
 
-    public MarkdownEditor(
-        ILogger<MarkdownEditor> logger,
-        ICommandService commandService)
-    {
-        _logger = logger;
-        _commandService = commandService;
-    }
+    public MarkdownEditor()
+    { }
 
     public override string GetComponentConfig()
     {
@@ -65,10 +54,6 @@ public class MarkdownEditor : ComponentEditorBase
     {
         switch (buttonId)
         {
-            case OpenDocumentButtonId:
-                OpenDocument();
-                break;
-
             case EditorButtonId:
                 SetEditorMode(EditorMode.Editor);
                 break;
@@ -114,18 +99,6 @@ public class MarkdownEditor : ComponentEditorBase
         }
 
         return Result<string>.Fail();
-    }
-
-    private void OpenDocument()
-    {
-        var resource = Component.Key.Resource;
-
-        // Execute a command to open the markdown document.
-        _commandService.Execute<IOpenDocumentCommand>(command =>
-        {
-            command.FileResource = resource;
-            command.ForceReload = false;
-        });
     }
 
     private void SetEditorMode(EditorMode editorMode)

--- a/app/Workspace/Celbridge.Inspector/Services/InspectorService.cs
+++ b/app/Workspace/Celbridge.Inspector/Services/InspectorService.cs
@@ -122,6 +122,12 @@ public class InspectorService : IInspectorService, IDisposable
 
     private void OnSelectedDocumentChangedMessage(object recipient, SelectedDocumentChangedMessage message)
     {
+        if (InspectedResource == message.DocumentResource)
+        {
+            // Avoid unnecessary cache invalidation and UI updates when the same document is re-selected
+            return;
+        }
+
         InspectedResource = message.DocumentResource;
         InspectedComponentIndex = -1;
 

--- a/app/Workspace/Celbridge.Inspector/ViewModels/InspectorPanelViewModel.cs
+++ b/app/Workspace/Celbridge.Inspector/ViewModels/InspectorPanelViewModel.cs
@@ -21,6 +21,12 @@ public partial class InspectorPanelViewModel : ObservableObject
 
     private void OnSelectedDocumentChangedMessage(object recipient, SelectedDocumentChangedMessage message)
     {
+        if (SelectedResource == message.DocumentResource)
+        {
+            // Avoid unnecessary UI rebuild when the same document is re-selected
+            return;
+        }
+
         SelectedResource = message.DocumentResource;
     }
 }


### PR DESCRIPTION
Removed the Open Document button in the Markdown Inspector, it's not needed now. Fixed the OpenDocument command incorrectly rebuilding the Inspector when opening the document that is already being inspected.