### PR TITLE
Organize tests into feature namespaces

### DIFF
--- a/Source/Tests/Archive/PackageArchiveTests.cs
+++ b/Source/Tests/Archive/PackageArchiveTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Compression;
 using Celbridge.Resources.Services;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Archive;
 
 [TestFixture]
 public class PackageArchiveTests

--- a/Source/Tests/Commands/CommandTests.cs
+++ b/Source/Tests/Commands/CommandTests.cs
@@ -7,7 +7,7 @@ using Celbridge.UserInterface.Services;
 using Celbridge.Workspace;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Commands;
 
 public class TestCommand : CommandBase
 {

--- a/Source/Tests/Host/CelbridgeHostTests.cs
+++ b/Source/Tests/Host/CelbridgeHostTests.cs
@@ -1,6 +1,6 @@
 using Celbridge.Host;
 
-namespace Celbridge.Tests.Helpers;
+namespace Celbridge.Tests.Host;
 
 /// <summary>
 /// Tests for CelbridgeHost facade behavior.

--- a/Source/Tests/Host/ContributionToolsHandlerTests.cs
+++ b/Source/Tests/Host/ContributionToolsHandlerTests.cs
@@ -3,7 +3,7 @@ using Celbridge.Host;
 using Celbridge.Server;
 using StreamJsonRpc;
 
-namespace Celbridge.Tests.Helpers;
+namespace Celbridge.Tests.Host;
 
 [TestFixture]
 public class ContributionToolsHandlerTests

--- a/Source/Tests/Host/MockHostChannel.cs
+++ b/Source/Tests/Host/MockHostChannel.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Celbridge.Host;
 
-namespace Celbridge.Tests.Helpers;
+namespace Celbridge.Tests.Host;
 
 /// <summary>
 /// Mock implementation of IHostChannel for testing.

--- a/Source/Tests/Host/ToolAllowlistTests.cs
+++ b/Source/Tests/Host/ToolAllowlistTests.cs
@@ -1,6 +1,6 @@
 using Celbridge.Host;
 
-namespace Celbridge.Tests.Helpers;
+namespace Celbridge.Tests.Host;
 
 [TestFixture]
 public class ToolAllowlistTests

--- a/Source/Tests/Messaging/MessagingTests.cs
+++ b/Source/Tests/Messaging/MessagingTests.cs
@@ -2,7 +2,7 @@ using Celbridge.Messaging;
 using Celbridge.Messaging.Services;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Messaging;
 
 [TestFixture]
 public class MessagingTests

--- a/Source/Tests/Resources/DeleteLinesHelperTests.cs
+++ b/Source/Tests/Resources/DeleteLinesHelperTests.cs
@@ -1,7 +1,7 @@
 using Celbridge.Resources;
 using Celbridge.Resources.Commands;
 
-namespace Celbridge.Tests.Tools;
+namespace Celbridge.Tests.Resources;
 
 /// <summary>
 /// Tests for DeleteLinesHelper — the pure logic helpers for the

--- a/Source/Tests/Resources/PathValidatorTests.cs
+++ b/Source/Tests/Resources/PathValidatorTests.cs
@@ -1,6 +1,6 @@
 using Celbridge.Resources.Services;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Resources;
 
 [TestFixture]
 public class PathValidatorTests

--- a/Source/Tests/Resources/ResourceKeyTests.cs
+++ b/Source/Tests/Resources/ResourceKeyTests.cs
@@ -1,4 +1,4 @@
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Resources;
 
 [TestFixture]
 public class ResourceKeyTests

--- a/Source/Tests/Resources/ResourceRegistryTests.cs
+++ b/Source/Tests/Resources/ResourceRegistryTests.cs
@@ -5,7 +5,7 @@ using Celbridge.Resources.Services;
 using Celbridge.UserInterface.Services;
 using Celbridge.Workspace;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Resources;
 
 [TestFixture]
 public class ResourceRegistryTests

--- a/Source/Tests/Resources/TextEditTests.cs
+++ b/Source/Tests/Resources/TextEditTests.cs
@@ -1,6 +1,6 @@
 using Celbridge.Resources;
 
-namespace Celbridge.Tests.Documents;
+namespace Celbridge.Tests.Resources;
 
 [TestFixture]
 public class TextEditTests

--- a/Source/Tests/Server/McpToolBridgeReadSchemaTypeTests.cs
+++ b/Source/Tests/Server/McpToolBridgeReadSchemaTypeTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Nodes;
 using Celbridge.Server.Services;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Server;
 
 /// <summary>
 /// Tests for McpToolBridge.ReadSchemaType. The MCP SDK emits a JSON Schema

--- a/Source/Tests/Server/TcpTransportTests.cs
+++ b/Source/Tests/Server/TcpTransportTests.cs
@@ -5,7 +5,7 @@ using Celbridge.Server;
 using Celbridge.Server.Services;
 using StreamJsonRpc;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Server;
 
 [TestFixture]
 public class TcpTransportTests

--- a/Source/Tests/Settings/EditorSettingsTests.cs
+++ b/Source/Tests/Settings/EditorSettingsTests.cs
@@ -3,7 +3,7 @@ using Celbridge.Settings.Services;
 using Celbridge.Workspace;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Settings;
 
 [TestFixture]
 public class EditorSettingsTests

--- a/Source/Tests/Settings/WorkspaceSettingsTests.cs
+++ b/Source/Tests/Settings/WorkspaceSettingsTests.cs
@@ -2,7 +2,7 @@ using Celbridge.Projects;
 using Celbridge.Workspace;
 using Celbridge.WorkspaceUI.Services;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.Settings;
 
 [TestFixture]
 public class WorkspaceSettingsTests

--- a/Source/Tests/Spreadsheet/SpreadsheetCommandTests.cs
+++ b/Source/Tests/Spreadsheet/SpreadsheetCommandTests.cs
@@ -5,7 +5,7 @@ using Celbridge.Spreadsheet.Services;
 using Celbridge.Workspace;
 using ClosedXML.Excel;
 
-namespace Celbridge.Tests.Tools;
+namespace Celbridge.Tests.Spreadsheet;
 
 /// <summary>
 /// Tests for the ISpreadsheet*Command implementations against fixture .xlsx

--- a/Source/Tests/Spreadsheet/SpreadsheetReaderTests.cs
+++ b/Source/Tests/Spreadsheet/SpreadsheetReaderTests.cs
@@ -2,7 +2,7 @@ using Celbridge.Spreadsheet;
 using Celbridge.Spreadsheet.Services;
 using ClosedXML.Excel;
 
-namespace Celbridge.Tests.Tools;
+namespace Celbridge.Tests.Spreadsheet;
 
 /// <summary>
 /// Tests for SpreadsheetReader against fixture .xlsx workbooks generated in

--- a/Source/Tests/UserInterface/LayoutManagerTests.cs
+++ b/Source/Tests/UserInterface/LayoutManagerTests.cs
@@ -6,7 +6,7 @@ using Celbridge.UserInterface.Services;
 using Celbridge.Workspace;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Celbridge.Tests;
+namespace Celbridge.Tests.UserInterface;
 
 [TestFixture]
 public class LayoutManagerTests

--- a/Source/Tests/UserInterface/PathDisambiguationHelperTests.cs
+++ b/Source/Tests/UserInterface/PathDisambiguationHelperTests.cs
@@ -1,6 +1,6 @@
 using Celbridge.UserInterface.Helpers;
 
-namespace Celbridge.Tests.Helpers;
+namespace Celbridge.Tests.UserInterface;
 
 [TestFixture]
 public class PathDisambiguationHelperTests

--- a/Source/Tests/WebHost/DocumentWebViewToolBridgeTests.cs
+++ b/Source/Tests/WebHost/DocumentWebViewToolBridgeTests.cs
@@ -3,7 +3,7 @@ using Celbridge.Commands;
 using Celbridge.WebHost;
 using Celbridge.WebHost.Services;
 
-namespace Celbridge.Tests.WebView;
+namespace Celbridge.Tests.WebHost;
 
 [TestFixture]
 public partial class DocumentWebViewToolBridgeTests

--- a/Source/Tests/WebHost/WebViewServiceSupportTests.cs
+++ b/Source/Tests/WebHost/WebViewServiceSupportTests.cs
@@ -3,7 +3,7 @@ using Celbridge.Settings;
 using Celbridge.WebHost.Services;
 using Celbridge.Workspace;
 
-namespace Celbridge.Tests.WebView;
+namespace Celbridge.Tests.WebHost;
 
 [TestFixture]
 public class WebViewServiceSupportTests

--- a/Source/Tests/WebHost/WebViewServiceUrlTests.cs
+++ b/Source/Tests/WebHost/WebViewServiceUrlTests.cs
@@ -2,7 +2,7 @@ using Celbridge.Settings;
 using Celbridge.WebHost.Services;
 using Celbridge.Workspace;
 
-namespace Celbridge.Tests.WebView;
+namespace Celbridge.Tests.WebHost;
 
 [TestFixture]
 public class WebViewServiceUrlTests

--- a/Source/Tests/WebView/HtmlViewerEditorFactoryTests.cs
+++ b/Source/Tests/WebView/HtmlViewerEditorFactoryTests.cs
@@ -1,7 +1,7 @@
 using Celbridge.WebView.Services;
 using Microsoft.Extensions.Localization;
 
-namespace Celbridge.Tests.Documents;
+namespace Celbridge.Tests.WebView;
 
 [TestFixture]
 public class HtmlViewerEditorFactoryTests

--- a/Source/Tests/WebView/WebViewDocumentViewModelTests.cs
+++ b/Source/Tests/WebView/WebViewDocumentViewModelTests.cs
@@ -6,7 +6,7 @@ using Celbridge.WebView.Services;
 using Celbridge.WebView.ViewModels;
 using Celbridge.Workspace;
 
-namespace Celbridge.Tests.Documents;
+namespace Celbridge.Tests.WebView;
 
 [TestFixture]
 public class WebViewDocumentViewModelTests

--- a/Source/Tests/WebView/WebViewEditorFactoryTests.cs
+++ b/Source/Tests/WebView/WebViewEditorFactoryTests.cs
@@ -1,7 +1,7 @@
 using Celbridge.WebView.Services;
 using Microsoft.Extensions.Localization;
 
-namespace Celbridge.Tests.Documents;
+namespace Celbridge.Tests.WebView;
 
 [TestFixture]
 public class WebViewEditorFactoryTests

--- a/Source/Tests/WebView/WebViewNavigationPolicyTests.cs
+++ b/Source/Tests/WebView/WebViewNavigationPolicyTests.cs
@@ -2,7 +2,7 @@ using Celbridge.Commands;
 using Celbridge.Explorer;
 using Celbridge.WebView.Services;
 
-namespace Celbridge.Tests.Documents;
+namespace Celbridge.Tests.WebView;
 
 [TestFixture]
 public class WebViewNavigationPolicyTests


### PR DESCRIPTION
Move and rename multiple test files into feature-specific folders and update their namespaces to match the new paths. Affected areas include Archive, Commands, Host (from Helpers), Messaging, Resources (from Tools/Documents), Server, Settings, Spreadsheet (from Tools), UserInterface, WebHost (from WebView), and WebView. This reorganizes test layout for clearer project structure and does not change test logic.