### PR TITLE
Introduce IPackageReader and origin-based package IO

### DIFF
--- a/Source/Core/Celbridge.Foundation/Packages/IPackageLocalizationService.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/IPackageLocalizationService.cs
@@ -6,10 +6,11 @@ namespace Celbridge.Packages;
 public interface IPackageLocalizationService
 {
     /// <summary>
-    /// Loads localization strings from a package's localization folder.
-    /// Uses convention: {packageFolder}/localization/{locale}.json
-    /// If locale is null, uses the current UI culture.
-    /// Falls back to "en.json" if the requested locale is not found, then to an empty dictionary.
+    /// Loads localization strings for the supplied package. Uses the convention
+    /// {package.PackageFolder}/localization/{locale}.json, with package.Origin
+    /// selecting whether the underlying read crosses the IFileStorage chokepoint.
+    /// If locale is null, uses the current UI culture. Falls back to "en.json"
+    /// if the requested locale is not found, then to an empty dictionary.
     /// </summary>
-    Dictionary<string, string> LoadStrings(string packageFolder, string? locale = null);
+    Dictionary<string, string> LoadStrings(PackageInfo package, string? locale = null);
 }

--- a/Source/Core/Celbridge.Foundation/Packages/PackageInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/PackageInfo.cs
@@ -1,6 +1,28 @@
 namespace Celbridge.Packages;
 
 /// <summary>
+/// Discovery origin of a package. Determines whether file reads cross the
+/// IFileStorage chokepoint (Project) or stay on direct File.* IO (Bundled,
+/// until the bundled-from-assembly migration lands).
+/// </summary>
+public enum PackageOrigin
+{
+    /// <summary>
+    /// First-party package shipped inside a Celbridge module DLL. Read sites
+    /// stay on direct File.* IO against the install folder.
+    /// </summary>
+    Bundled,
+
+    /// <summary>
+    /// User package discovered under the project's packages/ folder. Read
+    /// sites resolve a ResourceKey via IResourceRegistry and read through
+    /// IFileStorage so the chokepoint contract holds for every project-tree
+    /// byte.
+    /// </summary>
+    Project
+}
+
+/// <summary>
 /// Package identity, permissions, and hosting information.
 /// Shared across all contributions from the same package.
 /// </summary>
@@ -41,6 +63,13 @@ public partial record PackageInfo
     /// packages.
     /// </summary>
     public bool DevToolsBlocked { get; init; }
+
+    /// <summary>
+    /// Whether the package was discovered as a bundled (in-module) or project
+    /// (project-tree) package. Drives the read path selection at every site
+    /// that loads bytes for the package.
+    /// </summary>
+    public PackageOrigin Origin { get; init; }
 
     /// <summary>
     /// The folder containing the package (set during loading, not from TOML).

--- a/Source/Tests/Packages/FileTypeProviderTests.cs
+++ b/Source/Tests/Packages/FileTypeProviderTests.cs
@@ -34,8 +34,6 @@ public class PackageServiceDocumentTypeTests
 
         var logger = Substitute.For<ILogger<PackageRegistry>>();
         var messengerService = Substitute.For<IMessengerService>();
-        var localizationLogger = Substitute.For<ILogger<PackageLocalizationService>>();
-        var localizationService = new PackageLocalizationService(localizationLogger);
 
         var resourceRegistry = Substitute.For<IResourceRegistry>();
         resourceRegistry.ProjectFolderPath.Returns(_tempProjectFolder);
@@ -43,6 +41,17 @@ public class PackageServiceDocumentTypeTests
         {
             var key = callInfo.Arg<ResourceKey>();
             return Result<string>.Ok(Path.Combine(_tempProjectFolder, key.Path.Replace('/', Path.DirectorySeparatorChar)));
+        });
+        resourceRegistry.GetResourceKey(Arg.Any<string>()).Returns(callInfo =>
+        {
+            var path = callInfo.Arg<string>();
+            if (!path.StartsWith(_tempProjectFolder, StringComparison.OrdinalIgnoreCase))
+            {
+                return Result<ResourceKey>.Fail($"Path '{path}' is not under the project root");
+            }
+            var relative = Path.GetRelativePath(_tempProjectFolder, path)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            return Result<ResourceKey>.Ok(new ResourceKey(relative));
         });
 
         var resourceService = Substitute.For<IResourceService>();
@@ -59,6 +68,9 @@ public class PackageServiceDocumentTypeTests
             Substitute.For<IMessengerService>(),
             workspaceWrapper);
         workspaceService.FileStorage.Returns(fileStorage);
+
+        var localizationLogger = Substitute.For<ILogger<PackageLocalizationService>>();
+        var localizationService = new PackageLocalizationService(localizationLogger, workspaceWrapper);
 
         var registry = new PackageRegistry(logger, _moduleService, _featureFlags, localizationService, workspaceWrapper);
         _service = new PackageService(messengerService, registry);

--- a/Source/Tests/Packages/LocalizationHelperTests.cs
+++ b/Source/Tests/Packages/LocalizationHelperTests.cs
@@ -1,4 +1,5 @@
 using Celbridge.Packages;
+using Celbridge.Workspace;
 
 namespace Celbridge.Tests.Packages;
 
@@ -7,6 +8,7 @@ public class PackageLocalizationServiceTests
 {
     private string _tempFolder = null!;
     private IPackageLocalizationService _service = null!;
+    private PackageInfo _bundledPackage = null!;
 
     [SetUp]
     public void Setup()
@@ -15,7 +17,20 @@ public class PackageLocalizationServiceTests
         Directory.CreateDirectory(_tempFolder);
 
         var logger = Substitute.For<ILogger<PackageLocalizationService>>();
-        _service = new PackageLocalizationService(logger);
+
+        // The localization service only consults the workspace wrapper for
+        // Project-origin packages; tests use Bundled-origin packages so the
+        // wrapper is never dereferenced.
+        var workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+        _service = new PackageLocalizationService(logger, workspaceWrapper);
+
+        _bundledPackage = new PackageInfo
+        {
+            Id = "test.package",
+            Name = "Test Package",
+            PackageFolder = _tempFolder,
+            Origin = PackageOrigin.Bundled
+        };
     }
 
     [TearDown]
@@ -39,7 +54,7 @@ public class PackageLocalizationServiceTests
             }
             """);
 
-        var result = _service.LoadStrings(_tempFolder, "fr");
+        var result = _service.LoadStrings(_bundledPackage, "fr");
 
         result.Should().HaveCount(2);
         result["Greeting"].Should().Be("Bonjour");
@@ -58,7 +73,7 @@ public class PackageLocalizationServiceTests
             }
             """);
 
-        var result = _service.LoadStrings(_tempFolder, "ja");
+        var result = _service.LoadStrings(_bundledPackage, "ja");
 
         result.Should().HaveCount(2);
         result["Hello"].Should().Be("Hello");
@@ -71,7 +86,7 @@ public class PackageLocalizationServiceTests
         var localizationFolder = Path.Combine(_tempFolder, PackageLocalizationService.LocalizationFolder);
         Directory.CreateDirectory(localizationFolder);
 
-        var result = _service.LoadStrings(_tempFolder, "de");
+        var result = _service.LoadStrings(_bundledPackage, "de");
 
         result.Should().BeEmpty();
     }
@@ -79,7 +94,7 @@ public class PackageLocalizationServiceTests
     [Test]
     public void LoadStrings_NoLocalizationFolder_ReturnsEmptyDictionary()
     {
-        var result = _service.LoadStrings(_tempFolder, "en");
+        var result = _service.LoadStrings(_bundledPackage, "en");
 
         result.Should().BeEmpty();
     }
@@ -91,7 +106,7 @@ public class PackageLocalizationServiceTests
         Directory.CreateDirectory(localizationFolder);
         File.WriteAllText(Path.Combine(localizationFolder, "en.json"), "{ not valid json }");
 
-        var result = _service.LoadStrings(_tempFolder, "en");
+        var result = _service.LoadStrings(_bundledPackage, "en");
 
         result.Should().BeEmpty();
     }
@@ -107,7 +122,7 @@ public class PackageLocalizationServiceTests
             }
             """);
 
-        var result = _service.LoadStrings(_tempFolder, "en");
+        var result = _service.LoadStrings(_bundledPackage, "en");
 
         result.Should().HaveCount(1);
         result["Key"].Should().Be("Value");
@@ -126,7 +141,7 @@ public class PackageLocalizationServiceTests
             }
             """);
 
-        var result = _service.LoadStrings(_tempFolder, "en");
+        var result = _service.LoadStrings(_bundledPackage, "en");
 
         result.Should().HaveCount(2);
         result["Key1"].Should().Be("Value1");

--- a/Source/Tests/Packages/PackageRegistryTests.cs
+++ b/Source/Tests/Packages/PackageRegistryTests.cs
@@ -26,8 +26,6 @@ public class PackageServiceTests
 
         var logger = Substitute.For<ILogger<PackageRegistry>>();
         _messengerService = Substitute.For<IMessengerService>();
-        var localizationLogger = Substitute.For<ILogger<PackageLocalizationService>>();
-        var localizationService = new PackageLocalizationService(localizationLogger);
         _moduleService = Substitute.For<IModuleService>();
         _moduleService.GetBundledPackages().Returns(new List<BundledPackageDescriptor>());
         var featureFlags = Substitute.For<IFeatureFlags>();
@@ -39,6 +37,17 @@ public class PackageServiceTests
         {
             var key = callInfo.Arg<ResourceKey>();
             return Result<string>.Ok(Path.Combine(_tempProjectFolder, key.Path.Replace('/', Path.DirectorySeparatorChar)));
+        });
+        _resourceRegistry.GetResourceKey(Arg.Any<string>()).Returns(callInfo =>
+        {
+            var path = callInfo.Arg<string>();
+            if (!path.StartsWith(_tempProjectFolder, StringComparison.OrdinalIgnoreCase))
+            {
+                return Result<ResourceKey>.Fail($"Path '{path}' is not under the project root");
+            }
+            var relative = Path.GetRelativePath(_tempProjectFolder, path)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            return Result<ResourceKey>.Ok(new ResourceKey(relative));
         });
 
         var resourceService = Substitute.For<IResourceService>();
@@ -55,6 +64,9 @@ public class PackageServiceTests
             Substitute.For<IMessengerService>(),
             workspaceWrapper);
         workspaceService.FileStorage.Returns(fileStorage);
+
+        var localizationLogger = Substitute.For<ILogger<PackageLocalizationService>>();
+        var localizationService = new PackageLocalizationService(localizationLogger, workspaceWrapper);
 
         var registry = new PackageRegistry(logger, _moduleService, featureFlags, localizationService, workspaceWrapper);
         _service = new PackageService(_messengerService, registry);

--- a/Source/Workspace/Celbridge.Documents/Services/CustomDocumentViewFactory.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/CustomDocumentViewFactory.cs
@@ -45,7 +45,7 @@ public class CustomDocumentViewFactory : DocumentEditorFactoryBase
         // value when the key is not present (which also handles plain strings).
         var displayKey = _contribution.DisplayName;
 
-        var localizationStrings = localizationService.LoadStrings(_contribution.Package.PackageFolder);
+        var localizationStrings = localizationService.LoadStrings(_contribution.Package);
         if (localizationStrings.TryGetValue(displayKey, out var localizedName))
         {
             return localizedName;

--- a/Source/Workspace/Celbridge.Packages/Services/DirectPackageReader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/DirectPackageReader.cs
@@ -1,0 +1,41 @@
+namespace Celbridge.Packages;
+
+/// <summary>
+/// Reader used for bundled packages. Reads come straight off disk because
+/// bundled assets sit outside any IResourceRegistry root and cannot be
+/// addressed by a ResourceKey. Replaced by an assembly-resource reader when
+/// the bundled-from-assembly migration lands.
+/// </summary>
+public sealed class DirectPackageReader : IPackageReader
+{
+    public bool Exists(string absolutePath)
+    {
+        return File.Exists(absolutePath);
+    }
+
+    public Result<string> ReadAllText(string absolutePath)
+    {
+        try
+        {
+            return File.ReadAllText(absolutePath);
+        }
+        catch (Exception ex)
+        {
+            return Result<string>.Fail($"Failed to read file: '{absolutePath}'")
+                .WithException(ex);
+        }
+    }
+
+    public Result<byte[]> ReadAllBytes(string absolutePath)
+    {
+        try
+        {
+            return File.ReadAllBytes(absolutePath);
+        }
+        catch (Exception ex)
+        {
+            return Result<byte[]>.Fail($"Failed to read file: '{absolutePath}'")
+                .WithException(ex);
+        }
+    }
+}

--- a/Source/Workspace/Celbridge.Packages/Services/FileStoragePackageReader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/FileStoragePackageReader.cs
@@ -1,0 +1,78 @@
+using Celbridge.Resources;
+
+namespace Celbridge.Packages;
+
+/// <summary>
+/// Reader used for project packages. Reverse-resolves the absolute path to a
+/// ResourceKey via IResourceRegistry and routes every read through IFileStorage
+/// so the chokepoint contract holds for project-tree bytes.
+///
+/// IPackageReader is sync to match its sync callers (PackageManifestLoader,
+/// PackageLocalizationService) but IFileStorage is genuinely async. Each call
+/// is dispatched through Task.Run before the blocking wait so the async work
+/// starts on a thread-pool thread whose continuations do not try to resume on
+/// the caller's SynchronizationContext. Without that, calling this reader from
+/// the UI thread (workspace load, template fetch) deadlocks: the await
+/// continuations inside FileStorage would post back to the UI thread the
+/// outer GetResult is blocking.
+/// </summary>
+public sealed class FileStoragePackageReader : IPackageReader
+{
+    private readonly IFileStorage _fileStorage;
+    private readonly IResourceRegistry _resourceRegistry;
+
+    public FileStoragePackageReader(
+        IFileStorage fileStorage,
+        IResourceRegistry resourceRegistry)
+    {
+        _fileStorage = fileStorage;
+        _resourceRegistry = resourceRegistry;
+    }
+
+    public bool Exists(string absolutePath)
+    {
+        var keyResult = _resourceRegistry.GetResourceKey(absolutePath);
+        if (keyResult.IsFailure)
+        {
+            return false;
+        }
+
+        var infoResult = Task.Run(() => _fileStorage.GetInfoAsync(keyResult.Value))
+            .GetAwaiter()
+            .GetResult();
+        if (infoResult.IsFailure)
+        {
+            return false;
+        }
+
+        return infoResult.Value.Kind != StorageItemKind.NotFound;
+    }
+
+    public Result<string> ReadAllText(string absolutePath)
+    {
+        var keyResult = _resourceRegistry.GetResourceKey(absolutePath);
+        if (keyResult.IsFailure)
+        {
+            return Result<string>.Fail($"Could not resolve resource key for path: '{absolutePath}'")
+                .WithErrors(keyResult);
+        }
+
+        return Task.Run(() => _fileStorage.ReadAllTextAsync(keyResult.Value))
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    public Result<byte[]> ReadAllBytes(string absolutePath)
+    {
+        var keyResult = _resourceRegistry.GetResourceKey(absolutePath);
+        if (keyResult.IsFailure)
+        {
+            return Result<byte[]>.Fail($"Could not resolve resource key for path: '{absolutePath}'")
+                .WithErrors(keyResult);
+        }
+
+        return Task.Run(() => _fileStorage.ReadAllBytesAsync(keyResult.Value))
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/Source/Workspace/Celbridge.Packages/Services/IPackageReader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/IPackageReader.cs
@@ -1,0 +1,26 @@
+namespace Celbridge.Packages;
+
+/// <summary>
+/// Synchronous file-read primitives used by the package layer to load
+/// manifests, localization, templates, and extensions lists. The interface
+/// keeps PackageManifestLoader and PackageLocalizationService unaware of
+/// whether the bytes ultimately come from disk (bundled) or from IFileStorage
+/// (project), so each loader can stay on a single sync code path.
+/// </summary>
+public interface IPackageReader
+{
+    /// <summary>
+    /// True when a file exists at the given absolute path.
+    /// </summary>
+    bool Exists(string absolutePath);
+
+    /// <summary>
+    /// Reads the file at the given absolute path as UTF-8 text.
+    /// </summary>
+    Result<string> ReadAllText(string absolutePath);
+
+    /// <summary>
+    /// Reads the file at the given absolute path as raw bytes.
+    /// </summary>
+    Result<byte[]> ReadAllBytes(string absolutePath);
+}

--- a/Source/Workspace/Celbridge.Packages/Services/PackageLocalizationService.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageLocalizationService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Celbridge.Logging;
+using Celbridge.Workspace;
 
 namespace Celbridge.Packages;
 
@@ -24,27 +25,28 @@ public class PackageLocalizationService : IPackageLocalizationService
         AllowTrailingCommas = true
     };
 
-    private readonly ILogger<PackageLocalizationService> _logger;
+    private static readonly IPackageReader BundledReader = new DirectPackageReader();
 
-    public PackageLocalizationService(ILogger<PackageLocalizationService> logger)
+    private readonly ILogger<PackageLocalizationService> _logger;
+    private readonly IWorkspaceWrapper _workspaceWrapper;
+
+    public PackageLocalizationService(
+        ILogger<PackageLocalizationService> logger,
+        IWorkspaceWrapper workspaceWrapper)
     {
         _logger = logger;
+        _workspaceWrapper = workspaceWrapper;
     }
 
-    /// <summary>
-    /// Loads localization strings from a package's localization folder.
-    /// Uses convention: {packageFolder}/localization/{locale}.json
-    /// If locale is null, uses the current UI culture.
-    /// Falls back to "en.json" if the requested locale is not found, then to an empty dictionary.
-    /// </summary>
-    public Dictionary<string, string> LoadStrings(string packageFolder, string? locale = null)
+    public Dictionary<string, string> LoadStrings(PackageInfo package, string? locale = null)
     {
         locale ??= CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
 
-        var localizationFolder = Path.Combine(packageFolder, LocalizationFolder);
+        var reader = GetReaderForPackage(package);
+        var localizationFolder = Path.Combine(package.PackageFolder, LocalizationFolder);
 
         var localePath = Path.Combine(localizationFolder, $"{locale}.json");
-        var result = TryLoadJsonFile(localePath);
+        var result = TryLoadJsonFile(reader, localePath);
         if (result is not null)
         {
             return result;
@@ -53,7 +55,7 @@ public class PackageLocalizationService : IPackageLocalizationService
         if (locale != FallbackLocale)
         {
             var fallbackPath = Path.Combine(localizationFolder, $"{FallbackLocale}.json");
-            result = TryLoadJsonFile(fallbackPath);
+            result = TryLoadJsonFile(reader, fallbackPath);
             if (result is not null)
             {
                 return result;
@@ -63,22 +65,44 @@ public class PackageLocalizationService : IPackageLocalizationService
         return new Dictionary<string, string>();
     }
 
-    private Dictionary<string, string>? TryLoadJsonFile(string path)
+    // Project packages route through the chokepoint by reverse-resolving the path
+    // to a ResourceKey; bundled packages stay on direct File.* IO. The project
+    // reader is constructed on demand because the workspace-scoped IFileStorage
+    // and IResourceRegistry must be looked up at call time.
+    private IPackageReader GetReaderForPackage(PackageInfo package)
     {
-        if (!File.Exists(path))
+        if (package.Origin == PackageOrigin.Project)
         {
+            var fileStorage = _workspaceWrapper.WorkspaceService.FileStorage;
+            var resourceRegistry = _workspaceWrapper.WorkspaceService.ResourceService.Registry;
+            return new FileStoragePackageReader(fileStorage, resourceRegistry);
+        }
+
+        return BundledReader;
+    }
+
+    private Dictionary<string, string>? TryLoadJsonFile(IPackageReader reader, string path)
+    {
+        if (!reader.Exists(path))
+        {
+            return null;
+        }
+
+        var readResult = reader.ReadAllText(path);
+        if (readResult.IsFailure)
+        {
+            _logger.LogWarning($"Failed to load localization file: {path}. {readResult.FirstErrorMessage}");
             return null;
         }
 
         try
         {
-            var json = File.ReadAllText(path);
-            var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(json, _jsonOptions);
+            var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(readResult.Value, _jsonOptions);
             return dictionary;
         }
         catch (Exception exception)
         {
-            _logger.LogWarning($"Failed to load localization file: {path}. {exception.Message}");
+            _logger.LogWarning(exception, $"Failed to parse localization file: {path}");
             return null;
         }
     }

--- a/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
@@ -54,17 +54,30 @@ public static class PackageManifestLoader
     /// hostNameOverride, when non-null, replaces the default package-id-derived virtual host name.
     /// secrets, when non-empty, populates PackageInfo.Secrets for WebView injection.
     /// devToolsBlocked, when true, permanently disables DevTools on WebViews hosting this package.
+    /// origin tags the resulting PackageInfo so downstream read sites can pick the right IO path.
+    /// reader is the file-read primitive used for every byte the loader pulls; when null a
+    /// DirectPackageReader is used, which preserves the legacy direct-disk behaviour for
+    /// callers (tests, bundled discovery) that have no IFileStorage to route through.
     /// </summary>
     public static Result<Package> LoadPackage(
         string packageTomlPath,
         string? hostNameOverride = null,
         IReadOnlyDictionary<string, string>? secrets = null,
-        bool devToolsBlocked = false)
+        bool devToolsBlocked = false,
+        PackageOrigin origin = PackageOrigin.Bundled,
+        IPackageReader? reader = null)
     {
+        reader ??= new DirectPackageReader();
         try
         {
             var packageFolder = Path.GetFullPath(Path.GetDirectoryName(packageTomlPath) ?? string.Empty);
-            var toml = File.ReadAllText(packageTomlPath);
+            var readResult = reader.ReadAllText(packageTomlPath);
+            if (readResult.IsFailure)
+            {
+                return Result.Fail($"Failed to read package manifest: {packageTomlPath}")
+                    .WithErrors(readResult);
+            }
+            var toml = readResult.Value;
             var parsed = Toml.Parse(toml);
 
             if (parsed.HasErrors)
@@ -122,7 +135,8 @@ public static class PackageManifestLoader
                 HostName = hostName,
                 RequiresTools = requiresTools,
                 Secrets = packageSecrets,
-                DevToolsBlocked = devToolsBlocked
+                DevToolsBlocked = devToolsBlocked,
+                Origin = origin
             };
 
             var documentPaths = new List<string>();
@@ -146,7 +160,7 @@ public static class PackageManifestLoader
             foreach (var relativePath in documentPaths)
             {
                 var fullPath = Path.Combine(packageFolder, relativePath);
-                var loadResult = LoadDocument(fullPath, packageInfo);
+                var loadResult = LoadDocument(fullPath, packageInfo, reader);
                 if (loadResult.IsSuccess)
                 {
                     documentEditors.Add(loadResult.Value);
@@ -172,16 +186,23 @@ public static class PackageManifestLoader
     /// </summary>
     private static Result<DocumentEditorContribution> LoadDocument(
         string documentTomlPath,
-        PackageInfo packageInfo)
+        PackageInfo packageInfo,
+        IPackageReader reader)
     {
         try
         {
-            if (!File.Exists(documentTomlPath))
+            if (!reader.Exists(documentTomlPath))
             {
                 return Result.Fail($"Document manifest not found: {documentTomlPath}");
             }
 
-            var toml = File.ReadAllText(documentTomlPath);
+            var readResult = reader.ReadAllText(documentTomlPath);
+            if (readResult.IsFailure)
+            {
+                return Result.Fail($"Failed to read document manifest: {documentTomlPath}")
+                    .WithErrors(readResult);
+            }
+            var toml = readResult.Value;
             var parsed = Toml.Parse(toml);
 
             if (parsed.HasErrors)
@@ -239,7 +260,7 @@ public static class PackageManifestLoader
                                 $"A [[document_file_types]] entry cannot specify both '{ExtensionKey}' and '{ExtensionsFileKey}': {documentTomlPath}");
                         }
 
-                        var expandResult = ExpandExtensionsFile(packageInfo.PackageFolder, extensionsFilePath, fileTypeDisplayName);
+                        var expandResult = ExpandExtensionsFile(packageInfo.PackageFolder, extensionsFilePath, fileTypeDisplayName, reader);
                         if (expandResult.IsFailure)
                         {
                             return Result.Fail($"Failed to expand '{ExtensionsFileKey}' in {documentTomlPath}")
@@ -431,17 +452,24 @@ public static class PackageManifestLoader
     private static Result<List<DocumentFileType>> ExpandExtensionsFile(
         string packageFolder,
         string relativePath,
-        string displayName)
+        string displayName,
+        IPackageReader reader)
     {
         var fullPath = Path.Combine(packageFolder, relativePath);
-        if (!File.Exists(fullPath))
+        if (!reader.Exists(fullPath))
         {
             return Result.Fail($"Extensions file not found: {fullPath}");
         }
 
         try
         {
-            var json = File.ReadAllText(fullPath);
+            var readResult = reader.ReadAllText(fullPath);
+            if (readResult.IsFailure)
+            {
+                return Result.Fail($"Failed to read extensions file: {fullPath}")
+                    .WithErrors(readResult);
+            }
+            var json = readResult.Value;
             using var document = JsonDocument.Parse(json);
 
             if (document.RootElement.ValueKind != JsonValueKind.Object)

--- a/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
@@ -29,6 +29,11 @@ public class PackageRegistry
     private List<Package> _bundledPackages = [];
     private List<Package> _projectPackages = [];
 
+    // Bundled packages live outside any IResourceRegistry root so their reads
+    // stay on direct File.* IO. One reader is reused across the discovery and
+    // template-fetch paths to keep the bundled branch cheap.
+    private static readonly IPackageReader BundledReader = new DirectPackageReader();
+
     public PackageRegistry(
         ILogger<PackageRegistry> logger,
         IModuleService moduleService,
@@ -130,7 +135,7 @@ public class PackageRegistry
                 continue;
             }
 
-            var localizationStrings = _localizationService.LoadStrings(contribution.Package.PackageFolder);
+            var localizationStrings = _localizationService.LoadStrings(contribution.Package);
             var displayKey = contribution.FileTypes[0].DisplayName;
             string displayName;
             if (localizationStrings.TryGetValue(displayKey, out var localizedName))
@@ -151,11 +156,11 @@ public class PackageRegistry
         return documentTypes.AsReadOnly();
     }
 
-    // Template files are read from contribution.Package.PackageFolder, which is
-    // an absolute path that may live inside the project tree (project packages)
-    // or outside it (bundled packages shipped with module DLLs). The contribution
-    // does not carry a bundled/project tag, so the read stays on direct I/O until
-    // package origin is tracked.
+    // Reads the default template bytes for the given file extension, picking the
+    // first contribution that handles the extension and declares a default template.
+    // The reader is chosen by package origin: bundled packages stay on direct File.*
+    // because their bytes live outside any registry root, project packages route
+    // through IFileStorage by reverse-resolving the template path.
     public byte[]? GetDefaultTemplateContent(string fileExtension)
     {
         var normalizedExtension = fileExtension.ToLowerInvariant();
@@ -180,24 +185,42 @@ public class PackageRegistry
             }
 
             var templatePath = Path.Combine(contribution.Package.PackageFolder, defaultTemplate.TemplateFile);
-            if (!File.Exists(templatePath))
+            var reader = GetReaderForPackage(contribution.Package);
+
+            if (!reader.Exists(templatePath))
             {
                 _logger.LogWarning($"Template file not found: {templatePath}");
                 continue;
             }
 
-            try
+            var readResult = reader.ReadAllBytes(templatePath);
+            if (readResult.IsFailure)
             {
-                return File.ReadAllBytes(templatePath);
-            }
-            catch (Exception exception)
-            {
-                _logger.LogWarning($"Failed to read template file: {templatePath}. {exception.Message}");
+                _logger.LogWarning($"Failed to read template file: {templatePath}. {readResult.FirstErrorMessage}");
                 continue;
             }
+
+            return readResult.Value;
         }
 
         return null;
+    }
+
+    // Selects the file-read primitive that matches a package's discovery origin.
+    // Project packages are read through the chokepoint; bundled packages stay on
+    // direct File.* IO. The project reader is constructed on demand because the
+    // workspace-scoped IFileStorage and IResourceRegistry must be looked up at
+    // call time rather than cached.
+    private IPackageReader GetReaderForPackage(PackageInfo package)
+    {
+        if (package.Origin == PackageOrigin.Project)
+        {
+            var fileStorage = _workspaceWrapper.WorkspaceService.FileStorage;
+            var resourceRegistry = _workspaceWrapper.WorkspaceService.ResourceService.Registry;
+            return new FileStoragePackageReader(fileStorage, resourceRegistry);
+        }
+
+        return BundledReader;
     }
 
     private List<PackageLoadFailure> DiscoverBundledPackages()
@@ -209,7 +232,7 @@ public class PackageRegistry
         foreach (var descriptor in descriptors)
         {
             var manifestPath = Path.Combine(descriptor.Folder, ManifestFileName);
-            if (!File.Exists(manifestPath))
+            if (!BundledReader.Exists(manifestPath))
             {
                 // A bundled package with no manifest is a build-time error.
                 // Either the descriptor folder is wrong or the package content
@@ -228,7 +251,9 @@ public class PackageRegistry
                 manifestPath,
                 descriptor.HostNameOverride,
                 descriptor.Secrets,
-                descriptor.DevToolsBlocked);
+                descriptor.DevToolsBlocked,
+                origin: PackageOrigin.Bundled,
+                reader: BundledReader);
             if (loadResult.IsFailure)
             {
                 _logger.LogError(loadResult, $"Failed to load bundled package: {manifestPath}");
@@ -299,6 +324,7 @@ public class PackageRegistry
         }
 
         var resourceRegistry = _workspaceWrapper.WorkspaceService.ResourceService.Registry;
+        var projectReader = new FileStoragePackageReader(fileStorage, resourceRegistry);
         var candidates = new List<Package>();
 
         foreach (var item in enumerateResult.Value)
@@ -326,7 +352,12 @@ public class PackageRegistry
             var manifestPath = resolveResult.Value;
             var packageFolder = Path.GetDirectoryName(manifestPath)!;
 
-            var loadResult = PackageManifestLoader.LoadPackage(manifestPath, hostNameOverride: null, secrets: null);
+            var loadResult = PackageManifestLoader.LoadPackage(
+                manifestPath,
+                hostNameOverride: null,
+                secrets: null,
+                origin: PackageOrigin.Project,
+                reader: projectReader);
             if (loadResult.IsFailure)
             {
                 _logger.LogWarning(loadResult, $"Skipping invalid project package: {manifestPath}");


### PR DESCRIPTION
Add PackageOrigin and PackageInfo.Origin to track whether a package is Bundled or Project. Introduce IPackageReader with DirectPackageReader and FileStoragePackageReader implementations so package bytes can be read either directly from disk (bundled) or via IFileStorage/IResourceRegistry (project). Update PackageLocalizationService, PackageManifestLoader, and PackageRegistry to select the appropriate reader based on package origin and to handle read errors consistently; make FileStorage reads synchronous via Task.Run to avoid deadlocks. Adjust tests and call sites to pass PackageInfo and workspace wrappers where needed and add resource key stubs in tests.