### PR TITLE
Refactor the console height editor settings

### DIFF
--- a/app/Core/Celbridge.Foundation/Settings/IEditorSettings.cs
+++ b/app/Core/Celbridge.Foundation/Settings/IEditorSettings.cs
@@ -116,11 +116,6 @@ public interface IEditorSettings : INotifyPropertyChanged
     /// </summary>
     bool IsConsoleMaximized { get; set; }
 
-    /// <summary>
-    /// The console panel height before it was maximized (used for restore).
-    /// </summary>
-    float RestoreConsoleHeight { get; set; }
-
     // ========================================
     // Settings Page Options
     // ========================================

--- a/app/Core/Celbridge.Settings/Services/EditorSettings.cs
+++ b/app/Core/Celbridge.Settings/Services/EditorSettings.cs
@@ -110,12 +110,6 @@ public class EditorSettings : ObservableSettings, IEditorSettings
         set => SetValue(nameof(IsConsoleMaximized), value);
     }
 
-    public float RestoreConsoleHeight
-    {
-        get => GetValue<float>(nameof(RestoreConsoleHeight), WorkspaceConstants.ConsolePanelHeight);
-        set => SetValue(nameof(RestoreConsoleHeight), value);
-    }
-
     public ApplicationColorTheme Theme
     {
         get => GetValue<ApplicationColorTheme>(nameof(Theme), ApplicationColorTheme.System);

--- a/app/Core/Celbridge.UserInterface/Services/LayoutManager.cs
+++ b/app/Core/Celbridge.UserInterface/Services/LayoutManager.cs
@@ -312,7 +312,6 @@ public class LayoutManager : IWindowModeService, ILayoutService
         _editorSettings.PrimaryPanelWidth = WorkspaceConstants.PrimaryPanelWidth;
         _editorSettings.SecondaryPanelWidth = WorkspaceConstants.SecondaryPanelWidth;
         _editorSettings.ConsolePanelHeight = WorkspaceConstants.ConsolePanelHeight;
-        _editorSettings.RestoreConsoleHeight = WorkspaceConstants.ConsolePanelHeight;
 
         // Reset preferred window geometry
         _editorSettings.UsePreferredWindowGeometry = false;

--- a/app/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
+++ b/app/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
@@ -46,12 +46,6 @@ public partial class WorkspacePageViewModel : ObservableObject
         set => _editorSettings.ConsolePanelHeight = value;
     }
 
-    public float RestoreConsoleHeight
-    {
-        get => _editorSettings.RestoreConsoleHeight;
-        set => _editorSettings.RestoreConsoleHeight = value;
-    }
-
     public bool IsFullScreen => _windowModeService.IsFullScreen;
 
     // Panel visibility properties now use Primary/Secondary naming

--- a/app/Workspace/Celbridge.WorkspaceUI/Views/WorkspacePage.xaml.cs
+++ b/app/Workspace/Celbridge.WorkspaceUI/Views/WorkspacePage.xaml.cs
@@ -299,14 +299,6 @@ public sealed partial class WorkspacePage : Page
 
         if (ViewModel.IsConsoleMaximized)
         {
-            // Save the current console height before maximizing so we can restore it later.
-            // Only save if we have a valid height (not already maximized).
-            var currentConsoleHeight = (float)ConsolePanel.ActualHeight;
-            if (currentConsoleHeight > 0 && ConsolePanelRow.Height.GridUnitType != GridUnitType.Star)
-            {
-                ViewModel.RestoreConsoleHeight = currentConsoleHeight;
-            }
-
             // Hide the splitter while maximized
             ConsolePanelSplitter.Visibility = Visibility.Collapsed;
 
@@ -333,7 +325,7 @@ public sealed partial class WorkspacePage : Page
             ConsolePanelRow.MinHeight = MinConsolePanelHeight;
 
             // Restore console to the height it was before maximizing
-            var consoleHeight = ViewModel.RestoreConsoleHeight;
+            var consoleHeight = ViewModel.ConsolePanelHeight;
             if (consoleHeight <= 0)
             {
                 consoleHeight = WorkspaceConstants.ConsolePanelHeight;


### PR DESCRIPTION
Combined the RestoreConsoleHeight and ConsolePanelHeight properties into a single property as they were effectively storing the same information.