### PR TITLE
Remove MarkGuideRead; use TryMarkServed

### DIFF
--- a/Source/Core/Celbridge.Foundation/Tools/IGuides.cs
+++ b/Source/Core/Celbridge.Foundation/Tools/IGuides.cs
@@ -27,13 +27,7 @@ public record class GuideEntry(
 
 /// <summary>
 /// In-memory guide library backing the guides_read MCP tool and the
-/// auto-attach response filter. Loaded once at app startup from embedded
-/// markdown resources under Celbridge.Tools.Guides.*; the loader validates
-/// filename uniqueness, the requirement that every per-tool guide match a
-/// registered MCP tool alias and every namespace guide match a registered
-/// namespace, and the [RelatedGuides] / troubleshooter wiring. After
-/// construction the library is immutable for the life of the process —
-/// every method is an O(1) dictionary lookup.
+/// auto-attach response filter.
 /// </summary>
 public interface IGuides
 {
@@ -44,10 +38,8 @@ public interface IGuides
     GuideEntry? GetByName(string name);
 
     /// <summary>
-    /// Returns the [RelatedGuides] names declared on the tool method whose MCP
-    /// alias name (with the namespace separator as an underscore, e.g.
-    /// file_grep) is supplied. Returns an empty list when the tool name is not
-    /// registered or has no related guides.
+    /// Returns the [RelatedGuides] names declared on the tool with the given
+    /// MCP alias, or an empty list when the tool is unregistered or declares none.
     /// </summary>
     IReadOnlyList<string> GetRelatedGuides(string toolAliasName);
 }

--- a/Source/Core/Celbridge.Server/Services/AgentMonitor.cs
+++ b/Source/Core/Celbridge.Server/Services/AgentMonitor.cs
@@ -67,11 +67,6 @@ internal sealed class AgentSessionState
         return _guidesServed.TryAdd(guideName, 0);
     }
 
-    public void MarkGuideRead(string guideName)
-    {
-        _guidesServed.TryAdd(guideName, 0);
-    }
-
     public bool WasGuideRead(string guideName)
     {
         return _guidesServed.ContainsKey(guideName);
@@ -141,11 +136,6 @@ public sealed class AgentMonitor
     internal bool TryMarkServed(AgentSessionState state, string guideName)
     {
         return state.TryMarkServed(guideName);
-    }
-
-    internal void MarkGuideRead(AgentSessionState state, string guideName)
-    {
-        state.MarkGuideRead(guideName);
     }
 
     public void RecordInvocation(ToolInvocationRecord record)

--- a/Source/Core/Celbridge.Server/Services/AgentResponseFilter.cs
+++ b/Source/Core/Celbridge.Server/Services/AgentResponseFilter.cs
@@ -348,7 +348,8 @@ internal sealed class AgentResponseFilter
         var requested = ParseRequestedGuideNames(namesElement);
         foreach (var guideName in requested)
         {
-            monitor.MarkGuideRead(session, guideName);
+            // Consume the slot so auto-attach won't re-prepend the body.
+            _ = monitor.TryMarkServed(session, guideName);
         }
     }
 

--- a/Source/Tests/Server/AgentMonitorTests.cs
+++ b/Source/Tests/Server/AgentMonitorTests.cs
@@ -50,23 +50,6 @@ public class AgentMonitorTests
         state.TryMarkServed("file_read").Should().BeTrue();
     }
 
-    [Test]
-    public void MarkGuideRead_RecordsNameInSessionSet()
-    {
-        var state = new AgentSessionState("session-1");
-        state.MarkGuideRead("file_grep");
-        state.WasGuideRead("file_grep").Should().BeTrue();
-    }
-
-    [Test]
-    public void MarkGuideRead_IsIdempotent()
-    {
-        var state = new AgentSessionState("session-1");
-        state.MarkGuideRead("file_grep");
-        state.MarkGuideRead("file_grep");
-        state.WasGuideRead("file_grep").Should().BeTrue();
-    }
-
     // AgentSessionState — concurrency
 
     [Test]
@@ -92,25 +75,6 @@ public class AgentMonitorTests
 
         trueCount.Should().Be(1);
         state.WasGuideRead("file").Should().BeTrue();
-    }
-
-    [Test]
-    public async Task MarkGuideRead_ConcurrentCallsAllRecorded()
-    {
-        var state = new AgentSessionState("session-1");
-
-        var tasks = new List<Task>();
-        for (int taskIndex = 0; taskIndex < 64; taskIndex++)
-        {
-            var capturedIndex = taskIndex;
-            tasks.Add(Task.Run(() => state.MarkGuideRead($"guide_{capturedIndex}")));
-        }
-        await Task.WhenAll(tasks);
-
-        for (int index = 0; index < 64; index++)
-        {
-            state.WasGuideRead($"guide_{index}").Should().BeTrue();
-        }
     }
 
     // GetOrCreateSession — session-id keyed dedup


### PR DESCRIPTION
Remove the legacy MarkGuideRead API from AgentSessionState and the AgentMonitor wrapper, and update AgentResponseFilter to call monitor.TryMarkServed(session, guideName) (discarding the return) to consume the served slot. Corresponding unit tests that asserted MarkGuideRead behavior were deleted. Also tightened a summary comment in IGuides. This consolidates session guide-marking onto the TryMarkServed method and removes dead/duplicated APIs and tests.