### PR TITLE
Remove ResourceUtils.CopyFolder and update comments

### DIFF
--- a/Source/Workspace/Celbridge.Resources/Helpers/ResourceUtils.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/ResourceUtils.cs
@@ -4,35 +4,6 @@ namespace Celbridge.Resources.Helpers;
 
 public class ResourceUtils
 {
-    public static void CopyFolder(string sourceFolder, string destFolder)
-    {
-        DirectoryInfo dir = new DirectoryInfo(sourceFolder);
-
-        if (!dir.Exists)
-        {
-            throw new DirectoryNotFoundException($"Source directory does not exist or could not be found: {sourceFolder}");
-        }
-
-        DirectoryInfo[] dirs = dir.GetDirectories();
-        if (!Directory.Exists(destFolder))
-        {
-            Directory.CreateDirectory(destFolder);
-        }
-
-        FileInfo[] files = dir.GetFiles();
-        foreach (FileInfo file in files)
-        {
-            string tempPath = Path.Combine(destFolder, file.Name);
-            file.CopyTo(tempPath);
-        }
-
-        foreach (DirectoryInfo subdir in dirs)
-        {
-            string tempPath = Path.Combine(destFolder, subdir.Name);
-            CopyFolder(subdir.FullName, tempPath);
-        }
-    }
-
     public static async Task<Result> OpenApplication(string path)
     {
         await Task.CompletedTask;

--- a/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
@@ -346,6 +346,11 @@ public static class SidecarHelper
     /// </summary>
     public static CelFileStatus Inspect(string absolutePath, ILogger logger)
     {
+        // Direct read rather than via IFileStorage: Inspect runs synchronously
+        // inside ResourceClassifier during UpdateResourceRegistry, the absolute
+        // path has already been resolved through the root handler registry, and
+        // a transient read failure is benign (the file gets classified Broken
+        // and the next registry pass reclassifies it).
         string text;
         try
         {

--- a/Source/Workspace/Celbridge.Resources/Services/FileStorage.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/FileStorage.cs
@@ -661,8 +661,8 @@ public sealed class FileStorage : IFileStorage
             || handler.Capabilities.IsWritable;
     }
 
-    // Recursive folder copy. Mirrors ResourceUtils.CopyFolder but stays internal
-    // to the FS layer so the chokepoint owns the destination structure.
+    // Recursive folder copy used by the chokepoint's CopyAsync path. Stays
+    // internal to the FS layer so the chokepoint owns the destination structure.
     private static void CopyFolderRecursive(string sourceFolder, string destFolder)
     {
         Directory.CreateDirectory(destFolder);


### PR DESCRIPTION
Remove the public ResourceUtils.CopyFolder method to avoid duplication with the FS-layer implementation. Add a clarifying comment in SidecarHelper.Inspect explaining why the file is read directly (synchronous classification path and transient read failures are benign). Reword the comment on FileStorage.CopyFolderRecursive to clarify that it's an internal recursive copy used by the chokepoint so the FS layer controls the destination structure.