### PR TITLE
Fresh MCP server instance per workspace session

### DIFF
--- a/Source/Celbridge/App.xaml.cs
+++ b/Source/Celbridge/App.xaml.cs
@@ -298,7 +298,6 @@ public partial class App : Application
 
     private void InitializeCoreServices()
     {
-        Server.ServiceConfiguration.Initialize();
         UserInterface.ServiceConfiguration.Initialize();
         WebView.ServiceConfiguration.Initialize();
         Workspace.ServiceConfiguration.Initialize();

--- a/Source/Celbridge/Package.appxmanifest
+++ b/Source/Celbridge/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity  Name="org.celbridge.Celbridge" Version="0.2.6.0" Publisher="CN=AnTulcha"/>
+  <Identity  Name="org.celbridge.Celbridge" Version="0.2.7.0" Publisher="CN=AnTulcha"/>
   <Properties >
     <DisplayName>Celbridge</DisplayName>
     <PublisherDisplayName>celbridge.org</PublisherDisplayName>

--- a/Source/Celbridge/appsettings.json
+++ b/Source/Celbridge/appsettings.json
@@ -10,7 +10,7 @@
   "FeatureFlags": {
     "console-panel": true,
     "webview-dev-tools": true,
-    "note-editor": false,
+    "note-editor":false,
     "mcp-tools": false
   }
 }

--- a/Source/Core/Celbridge.Foundation/Server/IServerService.cs
+++ b/Source/Core/Celbridge.Foundation/Server/IServerService.cs
@@ -12,26 +12,35 @@ public enum ServerStatus
 }
 
 /// <summary>
-/// Coordinates the server infrastructure. Starts the HTTP server during
-/// application initialization and manages the lifecycle of the agent server,
-/// file server, and other server components in response to workspace events.
+/// Coordinates the server infrastructure. Starts a fresh HTTP server when a
+/// workspace is loaded and stops it when the workspace is unloaded. The same
+/// port is reused for the lifetime of the application so URLs remain stable
+/// across project switches.
 /// </summary>
 public interface IServerService
 {
     /// <summary>
     /// The current state of the server infrastructure.
-    /// Project loading should not proceed until this is Ready.
     /// </summary>
     ServerStatus Status { get; }
 
     /// <summary>
     /// The port the HTTP server is listening on, or 0 if not started.
+    /// Once assigned, the port is reused on subsequent starts within the
+    /// same application session.
     /// </summary>
     int Port { get; }
 
     /// <summary>
-    /// Starts the HTTP server and registers all endpoints.
+    /// Builds and starts a fresh HTTP server instance for the loaded workspace.
+    /// Reuses the port assigned on the first call within this application session.
     /// Sets Status to Ready on completion.
     /// </summary>
-    Task InitializeAsync();
+    Task StartAsync();
+
+    /// <summary>
+    /// Stops and disposes the HTTP server instance. The assigned port is retained
+    /// so the next StartAsync call binds to the same port.
+    /// </summary>
+    Task StopAsync();
 }

--- a/Source/Core/Celbridge.Foundation/Server/ServerMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Server/ServerMessages.cs
@@ -6,3 +6,10 @@ namespace Celbridge.Server;
 /// re-resolve and re-navigate their URLs when this message is received.
 /// </summary>
 public record ProjectFileServerReadyMessage();
+
+/// <summary>
+/// Sent when the server has been stopped, typically because the workspace
+/// is being unloaded. Clients holding cached server state (e.g. an MCP
+/// session id) should clear it so they reconnect against the next instance.
+/// </summary>
+public record ServerStoppedMessage();

--- a/Source/Core/Celbridge.Projects/Commands/LoadProjectCommand.cs
+++ b/Source/Core/Celbridge.Projects/Commands/LoadProjectCommand.cs
@@ -1,5 +1,4 @@
 using Celbridge.Commands;
-using Celbridge.Server;
 
 namespace Celbridge.Projects.Commands;
 
@@ -8,29 +7,21 @@ public class LoadProjectCommand : CommandBase, ILoadProjectCommand
     private readonly IProjectService _projectService;
     private readonly ICommandService _commandService;
     private readonly IProjectLoader _projectLoader;
-    private readonly IServerService _serverService;
 
     public LoadProjectCommand(
         ICommandService commandService,
         IProjectService projectService,
-        IProjectLoader projectLoader,
-        IServerService serverService)
+        IProjectLoader projectLoader)
     {
         _commandService = commandService;
         _projectService = projectService;
         _projectLoader = projectLoader;
-        _serverService = serverService;
     }
 
     public string ProjectFilePath { get; set; } = string.Empty;
 
     public override async Task<Result> ExecuteAsync()
     {
-        if (_serverService.Status != ServerStatus.Ready)
-        {
-            return Result.Fail("Failed to load project because the server is not yet initialized.");
-        }
-
         if (string.IsNullOrEmpty(ProjectFilePath))
         {
             return Result.Fail("Failed to load project because path is empty.");

--- a/Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs
@@ -1,5 +1,6 @@
 using Celbridge.Logging;
 using Celbridge.Navigation;
+using Celbridge.Server;
 using Celbridge.Workspace;
 
 namespace Celbridge.Projects.Services;
@@ -16,17 +17,20 @@ public class ProjectUnloader
     private readonly IProjectService _projectService;
     private readonly INavigationService _navigationService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
+    private readonly IServerService _serverService;
 
     public ProjectUnloader(
         ILogger<ProjectUnloader> logger,
         IProjectService projectService,
         INavigationService navigationService,
-        IWorkspaceWrapper workspaceWrapper)
+        IWorkspaceWrapper workspaceWrapper,
+        IServerService serverService)
     {
         _logger = logger;
         _projectService = projectService;
         _navigationService = navigationService;
         _workspaceWrapper = workspaceWrapper;
+        _serverService = serverService;
     }
 
     /// <summary>
@@ -57,6 +61,10 @@ public class ProjectUnloader
         // Clear the reference and dispose the project
         _projectService.ClearCurrentProject();
         (currentProject as IDisposable)?.Dispose();
+
+        // Stop the server. The assigned port is retained inside ServerService
+        // so the next StartAsync call binds to the same port.
+        await _serverService.StopAsync();
 
         _logger.LogInformation("Project '{ProjectName}' unloaded successfully", projectName);
         return Result.Ok();

--- a/Source/Core/Celbridge.Server/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.Server/ServiceConfiguration.cs
@@ -9,14 +9,8 @@ public static class ServiceConfiguration
     {
         services.AddSingleton<IFileServer, FileServer>();
         services.AddSingleton<IMcpToolBridge, McpToolBridge>();
-        services.AddSingleton<IAgentServer, Services.AgentServer>();
+        services.AddSingleton<IAgentServer, AgentServer>();
         services.AddSingleton<IServerService, ServerService>();
         services.AddTransient<ITcpTransport, TcpTransport>();
-    }
-
-    public static void Initialize()
-    {
-        var serverService = ServiceLocator.AcquireService<IServerService>();
-        _ = serverService.InitializeAsync();
     }
 }

--- a/Source/Core/Celbridge.Server/Services/McpToolBridge.cs
+++ b/Source/Core/Celbridge.Server/Services/McpToolBridge.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Celbridge.Messaging;
 using Celbridge.Tools;
 using ModelContextProtocol.Server;
 using Newtonsoft.Json.Linq;
@@ -35,6 +36,7 @@ public class McpToolBridge : IMcpToolBridge
 
     public McpToolBridge(
         IServerService serverService,
+        IMessengerService messengerService,
         ILogger<McpToolBridge> logger)
     {
         _serverService = serverService;
@@ -49,6 +51,12 @@ public class McpToolBridge : IMcpToolBridge
                 _aliasToToolName[entry.Value.Alias] = entry.Key;
             }
         }
+
+        // The MCP session is bound to the lifetime of a specific server instance.
+        // When the server is restarted for a new workspace, the cached session id
+        // is invalid against the fresh instance, so clear it and re-handshake on
+        // the next request.
+        messengerService.Register<ServerStoppedMessage>(this, (_, _) => _sessionId = null);
     }
 
     // The JS client addresses tools by alias (e.g. "document.open") while Python and the MCP
@@ -447,8 +455,8 @@ public class McpToolBridge : IMcpToolBridge
             return JsonNode.Parse(jsonObject.ToJsonString())?.AsObject();
         }
 
-        // Fall back to System.Text.Json serialization for plain CLR objects.
-        var serialized = System.Text.Json.JsonSerializer.Serialize(arguments);
+        // Fall back to Json serialization for plain CLR objects.
+        var serialized = JsonSerializer.Serialize(arguments);
         return JsonNode.Parse(serialized)?.AsObject();
     }
 

--- a/Source/Core/Celbridge.Server/Services/ServerService.cs
+++ b/Source/Core/Celbridge.Server/Services/ServerService.cs
@@ -1,7 +1,6 @@
 using Celbridge.Messaging;
 using Celbridge.Projects;
 using Celbridge.Settings;
-using Celbridge.Workspace;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,9 +8,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Celbridge.Server.Services;
 
 /// <summary>
-/// Coordinates the server infrastructure. Creates and starts the shared
-/// Kestrel instance, delegates endpoint configuration to AgentServer and
-/// FileServer, and manages their lifecycle in response to workspace events.
+/// Coordinates the server infrastructure. Builds a fresh Kestrel instance for
+/// each loaded workspace, delegates endpoint configuration to AgentServer and
+/// FileServer, and disposes the instance when the workspace unloads. The
+/// dynamically assigned port is captured on first start and reused on
+/// subsequent starts so URLs remain stable across the application session.
 /// </summary>
 public class ServerService : IServerService, IDisposable
 {
@@ -24,6 +25,7 @@ public class ServerService : IServerService, IDisposable
     private readonly ILogger<ServerService> _logger;
 
     private WebApplication? _webApplication;
+    private int _persistentPort;
     private bool _disposed;
 
     public ServerStatus Status { get; private set; }
@@ -46,17 +48,28 @@ public class ServerService : IServerService, IDisposable
         _applicationServices = applicationServices;
         _featureFlags = featureFlags;
         _logger = logger;
-
-        messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoaded);
-        messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
     }
 
-    public async Task InitializeAsync()
+    public async Task StartAsync()
     {
         if (!_featureFlags.IsEnabled(FeatureFlagConstants.McpTools))
         {
             Status = ServerStatus.Ready;
             _logger.LogInformation("MCP tools disabled by feature flag. Server will not start.");
+            return;
+        }
+
+        if (_webApplication is not null)
+        {
+            _logger.LogWarning("Server is already running. StartAsync call ignored.");
+            return;
+        }
+
+        var currentProject = _projectService.CurrentProject;
+        if (currentProject is null)
+        {
+            Status = ServerStatus.Error;
+            _logger.LogError("Cannot start server because no project is loaded.");
             return;
         }
 
@@ -66,8 +79,12 @@ public class ServerService : IServerService, IDisposable
         {
             var builder = WebApplication.CreateSlimBuilder();
 
-            // Use port 0 so Kestrel picks an available port
-            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            // Bind to the previously assigned port if we have one. Port 0 lets
+            // Kestrel pick any free port on the first start of the session.
+            var bindUrl = _persistentPort == 0
+                ? "http://127.0.0.1:0"
+                : $"http://127.0.0.1:{_persistentPort}";
+            builder.WebHost.UseUrls(bindUrl);
 
             // Make the main application's services available to MCP tool classes.
             // Tools take IApplicationServiceProvider and resolve what they need.
@@ -88,49 +105,76 @@ public class ServerService : IServerService, IDisposable
 
             await _webApplication.StartAsync();
 
-            // Read the actual port Kestrel assigned
+            // Read the actual port Kestrel assigned and remember it for the
+            // remainder of the application session.
             var addresses = _webApplication.Urls;
             foreach (var address in addresses)
             {
                 if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
                 {
                     Port = uri.Port;
+                    _persistentPort = uri.Port;
                     break;
                 }
             }
 
+            _fileServer.Enable(currentProject.ProjectFolderPath, Port);
+
             Status = ServerStatus.Ready;
-            _logger.LogInformation("Server initialized on port {Port}", Port);
+            _logger.LogInformation("Server started on port {Port}", Port);
+
+            _messengerService.Send(new ProjectFileServerReadyMessage());
         }
         catch (Exception exception)
         {
             Status = ServerStatus.Error;
-            _logger.LogError(exception, "Failed to initialize server");
+            _logger.LogError(exception, "Failed to start server");
+
+            // Ensure a partially constructed instance is torn down so the next
+            // start attempt begins from a clean state.
+            await TryDisposeWebApplicationAsync();
         }
     }
 
-    private void OnWorkspaceLoaded(object recipient, WorkspaceLoadedMessage message)
+    public async Task StopAsync()
     {
-        var currentProject = _projectService.CurrentProject;
-        if (currentProject is null)
+        if (_webApplication is null)
         {
-            return;
-        }
-
-        _fileServer.Enable(currentProject.ProjectFolderPath, Port);
-
-        _messengerService.Send(new ProjectFileServerReadyMessage());
-    }
-
-    private void OnWorkspaceUnloaded(object recipient, WorkspaceUnloadedMessage message)
-    {
-        var currentProject = _projectService.CurrentProject;
-        if (currentProject is null)
-        {
+            Status = ServerStatus.NotStarted;
+            Port = 0;
             return;
         }
 
         _fileServer.Disable();
+
+        await TryDisposeWebApplicationAsync();
+
+        Port = 0;
+        Status = ServerStatus.NotStarted;
+        _logger.LogInformation("Server stopped. Port {Port} retained for the next start.", _persistentPort);
+
+        _messengerService.Send(new ServerStoppedMessage());
+    }
+
+    private async Task TryDisposeWebApplicationAsync()
+    {
+        if (_webApplication is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _webApplication.DisposeAsync();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to dispose web application cleanly");
+        }
+        finally
+        {
+            _webApplication = null;
+        }
     }
 
     public void Dispose()

--- a/Source/Tests/Server/TcpTransportTests.cs
+++ b/Source/Tests/Server/TcpTransportTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using Celbridge.Messaging;
 using Celbridge.Server;
 using Celbridge.Server.Services;
 using StreamJsonRpc;
@@ -23,9 +24,11 @@ public class TcpTransportTests
         var mockServerService = Substitute.For<IServerService>();
         mockServerService.Port.Returns(0);
 
+        var mockMessengerService = Substitute.For<IMessengerService>();
+
         var bridgeLogger = Substitute.For<ILogger<McpToolBridge>>();
         var transportLogger = Substitute.For<ILogger<TcpTransport>>();
-        _mcpToolBridge = new McpToolBridge(mockServerService, bridgeLogger);
+        _mcpToolBridge = new McpToolBridge(mockServerService, mockMessengerService, bridgeLogger);
         _transport = new TcpTransport(transportLogger, _mcpToolBridge);
 
         // Find a free port and start listening

--- a/Source/Workspace/Celbridge.Resources/Services/ResourceMonitor.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ResourceMonitor.cs
@@ -137,6 +137,13 @@ public class ResourceMonitor : IResourceMonitor, IDisposable
         // Send granular notification for listeners (e.g., document editors)
         OnResourceCreated(e.FullPath);
 
+        // Also notify as changed because some save patterns (atomic temp-write
+        // followed by replace of an existing destination, used by the in-app
+        // file writer and many external editors) surface as a Created event on
+        // the destination rather than a Changed or Renamed event. Listeners
+        // that watch for content changes need to react in that case too.
+        OnResourceChanged(e.FullPath);
+
         ScheduleResourceUpdate();
     }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Celbridge.Console;
 using Celbridge.Logging;
 using Celbridge.Projects;
+using Celbridge.Server;
 using Celbridge.Settings;
 using Celbridge.UserInterface;
 
@@ -14,19 +15,22 @@ public class WorkspaceLoader
     private readonly IUserInterfaceService _userInterfaceService;
     private readonly IFeatureFlags _featureFlags;
     private readonly IProjectService _projectService;
+    private readonly IServerService _serverService;
 
     public WorkspaceLoader(
         ILogger<WorkspaceLoader> logger,
         IWorkspaceWrapper workspaceWrapper,
         IUserInterfaceService userInterfaceService,
         IFeatureFlags featureFlags,
-        IProjectService projectService)
+        IProjectService projectService,
+        IServerService serverService)
     {
         _logger = logger;
         _workspaceWrapper = workspaceWrapper;
         _userInterfaceService = userInterfaceService;
         _featureFlags = featureFlags;
         _projectService = projectService;
+        _serverService = serverService;
     }
 
     public async Task<Result> LoadWorkspaceAsync()
@@ -45,6 +49,17 @@ public class WorkspaceLoader
         {
             var projectFeatures = currentProject.Config.Features;
             _featureFlags.ApplyProjectOverrides(projectFeatures);
+        }
+
+        //
+        // Start a fresh server instance for this workspace.
+        // The same port is reused for the lifetime of the application so URLs
+        // resolved by the file server remain stable across project switches.
+        //
+        await _serverService.StartAsync();
+        if (_serverService.Status == ServerStatus.Error)
+        {
+            return Result.Fail("Failed to start the server for the workspace");
         }
 
         //


### PR DESCRIPTION
This pull request refactors the server lifecycle to improve reliability when switching workspaces and ensures the HTTP server is correctly started and stopped per workspace. The server now retains its assigned port for the entire application session, so URLs remain stable across project switches. Key changes include replacing the old initialization logic with explicit `StartAsync` and `StopAsync` methods, updating dependency injection, and improving how server state is communicated to dependent components.

**Server lifecycle and interface changes:**

* The `IServerService` interface now uses `StartAsync` and `StopAsync` methods instead of `InitializeAsync`, clarifies documentation, and guarantees the same port is reused for the session (`Source/Core/Celbridge.Foundation/Server/IServerService.cs`).
* The `ServerService` implementation is updated to start a fresh server on workspace load and dispose it on unload, retaining the assigned port. It now explicitly manages server state, port assignment, and error handling, and notifies clients when the server starts or stops (`Source/Core/Celbridge.Server/Services/ServerService.cs`) [[1]](diffhunk://#diff-ddab3ef734b0a6652d27103d8455b2afbf57f1fa78cb5556b751e4ac9a8a8a8aL4-R15) [[2]](diffhunk://#diff-ddab3ef734b0a6652d27103d8455b2afbf57f1fa78cb5556b751e4ac9a8a8a8aR28) [[3]](diffhunk://#diff-ddab3ef734b0a6652d27103d8455b2afbf57f1fa78cb5556b751e4ac9a8a8a8aL49-R53) [[4]](diffhunk://#diff-ddab3ef734b0a6652d27103d8455b2afbf57f1fa78cb5556b751e4ac9a8a8a8aR62-R87) [[5]](diffhunk://#diff-ddab3ef734b0a6652d27103d8455b2afbf57f1fa78cb5556b751e4ac9a8a8a8aL91-R177).

**Dependency injection and service configuration:**

* The dependency injection setup is updated to remove unnecessary initialization calls and ensure correct registration of server components (`Source/Core/Celbridge.Server/ServiceConfiguration.cs`, `Source/Celbridge/App.xaml.cs`) [[1]](diffhunk://#diff-721ae52b15abfe1966965b5305c13a71ac8d8ac2e6605a024d34b17e1ab46f94L12-L21) [[2]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dL301).
* Constructors for classes that manage workspace and project loading/unloading are updated to receive the new `IServerService` dependency as needed (`Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs`, `Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs`) [[1]](diffhunk://#diff-eb68887e54376b0a4a4585dd2d4e0a1d8c2a67fe3173c673dfdc7a4f6f4c17f5R20-R33) [[2]](diffhunk://#diff-8e1920f8ee6397d7ee126ed09a9e4a2f4aaaeea31eece5e095e6613dae14abd6R18-R33).

**Messaging and notifications:**

* A new `ServerStoppedMessage` is introduced, and components like `McpToolBridge` listen for it to clear cached state when the server restarts, ensuring clients reconnect to the correct instance (`Source/Core/Celbridge.Foundation/Server/ServerMessages.cs`, `Source/Core/Celbridge.Server/Services/McpToolBridge.cs`) [[1]](diffhunk://#diff-760e6838f57166c3511a9cd8370ba0a7a89a66bc3d030c73a888d5fec613c3d5R9-R15) [[2]](diffhunk://#diff-9d642639c43b411a98b39ce1f33cf8ada93603f3016ed148df038fc9cf91db4eR54-R59).

**Project loading/unloading logic:**

* The project loader no longer checks server readiness before loading, and the project unloader now explicitly stops the server when a project is unloaded (`Source/Core/Celbridge.Projects/Commands/LoadProjectCommand.cs`, `Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs`) [[1]](diffhunk://#diff-b0f66cbd6eca1491393a4740e634241fbcc81a38cbf14bb5bcaf5f0cf173bf47L11-L33) [[2]](diffhunk://#diff-eb68887e54376b0a4a4585dd2d4e0a1d8c2a67fe3173c673dfdc7a4f6f4c17f5R65-R68).

**Other improvements:**

* Resource monitoring is improved to handle file creation events that may indicate content changes, ensuring listeners respond appropriately (`Source/Workspace/Celbridge.Resources/Services/ResourceMonitor.cs`).
* The application version is bumped to `0.2.7.0` (`Source/Celbridge/Package.appxmanifest`).

These changes collectively make the server lifecycle more robust and predictable, especially during workspace/project switches, and improve testability and maintainability.