### PR TITLE
Reset splitter sizes on double click

### DIFF
--- a/app/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
+++ b/app/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
@@ -22,6 +22,11 @@ public interface IDocumentsPanel
     void SetSectionRatios(List<double> ratios);
 
     /// <summary>
+    /// Resets all document sections to equal widths.
+    /// </summary>
+    Task ResetSectionRatiosAsync();
+
+    /// <summary>
     /// Returns all open documents with their addresses (UI positions).
     /// </summary>
     Dictionary<ResourceKey, DocumentAddress> GetDocumentAddresses();

--- a/app/Core/Celbridge.Foundation/Documents/IResetSectionsCommand.cs
+++ b/app/Core/Celbridge.Foundation/Documents/IResetSectionsCommand.cs
@@ -1,0 +1,10 @@
+using Celbridge.Commands;
+
+namespace Celbridge.Documents;
+
+/// <summary>
+/// Resets all document sections to equal widths.
+/// </summary>
+public interface IResetSectionsCommand : IExecutableCommand
+{
+}

--- a/app/Core/Celbridge.UserInterface/Views/Controls/Splitter.xaml
+++ b/app/Core/Celbridge.UserInterface/Views/Controls/Splitter.xaml
@@ -4,11 +4,44 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 
+  <UserControl.Resources>
+    <!-- Fade in animation for hover - slightly delayed, smooth fade -->
+    <Storyboard x:Name="HoverFadeIn">
+      <DoubleAnimation Storyboard.TargetName="HoverLine"
+                       Storyboard.TargetProperty="Opacity"
+                       To="1.0"
+                       BeginTime="0:0:0.20"
+                       Duration="0:0:0.20">
+        <DoubleAnimation.EasingFunction>
+          <QuadraticEase EasingMode="EaseOut"/>
+        </DoubleAnimation.EasingFunction>
+      </DoubleAnimation>
+    </Storyboard>
+    
+    <!-- Fade out animation - quick fade -->
+    <Storyboard x:Name="HoverFadeOut">
+      <DoubleAnimation Storyboard.TargetName="HoverLine"
+                       Storyboard.TargetProperty="Opacity"
+                       To="0.0"
+                       Duration="0:0:0.20">
+        <DoubleAnimation.EasingFunction>
+          <QuadraticEase EasingMode="EaseIn"/>
+        </DoubleAnimation.EasingFunction>
+      </DoubleAnimation>
+    </Storyboard>
+  </UserControl.Resources>
+
   <!-- Transparent grab area with centered visible line. -->
   <Border x:Name="SplitterBorder"
           Background="Transparent">
-    <!-- Thin visible line - expands when dragging -->
-    <Rectangle x:Name="SplitterLine"
-               Fill="{ThemeResource DividerBrush}"/>
+    <Grid>
+      <!-- Base thin visible line -->
+      <Rectangle x:Name="SplitterLine"
+                 Fill="{ThemeResource DividerBrush}"/>
+      <!-- Accent hover line - fades in on hover -->
+      <Rectangle x:Name="HoverLine"
+                 Fill="{ThemeResource AccentFillColorDefaultBrush}"
+                 Opacity="0"/>
+    </Grid>
   </Border>
 </UserControl>

--- a/app/Workspace/Celbridge.Documents/Commands/ResetSectionsCommand.cs
+++ b/app/Workspace/Celbridge.Documents/Commands/ResetSectionsCommand.cs
@@ -1,0 +1,35 @@
+using Celbridge.Commands;
+using Celbridge.Workspace;
+
+namespace Celbridge.Documents.Commands;
+
+public class ResetSectionsCommand : CommandBase, IResetSectionsCommand
+{
+    public override CommandFlags CommandFlags => CommandFlags.SaveWorkspaceState;
+
+    private readonly IWorkspaceWrapper _workspaceWrapper;
+
+    public ResetSectionsCommand(IWorkspaceWrapper workspaceWrapper)
+    {
+        _workspaceWrapper = workspaceWrapper;
+    }
+
+    public override async Task<Result> ExecuteAsync()
+    {
+        var documentsPanel = _workspaceWrapper.WorkspaceService.DocumentsPanel;
+
+        await documentsPanel.ResetSectionRatiosAsync();
+
+        return Result.Ok();
+    }
+
+    //
+    // Static methods for scripting support.
+    //
+
+    public static void ResetSections()
+    {
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+        commandService.Execute<IResetSectionsCommand>();
+    }
+}

--- a/app/Workspace/Celbridge.Documents/ServiceConfiguration.cs
+++ b/app/Workspace/Celbridge.Documents/ServiceConfiguration.cs
@@ -50,5 +50,6 @@ public static class ServiceConfiguration
         services.AddTransient<IOpenDocumentCommand, OpenDocumentCommand>();
         services.AddTransient<ICloseDocumentCommand, CloseDocumentCommand>();
         services.AddTransient<ISelectDocumentCommand, SelectDocumentCommand>();
+        services.AddTransient<IResetSectionsCommand, ResetSectionsCommand>();
     }
 }

--- a/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/app/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -229,6 +229,11 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         SectionContainer.SetSectionRatios(ratios);
     }
 
+    public async Task ResetSectionRatiosAsync()
+    {
+        await SectionContainer.ResetSectionRatiosAsync();
+    }
+
     public Dictionary<ResourceKey, DocumentAddress> GetDocumentAddresses()
     {
         var addresses = new Dictionary<ResourceKey, DocumentAddress>();

--- a/app/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml
+++ b/app/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml
@@ -7,7 +7,7 @@ xmlns:controls="using:Celbridge.UserInterface.Views.Controls"
 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 
-  <Grid>
+  <Grid x:Name="RootGrid">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
       <RowDefinition Height="*" />

--- a/app/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml.cs
+++ b/app/Workspace/Celbridge.Inspector/Views/EntityEditor.xaml.cs
@@ -25,15 +25,12 @@ public sealed partial class EntityEditor : UserControl
         ViewModel.InspectedComponentChanged += ViewModel_InspectedComponentChanged;
 
         // Initialize splitter helper
-        var grid = this.Content as Grid;
-        if (grid != null)
-        {
-            _splitterHelper = new SplitterHelper(grid, GridResizeMode.Rows, 1, 2, minSize: 100);
-        }
+        _splitterHelper = new SplitterHelper(RootGrid, GridResizeMode.Rows, 1, 2, minSize: 100);
 
         // Set up splitter event handlers
         DetailSplitter.DragStarted += DetailSplitter_DragStarted;
         DetailSplitter.DragDelta += DetailSplitter_DragDelta;
+        DetailSplitter.DoubleClicked += DetailSplitter_DoubleClicked;
     }
 
     private void EntityEditor_Unloaded(object sender, RoutedEventArgs e)
@@ -43,6 +40,7 @@ public sealed partial class EntityEditor : UserControl
         // Clean up splitter event handlers
         DetailSplitter.DragStarted -= DetailSplitter_DragStarted;
         DetailSplitter.DragDelta -= DetailSplitter_DragDelta;
+        DetailSplitter.DoubleClicked -= DetailSplitter_DoubleClicked;
     }
 
     private void ViewModel_InspectedComponentChanged()
@@ -76,5 +74,12 @@ public sealed partial class EntityEditor : UserControl
     private void DetailSplitter_DragDelta(object? sender, double delta)
     {
         _splitterHelper?.OnDragDelta(delta);
+    }
+
+    private void DetailSplitter_DoubleClicked(object? sender, EventArgs e)
+    {
+        // Reset both rows to equal Star sizing (same as initial XAML layout)
+        RootGrid.RowDefinitions[1].Height = new GridLength(1, GridUnitType.Star);
+        RootGrid.RowDefinitions[2].Height = new GridLength(1, GridUnitType.Star);
     }
 }

--- a/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
+++ b/app/Workspace/Celbridge.Workspace/Views/WorkspacePage.xaml.cs
@@ -3,6 +3,7 @@ using Celbridge.Console.Views;
 using Celbridge.Documents;
 using Celbridge.Inspector;
 using Celbridge.Navigation;
+using Celbridge.UserInterface;
 using Celbridge.UserInterface.Helpers;
 using Celbridge.Workspace.ViewModels;
 
@@ -100,12 +101,15 @@ public sealed partial class WorkspacePage : Page
         // Set up splitter event handlers
         PrimaryPanelSplitter.DragStarted += PrimaryPanelSplitter_DragStarted;
         PrimaryPanelSplitter.DragDelta += PrimaryPanelSplitter_DragDelta;
+        PrimaryPanelSplitter.DoubleClicked += PrimaryPanelSplitter_DoubleClicked;
 
         SecondaryPanelSplitter.DragStarted += SecondaryPanelSplitter_DragStarted;
         SecondaryPanelSplitter.DragDelta += SecondaryPanelSplitter_DragDelta;
+        SecondaryPanelSplitter.DoubleClicked += SecondaryPanelSplitter_DoubleClicked;
 
         ConsolePanelSplitter.DragStarted += ConsolePanelSplitter_DragStarted;
         ConsolePanelSplitter.DragDelta += ConsolePanelSplitter_DragDelta;
+        ConsolePanelSplitter.DoubleClicked += ConsolePanelSplitter_DoubleClicked;
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
@@ -309,5 +313,20 @@ public sealed partial class WorkspacePage : Page
     private void ConsolePanelSplitter_DragDelta(object? sender, double delta)
     {
         _consolePanelSplitterHelper?.OnDragDelta(delta);
+    }
+
+    private void PrimaryPanelSplitter_DoubleClicked(object? sender, EventArgs e)
+    {
+        ViewModel.PrimaryPanelWidth = UserInterfaceConstants.PrimaryPanelWidth;
+    }
+
+    private void SecondaryPanelSplitter_DoubleClicked(object? sender, EventArgs e)
+    {
+        ViewModel.SecondaryPanelWidth = UserInterfaceConstants.SecondaryPanelWidth;
+    }
+
+    private void ConsolePanelSplitter_DoubleClicked(object? sender, EventArgs e)
+    {
+        ViewModel.ConsolePanelHeight = UserInterfaceConstants.ConsolePanelHeight;
     }
 }


### PR DESCRIPTION
Double click on any splitter resets it to it's original size. Added fade in/out animations on the divider line to better communicate when the mouse pointer is in the correct position to resize.

Fixes #616 