### PR TITLE
Add Javascript cel proxy for accessing MCP tools

### DIFF
--- a/Source/Core/Celbridge.Server/Services/McpToolBridge.cs
+++ b/Source/Core/Celbridge.Server/Services/McpToolBridge.cs
@@ -28,6 +28,7 @@ public class McpToolBridge : IMcpToolBridge
     private readonly ILogger<McpToolBridge> _logger;
     private readonly HttpClient _httpClient;
     private readonly Dictionary<string, ToolMetadata> _toolMetadata;
+    private readonly Dictionary<string, string> _aliasToToolName;
 
     private int _nextRequestId;
     private string? _sessionId;
@@ -40,6 +41,27 @@ public class McpToolBridge : IMcpToolBridge
         _logger = logger;
         _httpClient = new HttpClient();
         _toolMetadata = BuildToolMetadata();
+        _aliasToToolName = new Dictionary<string, string>(_toolMetadata.Count, StringComparer.Ordinal);
+        foreach (var entry in _toolMetadata)
+        {
+            if (!string.IsNullOrEmpty(entry.Value.Alias))
+            {
+                _aliasToToolName[entry.Value.Alias] = entry.Key;
+            }
+        }
+    }
+
+    // The JS client addresses tools by alias (e.g. "document.open") while Python and the MCP
+    // server itself use the underscore MCP name ("document_open"). Callers forward whichever
+    // form they have; resolve to the MCP name before hitting the wire.
+    private string ResolveMcpToolName(string name)
+    {
+        if (_aliasToToolName.TryGetValue(name, out var mcpName))
+        {
+            return mcpName;
+        }
+
+        return name;
     }
 
     [JsonRpcMethod("tools/list")]
@@ -146,10 +168,11 @@ public class McpToolBridge : IMcpToolBridge
     public async Task<object> ToolsCall(string name, JObject? arguments)
     {
         var argumentsNode = ConvertJObjectToJsonObject(arguments);
+        var mcpToolName = ResolveMcpToolName(name);
 
         var callParams = new JsonObject
         {
-            ["name"] = name
+            ["name"] = mcpToolName
         };
         if (argumentsNode is not null)
         {
@@ -164,7 +187,7 @@ public class McpToolBridge : IMcpToolBridge
                 return new Dictionary<string, object?>
                 {
                     ["isSuccess"] = false,
-                    ["errorMessage"] = "No response from MCP server",
+                    ["errorMessage"] = "MCP HTTP server is not running",
                     ["value"] = null
                 };
             }
@@ -285,10 +308,11 @@ public class McpToolBridge : IMcpToolBridge
     public async Task<ToolCallResult> CallToolAsync(string name, object? arguments)
     {
         var argumentsObject = NormalizeArguments(arguments);
+        var mcpToolName = ResolveMcpToolName(name);
 
         var callParams = new JsonObject
         {
-            ["name"] = name
+            ["name"] = mcpToolName
         };
         if (argumentsObject is not null)
         {
@@ -300,7 +324,7 @@ public class McpToolBridge : IMcpToolBridge
             var response = await SendMcpRequestAsync("tools/call", callParams);
             if (response is null)
             {
-                return new ToolCallResult(false, "No response from MCP server", null);
+                return new ToolCallResult(false, "MCP HTTP server is not running", null);
             }
 
             var isError = response["isError"]?.GetValue<bool>() ?? false;
@@ -562,6 +586,29 @@ public class McpToolBridge : IMcpToolBridge
         }
 
         var responseNode = JsonNode.Parse(responseJson);
+
+        // JSON-RPC error envelope that includes the server-provided message.
+        if (responseNode?["error"] is JsonNode errorNode)
+        {
+            var errorMessage = errorNode["message"]?.GetValue<string>() ?? "MCP server returned an error";
+            var errorCodeNode = errorNode["code"];
+            int? errorCode = null;
+            if (errorCodeNode is not null)
+            {
+                try
+                {
+                    errorCode = errorCodeNode.GetValue<int>();
+                }
+                catch
+                {
+                    errorCode = null;
+                }
+            }
+            var formatted = errorCode.HasValue
+                ? $"MCP error {errorCode.Value}: {errorMessage}"
+                : $"MCP error: {errorMessage}";
+            throw new InvalidOperationException(formatted);
+        }
 
         return responseNode?["result"]?.AsObject();
     }

--- a/Source/Core/Celbridge.Tools/Assets/AgentContext.md
+++ b/Source/Core/Celbridge.Tools/Assets/AgentContext.md
@@ -164,6 +164,18 @@ supported (`document.*`, `file.*`).
 requires_tools = ["document.*", "file.*", "app.get_status"]
 ```
 
+**Use the alias form — `namespace.snake_case_method` — in the manifest.** This
+is the same form listed in the Python API reference, and it matches the MCP
+tool name after swapping the first underscore for a dot. The JS proxy converts
+to camelCase at the call site, but the manifest does NOT. Examples:
+
+- `"file.list_contents"` → call site `cel.file.listContents(...)`
+- `"file.read_binary"` → call site `cel.file.readBinary(...)`
+- `"document.apply_edits"` → call site `cel.document.applyEdits(...)`
+
+Do not use camelCase (`"file.listContents"`) or the MCP underscore form
+(`"file_list_contents"`) — neither matches.
+
 Then import the client from the `shared.celbridge` virtual host and call
 host tools through the `cel` global (populated after `initialize()`
 resolves):

--- a/Source/Core/Celbridge.Tools/Assets/AgentContext.md
+++ b/Source/Core/Celbridge.Tools/Assets/AgentContext.md
@@ -145,3 +145,47 @@ from celbridge import app, document
 document.open("readme.md")
 app.log("Processing complete")
 ```
+
+## Writing Package Extensions (JavaScript)
+
+Package extensions run inside a WebView hosted by a document editor
+contribution (declared in `package.toml` under `[contributes].document_editors`).
+There is currently no non-editor WebView surface, so JS tool calls happen
+from within an editor.
+
+**Before writing any JS that calls `cel.*`, declare the tools your package
+needs in `package.toml` under `[mod].requires_tools`.** The `cel.*` proxy
+is built from this allowlist at `initialize()` time, so namespaces you
+did not declare simply do not exist on the proxy. Glob patterns are
+supported (`document.*`, `file.*`).
+
+```toml
+[mod]
+requires_tools = ["document.*", "file.*", "app.get_status"]
+```
+
+Then import the client from the `shared.celbridge` virtual host and call
+host tools through the `cel` global (populated after `initialize()`
+resolves):
+
+```javascript
+import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
+await celbridge.initialize();
+const tree = await cel.file.getTree("");
+```
+
+`initialize()` performs the `document/initialize` RPC handshake with the
+host and loads the tool descriptors.
+
+Failure modes:
+- Accessing `cel.*` before `initialize()` resolves throws `CelToolError`.
+- Calling a namespace that is not covered by `requires_tools` throws
+  `TypeError: Cannot read properties of undefined` — the namespace was
+  never added to the proxy. Fix the manifest, not the call site.
+- Calling a tool whose name is not covered by `requires_tools` but whose
+  namespace partially matches another entry throws `CEL_TOOL_DENIED` at
+  call time (the host re-checks the allowlist on every call).
+
+The celbridge-client source is served from the Celbridge install directory
+and is not readable via `file.read`. Call `query_get_javascript_api` for
+the full signature reference.

--- a/Source/Core/Celbridge.Tools/Assets/JavaScriptApiHeader.md
+++ b/Source/Core/Celbridge.Tools/Assets/JavaScriptApiHeader.md
@@ -1,0 +1,51 @@
+# Celbridge JavaScript API Reference
+
+Access tools from a package extension via the `cel` global (or `celbridge.cel`).
+All methods return Promises; errors throw `CelToolError` with { code, tool, message }.
+
+## Manifest (do this first)
+
+The `cel.*` proxy is built from your package's `requires_tools` allowlist at
+`initialize()` time. Namespaces you did not declare are NOT present on the
+proxy — calling `cel.document.open(...)` without declaring `document.*` throws
+`TypeError: Cannot read properties of undefined`, not `CEL_TOOL_DENIED`.
+
+Declare every tool your package calls in package.toml before writing JS:
+
+  [mod]
+  requires_tools = ["document.*", "file.read", "app.get_status"]
+
+Glob patterns are supported. The host re-enforces the allowlist on every
+call; a tool within a partially-matched namespace that is not itself
+allowed is rejected at call time with CEL_TOOL_DENIED.
+
+## Getting Started
+
+Package extensions run inside a WebView hosted by a document editor contribution.
+Import the client from the `shared.celbridge` virtual host, then await `initialize()`:
+
+  import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
+  await celbridge.initialize();
+  const tree = await cel.file.getTree("");
+
+`initialize()` performs the `document/initialize` handshake with the host and
+loads the tool descriptors. Accessing `cel.*` before it resolves throws.
+The celbridge-client source is served from the Celbridge install and is NOT
+readable via `file.read` — use this reference for signatures.
+
+## Conventions
+
+- Arguments are positional and camelCase. Extra arguments throw CEL_TOOL_INVALID_ARGS.
+- Methods marked `Promise<"ok">` resolve with the string 'ok' on success.
+- Methods marked `Promise<void>` resolve with `undefined`.
+- Error codes: CEL_TOOL_NOT_FOUND, CEL_TOOL_DENIED, CEL_TOOL_INVALID_ARGS, CEL_TOOL_FAILED.
+
+## Structured parameters
+
+Arrays and objects passed to `string`-typed parameters are JSON-encoded
+automatically, so you can pass native JS values directly:
+
+- `editsJson`: `[{ line: number, endLine: number, newText: string, column?: number, endColumn?: number }]`
+- `resources` (in file.readMany): `string[]` of resource keys
+- `files` (in file.grep): `string[]` of resource keys
+- `fileResource` (in document.close): a single resource key or a `string[]`

--- a/Source/Core/Celbridge.Tools/Assets/JavaScriptApiHeader.md
+++ b/Source/Core/Celbridge.Tools/Assets/JavaScriptApiHeader.md
@@ -19,6 +19,24 @@ Glob patterns are supported. The host re-enforces the allowlist on every
 call; a tool within a partially-matched namespace that is not itself
 allowed is rejected at call time with CEL_TOOL_DENIED.
 
+### Naming: manifest vs. JS call site
+
+The allowlist uses the tool's **alias** form: `namespace.snake_case_method`.
+The signatures listed below use the **JS method** form: `cel.namespace.camelCaseMethod`.
+The JS proxy converts snake_case to camelCase automatically — the manifest does not.
+
+Matching pairs (always declare the left form, always call the right form):
+
+  requires_tools entry       →  JS call site
+  "file.list_contents"       →  cel.file.listContents(...)
+  "file.read_binary"         →  cel.file.readBinary(...)
+  "document.apply_edits"     →  cel.document.applyEdits(...)
+  "explorer.create_folder"   →  cel.explorer.createFolder(...)
+
+Do NOT use `"file.listContents"` (camelCase in the manifest) or underscore MCP
+names like `"file_list_contents"` — both fail to match, and the `cel.*` proxy
+will omit the namespace with no diagnostic beyond a later `TypeError`.
+
 ## Getting Started
 
 Package extensions run inside a WebView hosted by a document editor contribution.

--- a/Source/Core/Celbridge.Tools/Assets/PythonApiHeader.md
+++ b/Source/Core/Celbridge.Tools/Assets/PythonApiHeader.md
@@ -1,0 +1,24 @@
+# Celbridge Python API Reference
+
+Access tools via the `cel` proxy in the Python REPL.
+Import namespaces with: `from celbridge import app, document, file`
+
+## Conventions
+
+- Parameters use snake_case. JSON results are returned as dicts.
+- Errors raise `CelError` with a message string.
+- Methods marked `-> ok` return the string 'ok' on success or raise `CelError`.
+- Methods with no return annotation return `None`.
+
+## Parameter Formats
+
+Some parameters accept structured data as JSON-encoded strings. The proxy
+auto-serializes Python lists and dicts (including nested structures with
+str, int, float, bool, and None values) to JSON for these parameters,
+so you can pass native Python objects directly:
+
+- `edits_json`: a list of edit dicts:
+  `[{"line": int, "endLine": int, "newText": str, "column"?: int (default 1), "endColumn"?: int (default -1 = end of line)}]`
+- `resources` (in file.read_many): a list of resource key strings: `["a.txt", "scripts/b.py"]`
+- `files` (in file.grep): a list of resource key strings: `["a.txt", "scripts/b.py"]`
+- `file_resource` (in document.close): a single resource key or a list: `"a.txt"` or `["a.txt", "b.txt"]`

--- a/Source/Core/Celbridge.Tools/Tools/File/FileTools.Search.cs
+++ b/Source/Core/Celbridge.Tools/Tools/File/FileTools.Search.cs
@@ -13,9 +13,12 @@ public partial class FileTools
 {
     /// <summary>
     /// Searches for resources by name using a glob pattern matched against the full resource path.
-    /// Supports ** for matching across path separators (e.g. "**/Commands/*.cs").
+    /// Patterns without a path separator match at any depth ("*.py" finds all .py files in the
+    /// project). Patterns containing a slash are anchored to their declared position
+    /// ("src/*.cs" matches only files directly under src). Use ** to match across path
+    /// separators within an anchored pattern (e.g. "**/Commands/*.cs").
     /// </summary>
-    /// <param name="pattern">Glob pattern to match resource paths (e.g. "*.py", "**/Commands/*.cs", "Services/**/I*.cs").</param>
+    /// <param name="pattern">Glob pattern to match resource paths. Examples: "*.py" (recursive), "src/*.cs" (anchored), "**/Commands/*.cs", "Services/**/I*.cs".</param>
     /// <param name="includeMetadata">When true, returns objects with resource, size, and modified fields instead of plain resource key strings.</param>
     /// <param name="type">Resource type to search: "file" (default) or "folder".</param>
     /// <returns>When includeMetadata is false: JSON array of matching resource key strings. When true: JSON array of objects with resource (string), size (long), modified (string, ISO 8601).</returns>

--- a/Source/Core/Celbridge.Tools/Tools/Query/QueryTools.GetJavaScriptApi.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Query/QueryTools.GetJavaScriptApi.cs
@@ -1,0 +1,168 @@
+using System.Reflection;
+using System.Text;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Celbridge.Tools;
+
+public partial class QueryTools
+{
+    /// <summary>
+    /// Returns the JavaScript API reference for the cel proxy exposed to package
+    /// extensions. Lists every available namespace, method, and its parameters
+    /// with TypeScript-style types and defaults. Use this when writing JavaScript
+    /// package extensions that call Celbridge tools.
+    /// </summary>
+    /// <returns>A text document listing all cel proxy namespaces and method signatures with Promise return types.</returns>
+    [McpServerTool(Name = "query_get_javascript_api", ReadOnly = true, Idempotent = true)]
+    [ToolAlias("query.get_javascript_api")]
+    public partial CallToolResult GetJavaScriptApi()
+    {
+        var reference = BuildJavaScriptApiReference();
+        return SuccessResult(reference);
+    }
+
+    private static string BuildJavaScriptApiReference()
+    {
+        var toolAssembly = typeof(QueryTools).Assembly;
+        var xmlReturns = ToolApiReflection.LoadXmlReturnsDocumentation(toolAssembly);
+        var toolMethods = ToolApiReflection.FindToolMethods(toolAssembly, xmlReturns, BuildJavaScriptParameterSignature);
+
+        var namespaces = new SortedDictionary<string, List<ToolMethodInfo>>();
+
+        foreach (var toolMethod in toolMethods)
+        {
+            if (!namespaces.TryGetValue(toolMethod.Namespace, out var methods))
+            {
+                methods = new List<ToolMethodInfo>();
+                namespaces[toolMethod.Namespace] = methods;
+            }
+            methods.Add(toolMethod);
+        }
+
+        var builder = new StringBuilder();
+        var header = LoadEmbeddedResource("Celbridge.Tools.Assets.JavaScriptApiHeader.md");
+        builder.AppendLine(header.TrimEnd());
+        builder.AppendLine();
+
+        foreach (var (namespaceName, methods) in namespaces)
+        {
+            builder.AppendLine($"## {namespaceName}");
+            builder.AppendLine();
+
+            methods.Sort((a, b) => string.Compare(a.MethodName, b.MethodName, StringComparison.Ordinal));
+
+            foreach (var method in methods)
+            {
+                var camelMethodName = ToCamelCase(method.MethodName);
+                var returnAnnotation = FormatJavaScriptReturnAnnotation(method.Returns, method.IsVoid);
+                builder.AppendLine($"  cel.{namespaceName}.{camelMethodName}({method.ParameterSignature}){returnAnnotation}");
+            }
+
+            builder.AppendLine();
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string FormatJavaScriptReturnAnnotation(string returns, bool isVoid)
+    {
+        if (isVoid)
+        {
+            return ": Promise<void>";
+        }
+
+        if (string.IsNullOrEmpty(returns))
+        {
+            return ": Promise<any>";
+        }
+
+        // Simplify the common action tool pattern to Promise<"ok">.
+        if (returns.Contains("\"ok\" on success"))
+        {
+            return ": Promise<\"ok\">";
+        }
+
+        return $": Promise<{returns}>";
+    }
+
+    private static string BuildJavaScriptParameterSignature(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        var parts = new List<string>();
+
+        foreach (var parameter in parameters)
+        {
+            var parameterName = ToCamelCase(parameter.Name ?? "");
+            var typeName = MapJavaScriptTypeName(parameter.ParameterType);
+
+            if (parameter.HasDefaultValue)
+            {
+                var defaultValue = FormatJavaScriptDefaultValue(parameter.DefaultValue, parameter.ParameterType);
+                parts.Add($"{parameterName}: {typeName} = {defaultValue}");
+            }
+            else
+            {
+                parts.Add($"{parameterName}: {typeName}");
+            }
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    private static string MapJavaScriptTypeName(Type type)
+    {
+        if (type == typeof(string)) return "string";
+        if (type == typeof(int)) return "number";
+        if (type == typeof(long)) return "number";
+        if (type == typeof(bool)) return "boolean";
+        if (type == typeof(double)) return "number";
+        if (type == typeof(float)) return "number";
+        return "string";
+    }
+
+    private static string FormatJavaScriptDefaultValue(object? value, Type parameterType)
+    {
+        if (value is null) return "null";
+        if (value is bool boolValue) return boolValue ? "true" : "false";
+        if (value is string stringValue) return stringValue == "" ? "\"\"" : $"\"{stringValue}\"";
+        return value.ToString() ?? "null";
+    }
+
+    private static string ToCamelCase(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return name;
+
+        // The input is either a camelCase C# parameter name (already correct) or a
+        // snake_case tool alias segment (e.g. "get_status"). Handle both by
+        // collapsing underscores and uppercasing the following character.
+        var builder = new StringBuilder(name.Length);
+        var upperNext = false;
+
+        for (int i = 0; i < name.Length; i++)
+        {
+            var character = name[i];
+            if (character == '_')
+            {
+                upperNext = true;
+                continue;
+            }
+
+            if (i == 0)
+            {
+                builder.Append(char.ToLowerInvariant(character));
+            }
+            else if (upperNext)
+            {
+                builder.Append(char.ToUpperInvariant(character));
+                upperNext = false;
+            }
+            else
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Source/Core/Celbridge.Tools/Tools/Query/QueryTools.GetPythonApi.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Query/QueryTools.GetPythonApi.cs
@@ -1,10 +1,8 @@
 using System.Reflection;
 using System.Text;
-using System.Xml.Linq;
 using Celbridge.Python;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
-using Path = System.IO.Path;
 
 namespace Celbridge.Tools;
 
@@ -27,8 +25,8 @@ public partial class QueryTools
     private static string BuildPythonApiReference()
     {
         var toolAssembly = typeof(QueryTools).Assembly;
-        var xmlReturns = LoadXmlReturnsDocumentation(toolAssembly);
-        var toolMethods = FindToolMethods(toolAssembly, xmlReturns);
+        var xmlReturns = ToolApiReflection.LoadXmlReturnsDocumentation(toolAssembly);
+        var toolMethods = ToolApiReflection.FindToolMethods(toolAssembly, xmlReturns, BuildParameterSignature);
 
         var namespaces = new SortedDictionary<string, List<ToolMethodInfo>>();
 
@@ -43,30 +41,8 @@ public partial class QueryTools
         }
 
         var builder = new StringBuilder();
-        builder.AppendLine("# Celbridge Python API Reference");
-        builder.AppendLine();
-        builder.AppendLine("Access tools via the `cel` proxy in the Python REPL.");
-        builder.AppendLine("Import namespaces with: `from celbridge import app, document, file`");
-        builder.AppendLine();
-        builder.AppendLine("## Conventions");
-        builder.AppendLine();
-        builder.AppendLine("- Parameters use snake_case. JSON results are returned as dicts.");
-        builder.AppendLine("- Errors raise `CelError` with a message string.");
-        builder.AppendLine("- Methods marked `-> ok` return the string 'ok' on success or raise `CelError`.");
-        builder.AppendLine("- Methods with no return annotation return `None`.");
-        builder.AppendLine();
-        builder.AppendLine("## Parameter Formats");
-        builder.AppendLine();
-        builder.AppendLine("Some parameters accept structured data as JSON-encoded strings. The proxy");
-        builder.AppendLine("auto-serializes Python lists and dicts (including nested structures with");
-        builder.AppendLine("str, int, float, bool, and None values) to JSON for these parameters,");
-        builder.AppendLine("so you can pass native Python objects directly:");
-        builder.AppendLine();
-        builder.AppendLine("- `edits_json`: a list of edit dicts:");
-        builder.AppendLine("  `[{\"line\": int, \"endLine\": int, \"newText\": str, \"column\"?: int (default 1), \"endColumn\"?: int (default -1 = end of line)}]`");
-        builder.AppendLine("- `resources` (in file.read_many): a list of resource key strings: `[\"a.txt\", \"scripts/b.py\"]`");
-        builder.AppendLine("- `files` (in file.grep): a list of resource key strings: `[\"a.txt\", \"scripts/b.py\"]`");
-        builder.AppendLine("- `file_resource` (in document.close): a single resource key or a list: `\"a.txt\"` or `[\"a.txt\", \"b.txt\"]`");
+        var header = LoadEmbeddedResource("Celbridge.Tools.Assets.PythonApiHeader.md");
+        builder.AppendLine(header.TrimEnd());
         builder.AppendLine();
 
         foreach (var (namespaceName, methods) in namespaces)
@@ -100,121 +76,6 @@ public partial class QueryTools
         return builder.ToString().TrimEnd();
     }
 
-    private static Dictionary<string, string> LoadXmlReturnsDocumentation(Assembly assembly)
-    {
-        var result = new Dictionary<string, string>();
-
-        var assemblyLocation = assembly.Location;
-        if (string.IsNullOrEmpty(assemblyLocation))
-        {
-            return result;
-        }
-
-        var xmlPath = Path.ChangeExtension(assemblyLocation, ".xml");
-        if (!File.Exists(xmlPath))
-        {
-            return result;
-        }
-
-        try
-        {
-            var document = XDocument.Load(xmlPath);
-            var members = document.Descendants("member");
-
-            foreach (var member in members)
-            {
-                var nameAttribute = member.Attribute("name")?.Value;
-                if (nameAttribute is null || !nameAttribute.StartsWith("M:"))
-                {
-                    continue;
-                }
-
-                var returnsElement = member.Element("returns");
-                if (returnsElement is null)
-                {
-                    continue;
-                }
-
-                var returnsText = returnsElement.Value.Trim();
-                if (!string.IsNullOrEmpty(returnsText))
-                {
-                    result[nameAttribute] = returnsText;
-                }
-            }
-        }
-        catch
-        {
-            // If XML parsing fails, continue without returns documentation
-        }
-
-        return result;
-    }
-
-    private static List<ToolMethodInfo> FindToolMethods(Assembly assembly, Dictionary<string, string> xmlReturns)
-    {
-        var results = new List<ToolMethodInfo>();
-
-        foreach (var type in assembly.GetTypes())
-        {
-            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
-            {
-                var toolAttribute = method.GetCustomAttribute<McpServerToolAttribute>();
-                var aliasAttribute = method.GetCustomAttribute<ToolAliasAttribute>();
-
-                if (toolAttribute is null || aliasAttribute is null)
-                {
-                    continue;
-                }
-
-                var alias = aliasAttribute.Alias;
-                var dotIndex = alias.IndexOf('.');
-                var namespaceName = dotIndex >= 0 ? alias[..dotIndex] : alias;
-                var methodName = dotIndex >= 0 ? alias[(dotIndex + 1)..] : alias;
-
-                var parameterSignature = BuildParameterSignature(method);
-                var returnsText = FindReturnsDocumentation(method, xmlReturns);
-                var isVoid = method.ReturnType == typeof(void);
-
-                results.Add(new ToolMethodInfo(namespaceName, methodName, parameterSignature, returnsText, isVoid));
-            }
-        }
-
-        return results;
-    }
-
-    private static string FindReturnsDocumentation(MethodInfo method, Dictionary<string, string> xmlReturns)
-    {
-        // Build the XML doc member name for this method
-        var declaringType = method.DeclaringType;
-        if (declaringType is null)
-        {
-            return "";
-        }
-
-        var typeName = declaringType.FullName?.Replace('+', '.');
-        var memberName = $"M:{typeName}.{method.Name}";
-
-        // Try exact match first (no parameters)
-        if (xmlReturns.TryGetValue(memberName, out var returnsText))
-        {
-            return returnsText;
-        }
-
-        // Try with parameter types for overloaded methods
-        var parameters = method.GetParameters();
-        if (parameters.Length > 0)
-        {
-            var parameterTypes = string.Join(",", parameters.Select(p => p.ParameterType.FullName));
-            var memberNameWithParams = $"{memberName}({parameterTypes})";
-            if (xmlReturns.TryGetValue(memberNameWithParams, out returnsText))
-            {
-                return returnsText;
-            }
-        }
-
-        return "";
-    }
-
     private static string FormatReturnAnnotation(string returns, bool isVoid)
     {
         if (isVoid)
@@ -227,7 +88,7 @@ public partial class QueryTools
             return "";
         }
 
-        // Simplify the common action tool pattern to just "ok"
+        // Simplify the common action tool pattern to just "ok".
         if (returns.Contains("\"ok\" on success"))
         {
             return " -> ok";
@@ -302,5 +163,3 @@ public partial class QueryTools
         return builder.ToString();
     }
 }
-
-internal record class ToolMethodInfo(string Namespace, string MethodName, string ParameterSignature, string Returns, bool IsVoid);

--- a/Source/Core/Celbridge.Tools/Tools/Query/ToolApiReflection.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Query/ToolApiReflection.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using System.Xml.Linq;
+using ModelContextProtocol.Server;
+using Path = System.IO.Path;
+
+namespace Celbridge.Tools;
+
+/// <summary>
+/// Shared reflection helpers for discovering MCP tool methods and their XML
+/// returns documentation. Used by the language-specific API reference tools
+/// (e.g. query_get_python_api, query_get_javascript_api) to build their
+/// output. Language-specific formatting (type names, parameter signatures,
+/// return annotations) lives in the tool classes themselves.
+/// </summary>
+internal static class ToolApiReflection
+{
+    /// <summary>
+    /// Loads the /// returns XML documentation for every method in the assembly,
+    /// keyed by the XML doc member name (e.g. "M:Celbridge.Tools.AppTools.ShowAlert").
+    /// Returns an empty dictionary if the XML file is missing or cannot be parsed.
+    /// </summary>
+    public static Dictionary<string, string> LoadXmlReturnsDocumentation(Assembly assembly)
+    {
+        var result = new Dictionary<string, string>();
+
+        var assemblyLocation = assembly.Location;
+        if (string.IsNullOrEmpty(assemblyLocation))
+        {
+            return result;
+        }
+
+        var xmlPath = Path.ChangeExtension(assemblyLocation, ".xml");
+        if (!File.Exists(xmlPath))
+        {
+            return result;
+        }
+
+        try
+        {
+            var document = XDocument.Load(xmlPath);
+            var members = document.Descendants("member");
+
+            foreach (var member in members)
+            {
+                var nameAttribute = member.Attribute("name")?.Value;
+                if (nameAttribute is null || !nameAttribute.StartsWith("M:"))
+                {
+                    continue;
+                }
+
+                var returnsElement = member.Element("returns");
+                if (returnsElement is null)
+                {
+                    continue;
+                }
+
+                var returnsText = returnsElement.Value.Trim();
+                if (!string.IsNullOrEmpty(returnsText))
+                {
+                    result[nameAttribute] = returnsText;
+                }
+            }
+        }
+        catch
+        {
+            // If XML parsing fails, continue without returns documentation.
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Discovers every MCP tool method in the assembly. A method is considered a
+    /// tool when it carries both an McpServerTool and a ToolAlias attribute.
+    /// The parameter signature is built by the caller-supplied formatter so that
+    /// each language can apply its own type mapping and naming conventions.
+    /// </summary>
+    public static List<ToolMethodInfo> FindToolMethods(
+        Assembly assembly,
+        Dictionary<string, string> xmlReturns,
+        Func<MethodInfo, string> buildParameterSignature)
+    {
+        var results = new List<ToolMethodInfo>();
+
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                var toolAttribute = method.GetCustomAttribute<McpServerToolAttribute>();
+                var aliasAttribute = method.GetCustomAttribute<ToolAliasAttribute>();
+
+                if (toolAttribute is null || aliasAttribute is null)
+                {
+                    continue;
+                }
+
+                var alias = aliasAttribute.Alias;
+                var dotIndex = alias.IndexOf('.');
+                var namespaceName = dotIndex >= 0 ? alias[..dotIndex] : alias;
+                var methodName = dotIndex >= 0 ? alias[(dotIndex + 1)..] : alias;
+
+                var parameterSignature = buildParameterSignature(method);
+                var returnsText = FindReturnsDocumentation(method, xmlReturns);
+                var isVoid = method.ReturnType == typeof(void);
+
+                results.Add(new ToolMethodInfo(namespaceName, methodName, parameterSignature, returnsText, isVoid));
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Looks up the /// returns text for a method by building its XML doc member
+    /// name. Tries the unparameterised form first, then falls back to the
+    /// overload-disambiguated form ("M:Type.Method(ParamTypes)").
+    /// </summary>
+    public static string FindReturnsDocumentation(MethodInfo method, Dictionary<string, string> xmlReturns)
+    {
+        var declaringType = method.DeclaringType;
+        if (declaringType is null)
+        {
+            return "";
+        }
+
+        var typeName = declaringType.FullName?.Replace('+', '.');
+        var memberName = $"M:{typeName}.{method.Name}";
+
+        if (xmlReturns.TryGetValue(memberName, out var returnsText))
+        {
+            return returnsText;
+        }
+
+        var parameters = method.GetParameters();
+        if (parameters.Length > 0)
+        {
+            var parameterTypes = string.Join(",", parameters.Select(p => p.ParameterType.FullName));
+            var memberNameWithParams = $"{memberName}({parameterTypes})";
+            if (xmlReturns.TryGetValue(memberNameWithParams, out returnsText))
+            {
+                return returnsText;
+            }
+        }
+
+        return "";
+    }
+}
+
+/// <summary>
+/// Reflected metadata for a single MCP tool method, consumed by the
+/// language-specific API reference renderers.
+/// </summary>
+internal record class ToolMethodInfo(
+    string Namespace,
+    string MethodName,
+    string ParameterSignature,
+    string Returns,
+    bool IsVoid);

--- a/Source/Core/Celbridge.Utilities/GlobHelper.cs
+++ b/Source/Core/Celbridge.Utilities/GlobHelper.cs
@@ -26,10 +26,18 @@ public static class GlobHelper
     /// against a full forward-slash-separated resource key.
     /// Supports * (any characters within a path segment), ? (any single character
     /// within a path segment), and ** (any characters including path separators).
+    /// Patterns without a path separator match at any depth — "*.py" behaves as
+    /// "**/*.py", matching git-ignore semantics. Explicit paths like "src/*.cs"
+    /// stay anchored to their declared position.
     /// Examples: "*.py", "src/*.cs", "**/Commands/*.cs", "Services/**/I*.cs"
     /// </summary>
     public static string PathGlobToRegex(string glob)
     {
+        if (!glob.Contains('/'))
+        {
+            glob = "**/" + glob;
+        }
+
         var escaped = Regex.Escape(glob);
         var result = escaped
             .Replace("\\*\\*/", "(?:[^/]*/)*")

--- a/Source/Core/Celbridge.WebView/Web/celbridge-client/api/tools-api.js
+++ b/Source/Core/Celbridge.WebView/Web/celbridge-client/api/tools-api.js
@@ -8,6 +8,12 @@
 // The host re-enforces the same allowlist on every `tools/call` — the client-side proxy
 // is a convenience that keeps undeclared tools off the API surface, but the host gate is
 // authoritative.
+//
+// Calling convention:
+//   - Arguments are positional and camelCase, in parameter declaration order.
+//   - Extra positional arguments throw CelToolError(InvalidArgs).
+//   - Arrays and plain objects passed to `string`-typed parameters are JSON-stringified
+//     automatically (for editsJson, resources, files, etc.).
 
 /**
  * Error codes for tool proxy failures. Wire codes are JSON-RPC application error codes
@@ -94,22 +100,63 @@ export function isToolAllowed(alias, allowedPatterns) {
 }
 
 /**
- * Builds a nested object proxy from a flat list of tool aliases.
- * For an alias like "document.open", the proxy exposes `proxy.document.open(args)`,
- * which dispatches via `invoke(alias, args)`.
+ * Returns true if the value is a plain object literal (not null, not an array,
+ * not a class instance). Used by the positional-call shape to decide whether a
+ * trailing argument should be unpacked as keyword arguments.
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object') {
+        return false;
+    }
+    if (Array.isArray(value)) {
+        return false;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Converts a snake_case identifier to camelCase. Used to translate server-side
+ * aliases (e.g. "get_version") into their JavaScript method names ("getVersion").
+ * @param {string} name
+ * @returns {string}
+ */
+function snakeToCamelCase(name) {
+    if (typeof name !== 'string' || name.length === 0) {
+        return '';
+    }
+    return name.replace(/_([a-z0-9])/g, (_, character) => character.toUpperCase());
+}
+
+/**
+ * Builds a nested object proxy from a list of tool descriptors.
  *
- * @param {ReadonlyArray<string>} aliases - The allowed tool aliases.
- * @param {(alias: string, args?: Object) => Promise<any>} invoke - Dispatch function.
+ * Each descriptor's alias becomes a method path: "document.apply_edits" exposes
+ * `proxy.document.applyEdits(...)`. Arguments are mapped to the descriptor's
+ * parameter list in declaration order. Arrays and plain objects passed to
+ * string-typed parameters are JSON-stringified automatically.
+ *
+ * @param {ReadonlyArray<ToolDescriptor>} descriptors - The tool descriptors to expose.
+ * @param {(alias: string, args: Object) => Promise<any>} invoke - Dispatch function.
  * @returns {Object} The root of the proxy tree.
  */
-export function buildCelProxy(aliases, invoke) {
+export function buildCelProxy(descriptors, invoke) {
     const root = {};
-    for (const alias of aliases) {
-        if (typeof alias !== 'string' || alias.length === 0) {
+    if (!Array.isArray(descriptors)) {
+        return root;
+    }
+
+    for (const descriptor of descriptors) {
+        if (!descriptor || typeof descriptor.alias !== 'string' || descriptor.alias.length === 0) {
             continue;
         }
+        const alias = descriptor.alias;
         const segments = alias.split('.');
-        const leafName = segments.pop();
+        const leafSegment = segments.pop();
+        const leafName = snakeToCamelCase(leafSegment);
+
         let node = root;
         for (const segment of segments) {
             if (!Object.prototype.hasOwnProperty.call(node, segment) || typeof node[segment] !== 'object') {
@@ -117,15 +164,61 @@ export function buildCelProxy(aliases, invoke) {
             }
             node = node[segment];
         }
-        node[leafName] = (args) => invoke(alias, args);
+        node[leafName] = buildLeafFunction(descriptor, invoke);
     }
+
     return root;
 }
 
+function buildLeafFunction(descriptor, invoke) {
+    const alias = descriptor.alias;
+    const rawParameters = Array.isArray(descriptor.parameters) ? descriptor.parameters : [];
+    const parameterNames = [];
+    const parameterTypes = {};
+
+    for (const parameter of rawParameters) {
+        if (parameter && typeof parameter.name === 'string') {
+            parameterNames.push(parameter.name);
+            parameterTypes[parameter.name] = typeof parameter.type === 'string' ? parameter.type : '';
+        }
+    }
+
+    const expectedCount = parameterNames.length;
+    const signature = `cel.${alias}(${parameterNames.join(', ')})`;
+
+    return (...args) => {
+        if (args.length > expectedCount) {
+            throw new CelToolError(
+                CelToolErrorCode.InvalidArgs,
+                alias,
+                `${signature} was called with ${args.length} positional arguments`
+            );
+        }
+
+        const argumentsObject = {};
+        for (let index = 0; index < args.length; index++) {
+            const parameterName = parameterNames[index];
+            if (typeof parameterName === 'string') {
+                argumentsObject[parameterName] = args[index];
+            }
+        }
+
+        // Auto-serialize arrays and plain objects when the tool parameter expects a string.
+        for (const [parameterName, value] of Object.entries(argumentsObject)) {
+            if (parameterTypes[parameterName] === 'string' && (Array.isArray(value) || isPlainObject(value))) {
+                argumentsObject[parameterName] = JSON.stringify(value);
+            }
+        }
+
+        return invoke(alias, argumentsObject);
+    };
+}
+
 /**
- * Client-side tools API. Builds a dynamic `cel.*` proxy from the allowlist and
- * dispatches tool calls through JSON-RPC to the host. The host re-enforces the
- * allowlist on every call — this proxy does not bypass that gate.
+ * Client-side tools API. Loads tool descriptors from the host during
+ * `celbridge.initialize()`, builds a positional `cel.*` proxy, and dispatches
+ * calls through JSON-RPC. The host re-enforces the allowlist on every call —
+ * this proxy does not bypass that gate.
  */
 export class ToolsAPI {
     /** @type {import('../core/rpc-transport.js').RpcTransport} */
@@ -134,19 +227,25 @@ export class ToolsAPI {
     /** @type {ReadonlyArray<string>} */
     #allowedPatterns;
 
+    /** @type {ReadonlyArray<ToolDescriptor>|null} */
+    #descriptors = null;
+
     /** @type {Object|null} */
     #celProxy = null;
-
-    /** @type {Promise<ReadonlyArray<ToolDescriptor>>|null} */
-    #toolListPromise = null;
 
     /**
      * @param {import('../core/rpc-transport.js').RpcTransport} transport
      * @param {ReadonlyArray<string>} [allowedPatterns] - Glob patterns for allowed tools.
+     * @param {ReadonlyArray<ToolDescriptor>} [initialDescriptors] - Pre-supplied descriptors
+     *   (tests can pass these to skip the tools/list fetch).
      */
-    constructor(transport, allowedPatterns = []) {
+    constructor(transport, allowedPatterns = [], initialDescriptors = null) {
         this.#transport = transport;
         this.#allowedPatterns = Array.isArray(allowedPatterns) ? [...allowedPatterns] : [];
+
+        if (Array.isArray(initialDescriptors)) {
+            this.setDescriptors(initialDescriptors);
+        }
     }
 
     /**
@@ -158,15 +257,75 @@ export class ToolsAPI {
     }
 
     /**
-     * Lists all tools reachable through this proxy (pre-filtered by the allowlist).
-     * Result is cached; subsequent calls return the same list without re-querying the host.
-     * @returns {Promise<ReadonlyArray<ToolDescriptor>>}
+     * Returns true once descriptors have been loaded (via loadDescriptors,
+     * setDescriptors, or the constructor's initialDescriptors argument).
+     * The `cel` proxy throws until this is true.
+     * @returns {boolean}
      */
-    async list() {
-        if (this.#toolListPromise === null) {
-            this.#toolListPromise = this.#fetchToolList();
+    get isReady() {
+        return this.#descriptors !== null;
+    }
+
+    /**
+     * Fetches tools/list from the host, filters by the allowlist, and stores
+     * the descriptors so `cel.*` becomes callable. Invoked by Celbridge.initialize().
+     * Safe to call multiple times; subsequent calls refresh the descriptor list.
+     *
+     * When the allowlist is empty the fetch is skipped — no tool can pass the
+     * gate, so there is nothing to discover. Packages that do not declare
+     * `requires_tools` therefore pay no startup round-trip.
+     *
+     * @returns {Promise<void>}
+     */
+    async loadDescriptors() {
+        if (this.#allowedPatterns.length === 0) {
+            this.setDescriptors([]);
+            return;
         }
-        return this.#toolListPromise;
+
+        let response;
+        try {
+            response = await this.#transport.request('tools/list', {});
+        } catch {
+            // If the host does not expose tools (older host or test environment),
+            // mark ready with an empty descriptor list rather than rejecting.
+            this.setDescriptors([]);
+            return;
+        }
+
+        const tools = Array.isArray(response) ? response : response?.tools;
+        const filtered = Array.isArray(tools)
+            ? tools.filter(tool => typeof tool?.alias === 'string' && isToolAllowed(tool.alias, this.#allowedPatterns))
+            : [];
+
+        this.setDescriptors(filtered);
+    }
+
+    /**
+     * Replaces the descriptor list and rebuilds the `cel.*` proxy. Primarily
+     * for tests that want to skip the `tools/list` round-trip.
+     * @param {ReadonlyArray<ToolDescriptor>} descriptors
+     */
+    setDescriptors(descriptors) {
+        const copy = Array.isArray(descriptors) ? [...descriptors] : [];
+        this.#descriptors = Object.freeze(copy);
+        this.#celProxy = buildCelProxy(copy, (alias, args) => this.call(alias, args));
+    }
+
+    /**
+     * Returns the cached descriptor list for tools reachable through this proxy.
+     * Throws if called before `loadDescriptors` / `setDescriptors` has run.
+     * @returns {ReadonlyArray<ToolDescriptor>}
+     */
+    list() {
+        if (this.#descriptors === null) {
+            throw new CelToolError(
+                CelToolErrorCode.Failed,
+                '',
+                'Tool descriptors not loaded. Call celbridge.initialize() first.'
+            );
+        }
+        return this.#descriptors;
     }
 
     /**
@@ -208,67 +367,21 @@ export class ToolsAPI {
     }
 
     /**
-     * Returns the `cel.*` proxy. Lazily constructed from the allowlist on first access.
+     * Returns the `cel.*` proxy. Throws `CelToolError` synchronously if accessed
+     * before `celbridge.initialize()` has loaded the tool descriptors.
      * The proxy tree mirrors the Python `cel` object layout: a tool alias like
-     * "document.open" is exposed as `cel.document.open(args)`.
+     * "document.apply_edits" is exposed as `cel.document.applyEdits(...)`.
      * @returns {Object}
      */
     get cel() {
         if (this.#celProxy === null) {
-            const reachableAliases = this.#enumerateLiteralAliases();
-            this.#celProxy = buildCelProxy(reachableAliases, (alias, args) => this.call(alias, args));
+            throw new CelToolError(
+                CelToolErrorCode.Failed,
+                '',
+                'cel proxy not initialized. Call celbridge.initialize() first.'
+            );
         }
         return this.#celProxy;
-    }
-
-    /**
-     * Rebuilds the proxy after the tool list has been fetched from the host,
-     * merging in any aliases matched by wildcard patterns.
-     * Call this after `await list()` if the package uses wildcard allowlist entries
-     * and you want them surfaced on `celbridge.cel`.
-     */
-    async refreshProxy() {
-        const tools = await this.list();
-        const aliases = tools
-            .map(tool => tool?.alias)
-            .filter(alias => typeof alias === 'string' && alias.length > 0);
-        this.#celProxy = buildCelProxy(aliases, (alias, args) => this.call(alias, args));
-    }
-
-    #enumerateLiteralAliases() {
-        const literals = [];
-        for (const pattern of this.#allowedPatterns) {
-            if (typeof pattern !== 'string') {
-                continue;
-            }
-            if (pattern === '*' || pattern.endsWith('.*')) {
-                // Wildcards expand only after list() has been called; skip here.
-                continue;
-            }
-            literals.push(pattern);
-        }
-        return literals;
-    }
-
-    async #fetchToolList() {
-        let response;
-        try {
-            response = await this.#transport.request('tools/list', {});
-        } catch (error) {
-            // If the host does not expose tools (older host or test environment),
-            // return an empty list rather than rejecting.
-            return [];
-        }
-
-        const tools = Array.isArray(response) ? response : response?.tools;
-        if (!Array.isArray(tools)) {
-            return [];
-        }
-
-        return tools.filter(tool => {
-            const alias = tool?.alias;
-            return typeof alias === 'string' && isToolAllowed(alias, this.#allowedPatterns);
-        });
     }
 }
 
@@ -290,10 +403,18 @@ export function jsonRpcCodeForCelCode(celCode) {
 }
 
 /**
+ * @typedef {Object} ToolParameter
+ * @property {string} name - Parameter name in camelCase.
+ * @property {string} type - JSON Schema type name (e.g. "string", "number", "boolean", "array").
+ * @property {boolean} [hasDefaultValue] - True if the parameter has a default.
+ * @property {*} [defaultValue] - The default value, if any.
+ */
+
+/**
  * @typedef {Object} ToolDescriptor
  * @property {string} name - The MCP tool name (e.g. "app_get_version").
  * @property {string} alias - The cel-proxy alias (e.g. "app.get_version").
  * @property {string} description - Human-readable description.
  * @property {string} [returnType] - JSON Schema type name for the return value.
- * @property {Array<Object>} [parameters] - Parameter metadata.
+ * @property {Array<ToolParameter>} [parameters] - Parameter metadata.
  */

--- a/Source/Core/Celbridge.WebView/Web/celbridge-client/celbridge.js
+++ b/Source/Core/Celbridge.WebView/Web/celbridge-client/celbridge.js
@@ -78,6 +78,14 @@ export class Celbridge {
     options;
 
     /**
+     * Set to `false` to opt out of exposing the `cel` proxy on `globalThis` during
+     * `initialize()`. Useful for embedding scenarios where the host page already
+     * uses the name.
+     * @type {boolean}
+     */
+    #exposeCelGlobal;
+
+    /**
      * Creates a new Celbridge instance.
      * @param {Object} [options] - Configuration options.
      * @param {Function} [options.postMessage] - Custom postMessage function (for testing).
@@ -85,6 +93,9 @@ export class Celbridge {
      * @param {number} [options.timeout] - Request timeout in milliseconds.
      * @param {Object} [options.context] - Injected capability context (for testing).
      *   Normally read from `globalThis.__celbridgeContext`.
+     * @param {boolean} [options.exposeCelGlobal=true] - When `true` (the default),
+     *   `initialize()` assigns the `cel.*` proxy to `globalThis.cel` so extensions
+     *   can call `cel.namespace.method(...)` without importing the client.
      */
     constructor(options = {}) {
         this.#transport = new RpcTransport(options);
@@ -100,11 +111,13 @@ export class Celbridge {
         this.tools = new ToolsAPI(this.#transport, context.allowedTools);
         this.secrets = context.secrets;
         this.options = context.options;
+        this.#exposeCelGlobal = options.exposeCelGlobal !== false;
     }
 
     /**
-     * Convenience accessor for the `cel.*` tool proxy.
-     * Equivalent to `client.tools.cel`.
+     * Convenience accessor for the `cel.*` tool proxy. Equivalent to `client.tools.cel`.
+     * Throws synchronously with `CelToolError` if accessed before `initialize()` resolves —
+     * the proxy is built from descriptors fetched during initialization.
      * @returns {Object}
      */
     get cel() {
@@ -135,6 +148,16 @@ export class Celbridge {
         });
 
         this.#transport.markInitialized();
+
+        // Load tool descriptors so the `cel.*` proxy becomes callable.
+        // One round-trip to the host; before this resolves, accessing `cel.*` throws.
+        await this.tools.loadDescriptors();
+
+        // Expose `cel` on globalThis for the "just call cel.namespace.method(...)"
+        // agent experience. Opt out with `new Celbridge({ exposeCelGlobal: false })`.
+        if (this.#exposeCelGlobal && typeof globalThis !== 'undefined') {
+            globalThis.cel = this.tools.cel;
+        }
 
         // Auto-load localization if locale is provided in metadata
         if (result.metadata?.locale) {

--- a/Source/Core/Celbridge.WebView/Web/celbridge-client/tests/tools-api.test.js
+++ b/Source/Core/Celbridge.WebView/Web/celbridge-client/tests/tools-api.test.js
@@ -40,6 +40,16 @@ function createTestClient(options = {}) {
     return { client, sentMessages, simulateResponse, simulateError };
 }
 
+/**
+ * Convenience: build a descriptor with the given alias and parameter list.
+ * @param {string} alias
+ * @param {Array<{name: string, type?: string}>} [parameters]
+ * @returns {import('./api/tools-api.js').ToolDescriptor}
+ */
+function descriptor(alias, parameters = []) {
+    return { name: alias.replace(/\./g, '_'), alias, description: '', parameters };
+}
+
 describe('matchesToolPattern', () => {
     it('matches literal alias exactly', () => {
         expect(matchesToolPattern('app.get_version', 'app.get_version')).toBe(true);
@@ -77,24 +87,112 @@ describe('isToolAllowed', () => {
 });
 
 describe('buildCelProxy', () => {
-    it('builds nested namespaces from dotted aliases', () => {
+    it('builds nested namespaces from descriptor aliases with camelCase leaf names', () => {
         const calls = [];
         const invoke = (alias, args) => {
             calls.push({ alias, args });
             return Promise.resolve('ok');
         };
-        const proxy = buildCelProxy(['app.get_version', 'document.open'], invoke);
+        const proxy = buildCelProxy(
+            [
+                descriptor('app.get_version'),
+                descriptor('document.open', [{ name: 'fileResource', type: 'string' }])
+            ],
+            invoke
+        );
 
-        expect(typeof proxy.app.get_version).toBe('function');
+        expect(typeof proxy.app.getVersion).toBe('function');
         expect(typeof proxy.document.open).toBe('function');
 
-        return proxy.app.get_version({ foo: 1 }).then(() => {
-            expect(calls[0]).toEqual({ alias: 'app.get_version', args: { foo: 1 } });
+        return proxy.document.open('readme.md').then(() => {
+            expect(calls[0]).toEqual({ alias: 'document.open', args: { fileResource: 'readme.md' } });
         });
     });
 
-    it('ignores empty or non-string aliases', () => {
-        const proxy = buildCelProxy(['', null, undefined, 'valid.tool'], () => Promise.resolve());
+    it('maps positional arguments to parameter names in declaration order', () => {
+        const calls = [];
+        const proxy = buildCelProxy(
+            [descriptor('document.apply_edits', [
+                { name: 'fileResource', type: 'string' },
+                { name: 'editsJson', type: 'string' },
+                { name: 'openDocument', type: 'boolean' }
+            ])],
+            (alias, args) => { calls.push({ alias, args }); return Promise.resolve('ok'); }
+        );
+
+        return proxy.document.applyEdits('a.md', '[]', false).then(() => {
+            expect(calls[0].args).toEqual({
+                fileResource: 'a.md',
+                editsJson: '[]',
+                openDocument: false
+            });
+        });
+    });
+
+    it('throws CelToolError(InvalidArgs) on arity overflow', () => {
+        const proxy = buildCelProxy(
+            [descriptor('app.get_version', [])],
+            () => Promise.resolve('ok')
+        );
+
+        expect(() => proxy.app.getVersion('extra')).toThrow(CelToolError);
+        try {
+            proxy.app.getVersion('extra');
+        } catch (error) {
+            expect(error.code).toBe(CelToolErrorCode.InvalidArgs);
+            expect(error.message).toContain('cel.app.get_version');
+            expect(error.message).toContain('1 positional arguments');
+        }
+    });
+
+    it('JSON-stringifies arrays passed to string-typed parameters', () => {
+        const calls = [];
+        const proxy = buildCelProxy(
+            [descriptor('document.apply_edits', [
+                { name: 'fileResource', type: 'string' },
+                { name: 'editsJson', type: 'string' }
+            ])],
+            (alias, args) => { calls.push({ alias, args }); return Promise.resolve('ok'); }
+        );
+
+        const edits = [{ line: 1, endLine: 1, newText: 'hi' }];
+        return proxy.document.applyEdits('a.md', edits).then(() => {
+            expect(calls[0].args.editsJson).toBe(JSON.stringify(edits));
+        });
+    });
+
+    it('JSON-stringifies plain objects passed to string-typed parameters', () => {
+        const calls = [];
+        const proxy = buildCelProxy(
+            [descriptor('app.custom', [{ name: 'payload', type: 'string' }])],
+            (alias, args) => { calls.push({ alias, args }); return Promise.resolve('ok'); }
+        );
+
+        return proxy.app.custom({ a: 1 }).then(() => {
+            expect(calls[0].args).toEqual({ payload: '{"a":1}' });
+        });
+    });
+
+    it('does not stringify arguments for non-string parameters', () => {
+        const calls = [];
+        const proxy = buildCelProxy(
+            [descriptor('document.open', [
+                { name: 'fileResource', type: 'string' },
+                { name: 'sectionIndex', type: 'integer' }
+            ])],
+            (alias, args) => { calls.push({ alias, args }); return Promise.resolve('ok'); }
+        );
+
+        return proxy.document.open('a.md', 2).then(() => {
+            expect(calls[0].args).toEqual({ fileResource: 'a.md', sectionIndex: 2 });
+        });
+    });
+
+    it('ignores non-descriptor entries', () => {
+        const proxy = buildCelProxy(
+            [null, undefined, {}, { alias: '' }, descriptor('valid.tool')],
+            () => Promise.resolve()
+        );
         expect(typeof proxy.valid.tool).toBe('function');
     });
 });
@@ -102,8 +200,30 @@ describe('buildCelProxy', () => {
 describe('ToolsAPI', () => {
     it('exposes allowedPatterns as a readonly copy', () => {
         const patterns = ['app.*', 'document.open'];
-        const api = new ToolsAPI(/* transport */ { request: () => Promise.resolve([]) }, patterns);
+        const api = new ToolsAPI({ request: () => Promise.resolve([]) }, patterns);
         expect(api.allowedPatterns).toEqual(patterns);
+    });
+
+    it('cel proxy throws synchronously before descriptors are loaded', () => {
+        const api = new ToolsAPI({ request: () => Promise.resolve([]) }, ['*']);
+        expect(api.isReady).toBe(false);
+        expect(() => api.cel).toThrow(CelToolError);
+        try {
+            void api.cel;
+        } catch (error) {
+            expect(error.code).toBe(CelToolErrorCode.Failed);
+            expect(error.message).toContain('not initialized');
+        }
+    });
+
+    it('accepts initialDescriptors via constructor to skip fetch', () => {
+        const api = new ToolsAPI(
+            { request: () => Promise.reject(new Error('should not fetch')) },
+            ['*'],
+            [descriptor('app.get_version')]
+        );
+        expect(api.isReady).toBe(true);
+        expect(typeof api.cel.app.getVersion).toBe('function');
     });
 
     it('call() rejects tools not in the allowlist with CEL_TOOL_DENIED', async () => {
@@ -161,29 +281,40 @@ describe('ToolsAPI', () => {
         });
     });
 
-    it('cel proxy lazily exposes only literal aliases', () => {
-        const api = new ToolsAPI({ request: () => Promise.resolve([]) }, ['app.get_version', 'document.*']);
-        const cel = api.cel;
-        expect(typeof cel.app.get_version).toBe('function');
-        // Wildcard entries don't populate the proxy until refreshProxy() runs.
-        expect(cel.document).toBeUndefined();
-    });
-
-    it('refreshProxy() expands wildcards from tools/list response', async () => {
+    it('loadDescriptors() fetches tools/list and filters by the allowlist', async () => {
         const transport = {
-            request: () => Promise.resolve([
-                { name: 'doc_open', alias: 'document.open' },
-                { name: 'doc_save', alias: 'document.save' },
-                { name: 'file_read', alias: 'file.read' }
-            ])
+            request: (method) => {
+                expect(method).toBe('tools/list');
+                return Promise.resolve([
+                    descriptor('document.open', [{ name: 'fileResource', type: 'string' }]),
+                    descriptor('document.save'),
+                    descriptor('file.read', [{ name: 'fileResource', type: 'string' }])
+                ]);
+            }
         };
         const api = new ToolsAPI(transport, ['document.*']);
 
-        await api.refreshProxy();
+        await api.loadDescriptors();
 
+        expect(api.isReady).toBe(true);
         expect(typeof api.cel.document.open).toBe('function');
         expect(typeof api.cel.document.save).toBe('function');
         expect(api.cel.file).toBeUndefined(); // filtered out by allowlist
+    });
+
+    it('loadDescriptors() tolerates transport failures with an empty descriptor list', async () => {
+        const transport = { request: () => Promise.reject(new Error('no tools/list')) };
+        const api = new ToolsAPI(transport, ['*']);
+
+        await api.loadDescriptors();
+
+        expect(api.isReady).toBe(true);
+        expect(api.list()).toEqual([]);
+    });
+
+    it('list() throws before descriptors are loaded', () => {
+        const api = new ToolsAPI({ request: () => Promise.resolve([]) }, ['*']);
+        expect(() => api.list()).toThrow(CelToolError);
     });
 });
 
@@ -209,20 +340,52 @@ describe('Celbridge.tools integration', () => {
         expect(client.secrets.spreadjs_license).toBe('abc123');
     });
 
-    it('cel proxy dispatches via tools/call', async () => {
+    it('cel accessor throws before initialize() completes', () => {
+        const { client } = createTestClient({
+            context: { allowedTools: ['*'], secrets: {} }
+        });
+        expect(() => client.cel).toThrow(/not initialized/);
+    });
+
+    it('cel proxy dispatches via tools/call with positional arguments after initialize()', async () => {
         const { client, sentMessages, simulateResponse } = createTestClient({
             context: { allowedTools: ['app.get_version'], secrets: {} }
         });
 
-        const promise = client.cel.app.get_version({});
+        // Kick off initialize() — it sends document/initialize, then tools/list,
+        // then (optionally) localization if metadata.locale is present.
+        const initPromise = client.initialize();
 
-        const sent = JSON.parse(sentMessages[0]);
-        expect(sent.method).toBe('tools/call');
-        expect(sent.params.name).toBe('app.get_version');
+        const docInitMessage = JSON.parse(sentMessages[0]);
+        expect(docInitMessage.method).toBe('document/initialize');
+        simulateResponse(docInitMessage.id, {
+            content: '',
+            metadata: { filePath: '', resourceKey: '', fileName: '', locale: '' }
+        });
 
-        simulateResponse(sent.id, { isSuccess: true, value: '0.2.5' });
+        // Allow the microtask queue to advance so tools/list is posted.
+        await Promise.resolve();
+        await Promise.resolve();
 
-        await expect(promise).resolves.toBe('0.2.5');
+        const listMessage = JSON.parse(sentMessages[1]);
+        expect(listMessage.method).toBe('tools/list');
+        simulateResponse(listMessage.id, [
+            descriptor('app.get_version', [])
+        ]);
+
+        await initPromise;
+
+        // Now the proxy is built. Call via positional shape.
+        const callPromise = client.cel.app.getVersion();
+
+        const callMessage = JSON.parse(sentMessages[2]);
+        expect(callMessage.method).toBe('tools/call');
+        expect(callMessage.params.name).toBe('app.get_version');
+        expect(callMessage.params.arguments).toEqual({});
+
+        simulateResponse(callMessage.id, { isSuccess: true, value: '0.2.5' });
+
+        await expect(callPromise).resolves.toBe('0.2.5');
     });
 
     it('denied tool calls reject without hitting the transport', async () => {
@@ -236,6 +399,77 @@ describe('Celbridge.tools integration', () => {
             tool: 'file.read'
         });
         expect(sentMessages).toHaveLength(0);
+    });
+});
+
+describe('cel globalThis exposure', () => {
+    it('assigns globalThis.cel after initialize() resolves', async () => {
+        delete globalThis.cel;
+
+        const { client, sentMessages, simulateResponse } = createTestClient({
+            context: { allowedTools: ['app.get_version'], secrets: {} }
+        });
+
+        const initPromise = client.initialize();
+
+        const docInit = JSON.parse(sentMessages[0]);
+        simulateResponse(docInit.id, {
+            content: '',
+            metadata: { filePath: '', resourceKey: '', fileName: '', locale: '' }
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const toolsList = JSON.parse(sentMessages[1]);
+        simulateResponse(toolsList.id, [
+            { name: 'app_get_version', alias: 'app.get_version', description: '', parameters: [] }
+        ]);
+
+        await initPromise;
+
+        expect(globalThis.cel).toBeDefined();
+        expect(typeof globalThis.cel.app.getVersion).toBe('function');
+
+        delete globalThis.cel;
+    });
+
+    it('accessing cel global before initialize() throws via client.cel', () => {
+        delete globalThis.cel;
+        const { client } = createTestClient({
+            context: { allowedTools: ['*'], secrets: {} }
+        });
+
+        expect(() => client.cel).toThrow(/not initialized/);
+        expect(globalThis.cel).toBeUndefined();
+    });
+
+    it('exposeCelGlobal: false keeps globalThis.cel untouched', async () => {
+        delete globalThis.cel;
+
+        const sentMessages = [];
+        let messageHandler = null;
+        const client = new Celbridge({
+            postMessage: (msg) => sentMessages.push(msg),
+            onMessage: (handler) => { messageHandler = handler; },
+            timeout: 1000,
+            exposeCelGlobal: false,
+            context: { allowedTools: [], secrets: {} }
+        });
+
+        const initPromise = client.initialize();
+        const docInit = JSON.parse(sentMessages[0]);
+        messageHandler(JSON.stringify({
+            jsonrpc: '2.0',
+            id: docInit.id,
+            result: { content: '', metadata: { filePath: '', resourceKey: '', fileName: '' } }
+        }));
+
+        await initPromise;
+
+        // With allowedTools=[], no tools/list is sent, so init completes with only the one message.
+        expect(globalThis.cel).toBeUndefined();
+        expect(client.tools.isReady).toBe(true);
     });
 });
 

--- a/Source/Tests/Tools/FileToolHelpersTests.cs
+++ b/Source/Tests/Tools/FileToolHelpersTests.cs
@@ -53,7 +53,11 @@ public class FileToolHelpersTests
     //
 
     [TestCase("*.py", "foo.py", true)]
-    [TestCase("*.py", "src/foo.py", false, TestName = "PathGlobToRegex_StarExtension_NoMatchAcrossSlash")]
+    [TestCase("*.py", "src/foo.py", true, TestName = "PathGlobToRegex_StarExtension_MatchesAtAnyDepth")]
+    [TestCase("*.py", "a/b/foo.py", true, TestName = "PathGlobToRegex_StarExtension_MatchesDeepNesting")]
+    [TestCase("*.py", "foo.txt", false, TestName = "PathGlobToRegex_StarExtension_RequiresExtensionMatch")]
+    [TestCase("readme", "readme", true, TestName = "PathGlobToRegex_BareName_MatchesTopLevel")]
+    [TestCase("readme", "src/readme", true, TestName = "PathGlobToRegex_BareName_MatchesAtAnyDepth")]
     [TestCase("src/*.cs", "src/foo.cs", true)]
     [TestCase("src/*.cs", "src/sub/foo.cs", false, TestName = "PathGlobToRegex_Star_NoMatchAcrossSlash")]
     [TestCase("src/*.cs", "other/foo.cs", false)]

--- a/Source/Tests/Tools/QueryToolTests.cs
+++ b/Source/Tests/Tools/QueryToolTests.cs
@@ -40,6 +40,17 @@ public class QueryToolTests
     }
 
     [Test]
+    public void GetContext_ContainsJavaScriptExtensionSection()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetContext());
+
+        text.Should().Contain("Writing Package Extensions (JavaScript)");
+        text.Should().Contain("query_get_javascript_api");
+        text.Should().Contain("requires_tools");
+    }
+
+    [Test]
     public void GetPythonApi_ReturnsApiReference()
     {
         var tools = new QueryTools(_services);
@@ -93,6 +104,91 @@ public class QueryToolTests
         // Methods should be listed compactly with indent, not as ### headings
         text.Should().NotContain("### app.");
         text.Should().Contain("  app.get_status(");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_ReturnsApiReference()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().Contain("# Celbridge JavaScript API Reference");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_ContainsAllNamespaces()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().Contain("## app");
+        text.Should().Contain("## document");
+        text.Should().Contain("## explorer");
+        text.Should().Contain("## file");
+        text.Should().Contain("## package");
+        text.Should().Contain("## query");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_UsesCamelCaseParameters()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        // Parameters should be camelCase (e.g. fileResource), not snake_case (file_resource)
+        text.Should().Contain("fileResource: string");
+        text.Should().NotContain("file_resource: string");
+        text.Should().Contain("editsJson: string");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_UsesCamelCaseMethodNames()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        // Method names from snake_case aliases become camelCase (e.g. apply_edits -> applyEdits)
+        text.Should().Contain("cel.document.applyEdits(");
+        text.Should().Contain("cel.explorer.getContext()");
+        text.Should().NotContain("cel.document.apply_edits(");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_ContainsPromiseReturnTypes()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().Contain(": Promise<");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_DocumentsRequiresTools()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().Contain("requires_tools");
+        text.Should().Contain("CEL_TOOL_DENIED");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_DocumentsCelToolError()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().Contain("CelToolError");
+    }
+
+    [Test]
+    public void GetJavaScriptApi_CompactFormat_NoMarkdownHeadingsPerMethod()
+    {
+        var tools = new QueryTools(_services);
+        var text = GetResultText(tools.GetJavaScriptApi());
+
+        text.Should().NotContain("### cel.app.");
+        text.Should().Contain("  cel.app.getStatus(");
     }
 
     private static string GetResultText(CallToolResult result)

--- a/Source/Workspace/Celbridge.Documents/Commands/ApplyEditsCommand.cs
+++ b/Source/Workspace/Celbridge.Documents/Commands/ApplyEditsCommand.cs
@@ -134,7 +134,13 @@ public class ApplyEditsCommand : CommandBase, IApplyEditsCommand
                 var saveResult = await view.SaveDocument();
                 if (saveResult.IsFailure)
                 {
+                    // Propagate save failures so callers see "Contribution editor failed to
+                    // respond within N seconds" (or similar) instead of silent success. The
+                    // in-memory edit has been applied but the disk write failed, so the
+                    // caller's assumption that a follow-up file_read sees the new content
+                    // would be wrong without this signal.
                     _logger.LogWarning(saveResult, $"Failed to force-save document after applying edits: {resource}");
+                    failedResources.Add(resource);
                 }
             }
         }

--- a/Source/Workspace/Celbridge.Documents/Commands/FindReplaceDocumentCommand.cs
+++ b/Source/Workspace/Celbridge.Documents/Commands/FindReplaceDocumentCommand.cs
@@ -118,6 +118,18 @@ public class FindReplaceDocumentCommand : CommandBase, IFindReplaceDocumentComma
                 .WithErrors(applyResult);
         }
 
+        // Flush the edits to disk so MCP callers' follow-up file_read sees the post-edit
+        // state. Do NOT gate on HasUnsavedChanges: ApplyEditsAsync is a fire-and-forget
+        // notification, and the document/changed round-trip that flips the flag often
+        // hasn't arrived by the time this line runs. Same pattern as ApplyEditsCommand's
+        // ForceSave branch.
+        var saveAfterEditsResult = await documentView.SaveDocument();
+        if (saveAfterEditsResult.IsFailure)
+        {
+            return Result.Fail($"Failed to save document after find/replace: '{FileResource}'")
+                .WithErrors(saveAfterEditsResult);
+        }
+
         ResultValue = edits.Count;
         return Result.Ok();
     }


### PR DESCRIPTION
This pull request introduces several improvements to the Celbridge tool API infrastructure, focusing on better tool name resolution, enhanced error handling, and comprehensive documentation for both JavaScript and Python APIs. The most significant changes include the addition of a new tool for generating a JavaScript API reference, clarification of tool naming conventions, improved error messages, and updates to documentation and comments for better developer guidance.

**API infrastructure and tool name resolution:**

* Added a mapping in `McpToolBridge` to resolve tool names from JavaScript aliases (dot notation) to MCP tool names (underscore notation), ensuring tool calls work regardless of the naming convention used by the caller. This affects both `ToolsCall` and `CallToolAsync` methods, which now resolve names before making requests. [[1]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eR31) [[2]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eR44-R64) [[3]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eR171-R175) [[4]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eR311-R315)
* Improved error messages when the MCP HTTP server is not running, providing clearer diagnostics to users. [[1]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eL167-R190) [[2]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eL303-R327)
* Enhanced error handling in session establishment to surface JSON-RPC error messages and codes from the MCP server more clearly.

**API documentation and developer guidance:**

* Added a new `query_get_javascript_api` tool that generates a comprehensive JavaScript API reference for the `cel` proxy, listing all available namespaces, methods, and parameter signatures in a TypeScript-like format. This includes a new file `JavaScriptApiHeader.md` for the reference header. [[1]](diffhunk://#diff-2d52a3e2e450cb5dfa0d7de8876286f19e62367ff819853b83fa9dfa016fa550R1-R168) [[2]](diffhunk://#diff-e394d705bc0fd6a0e78425f749b7d47533776e665fa6999b5c4698da31fcd84cR1-R69)
* Updated and clarified documentation for writing JavaScript package extensions, emphasizing the correct use of tool aliases in manifests and call sites, and explaining failure modes and naming conventions.
* Added a Python API reference header and improved documentation for Python tool usage, including parameter conventions and structured data handling.
* Improved the XML doc comment for the file search tool to clarify glob pattern matching behavior and provide better examples.

**Codebase organization and refactoring:**

* Refactored internal API reflection utilities to be reusable across both JavaScript and Python API reference generation, and cleaned up related code. [[1]](diffhunk://#diff-1d378a4e1a326833c91f9fe381bb76c7a1b4af4788fd464013743a47f4ed50ebL3-L7) [[2]](diffhunk://#diff-1d378a4e1a326833c91f9fe381bb76c7a1b4af4788fd464013743a47f4ed50ebL30-R29)