### PR TITLE
Enhance document closing and writable state handling with tests

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -201,13 +201,13 @@
   <data name="ResourceTree_CannotRename" xml:space="preserve">
     <value>Cannot rename</value>
   </data>
-  <data name="ResourceTree_ReadOnly_Locked" xml:space="preserve">
+  <data name="Resource_ReadOnly_Locked" xml:space="preserve">
     <value>Locked by project configuration. Edit [resources].lock to unlock.</value>
   </data>
-  <data name="ResourceTree_ReadOnly_ReadOnlyAttribute" xml:space="preserve">
+  <data name="Resource_ReadOnly_ReadOnlyAttribute" xml:space="preserve">
     <value>File is read-only on disk.</value>
   </data>
-  <data name="ResourceTree_ReadOnly_ReadOnlyRoot" xml:space="preserve">
+  <data name="Resource_ReadOnly_ReadOnlyRoot" xml:space="preserve">
     <value>Bundled package — read-only by design.</value>
   </data>
   <data name="Policy_Locked_Single" xml:space="preserve">

--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -201,6 +201,15 @@
   <data name="ResourceTree_CannotRename" xml:space="preserve">
     <value>Cannot rename</value>
   </data>
+  <data name="ResourceTree_ReadOnly_Locked" xml:space="preserve">
+    <value>Locked by project configuration. Edit [resources].lock to unlock.</value>
+  </data>
+  <data name="ResourceTree_ReadOnly_ReadOnlyAttribute" xml:space="preserve">
+    <value>File is read-only on disk.</value>
+  </data>
+  <data name="ResourceTree_ReadOnly_ReadOnlyRoot" xml:space="preserve">
+    <value>Bundled package — read-only by design.</value>
+  </data>
   <data name="Policy_Locked_Single" xml:space="preserve">
     <value>'{0}' is locked.</value>
   </data>

--- a/Source/Core/Celbridge.FileSystem/Services/FileSystemMonitor.cs
+++ b/Source/Core/Celbridge.FileSystem/Services/FileSystemMonitor.cs
@@ -61,10 +61,14 @@ public sealed class FileSystemMonitor : IFileSystemMonitor
         {
             var watcher = new FileSystemWatcher(_backingFolderPath)
             {
+                // Attributes is included so an external attrib +r / -r surfaces
+                // as a Changed event. Consumers that cache WritableState use it
+                // to refresh the ReadOnlyAttribute source.
                 NotifyFilter = NotifyFilters.FileName
                              | NotifyFilters.DirectoryName
                              | NotifyFilters.LastWrite
-                             | NotifyFilters.Size,
+                             | NotifyFilters.Size
+                             | NotifyFilters.Attributes,
                 IncludeSubdirectories = true,
                 EnableRaisingEvents = false
             };

--- a/Source/Core/Celbridge.FileSystem/Services/LocalFileSystem.cs
+++ b/Source/Core/Celbridge.FileSystem/Services/LocalFileSystem.cs
@@ -167,16 +167,32 @@ public sealed class LocalFileSystem : ILocalFileSystem
             // for every consumer.
             var directoryInfo = new DirectoryInfo(path);
 
+            // FileSystemInfo.Attributes is also populated from the directory walk,
+            // so the portable read-only flag costs no extra stat per item.
             var folderInfos = directoryInfo.EnumerateDirectories(pattern, searchOption).OrderBy(folder => folder.FullName, StringComparer.Ordinal);
             foreach (var folderInfo in folderInfos)
             {
-                entries.Add(new FileSystemEntry(folderInfo.FullName, IsFolder: true, Size: 0, ModifiedUtc: folderInfo.LastWriteTimeUtc));
+                var folderAttributes = MapToPortable(folderInfo.Attributes);
+                var folderEntry = new FileSystemEntry(
+                    FullPath: folderInfo.FullName,
+                    IsFolder: true,
+                    Size: 0,
+                    ModifiedUtc: folderInfo.LastWriteTimeUtc,
+                    Attributes: folderAttributes);
+                entries.Add(folderEntry);
             }
 
             var fileInfos = directoryInfo.EnumerateFiles(pattern, searchOption).OrderBy(file => file.FullName, StringComparer.Ordinal);
             foreach (var fileInfo in fileInfos)
             {
-                entries.Add(new FileSystemEntry(fileInfo.FullName, IsFolder: false, Size: fileInfo.Length, ModifiedUtc: fileInfo.LastWriteTimeUtc));
+                var fileAttributes = MapToPortable(fileInfo.Attributes);
+                var fileEntry = new FileSystemEntry(
+                    FullPath: fileInfo.FullName,
+                    IsFolder: false,
+                    Size: fileInfo.Length,
+                    ModifiedUtc: fileInfo.LastWriteTimeUtc,
+                    Attributes: fileAttributes);
+                entries.Add(fileEntry);
             }
 
             IReadOnlyList<FileSystemEntry> list = entries;

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
@@ -47,16 +47,12 @@ public interface IDocumentView
     Task<Result> SaveDocument();
 
     /// <summary>
-    /// The document's writable state, or the reason it is non-editable. Set
-    /// via SetWritableState after the file resource resolves and the state is
-    /// queried.
+    /// The document's writable state, or the reason it is non-editable.
     /// </summary>
     WritableState WritableState { get; }
 
     /// <summary>
-    /// Applies a writable state to the document view. The base class stores
-    /// the value and notifies the concrete view via OnWritableStateChanged so
-    /// it can refuse edits in its own native way.
+    /// Sets the document's writable state.
     /// </summary>
     void SetWritableState(WritableState state);
 

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
@@ -1,3 +1,5 @@
+using Celbridge.Resources;
+
 namespace Celbridge.Documents;
 
 /// <summary>
@@ -43,6 +45,20 @@ public interface IDocumentView
     /// Save the document content from the document view using the previously set file resource.
     /// </summary>
     Task<Result> SaveDocument();
+
+    /// <summary>
+    /// The document's writable state, or the reason it is non-editable. Set
+    /// via SetWritableState after the file resource resolves and the state is
+    /// queried.
+    /// </summary>
+    WritableState WritableState { get; }
+
+    /// <summary>
+    /// Applies a writable state to the document view. The base class stores
+    /// the value and notifies the concrete view via OnWritableStateChanged so
+    /// it can refuse edits in its own native way.
+    /// </summary>
+    void SetWritableState(WritableState state);
 
     /// <summary>
     /// Navigate to a specific location within the document.

--- a/Source/Core/Celbridge.Foundation/FileSystem/ILocalFileSystem.cs
+++ b/Source/Core/Celbridge.Foundation/FileSystem/ILocalFileSystem.cs
@@ -74,12 +74,18 @@ public record StorageItemInfo(
     FileSystemAttributes Attributes);
 
 /// <summary>
-/// A file or folder entry returned by EnumerateAsync, with its absolute path and
-/// the size and modified-time from the directory walk. IsFolder is false for
-/// anything that is not a directory, so a non-folder is not guaranteed to be a
-/// readable regular file. Size is 0 for folders.
+/// A file or folder entry returned by EnumerateAsync, with its absolute path,
+/// the size, modified-time, and portable attribute flags from the directory
+/// walk. IsFolder is false for anything that is not a directory, so a
+/// non-folder is not guaranteed to be a readable regular file. Size is 0 for
+/// folders.
 /// </summary>
-public record FileSystemEntry(string FullPath, bool IsFolder, long Size, DateTime ModifiedUtc);
+public record FileSystemEntry(
+    string FullPath,
+    bool IsFolder,
+    long Size,
+    DateTime ModifiedUtc,
+    FileSystemAttributes Attributes);
 
 /// <summary>
 /// Path-based gateway for local-substrate filesystem reads and writes. The

--- a/Source/Core/Celbridge.Foundation/Resources/IResource.cs
+++ b/Source/Core/Celbridge.Foundation/Resources/IResource.cs
@@ -19,4 +19,9 @@ public interface IResource
     /// The folder resource that contains this resource.
     /// </summary>
     public IFolderResource? ParentFolder { get; }
+
+    /// <summary>
+    /// Whether the resource is editable, and if not, why.
+    /// </summary>
+    WritableState WritableState { get; }
 }

--- a/Source/Core/Celbridge.Foundation/Resources/IResourceOperationService.cs
+++ b/Source/Core/Celbridge.Foundation/Resources/IResourceOperationService.cs
@@ -37,10 +37,8 @@ public enum ResourceLockState
 }
 
 /// <summary>
-/// Whether a resource can be edited, and if not, why. Reported by
-/// GetWritableStateAsync. Editor and display surfaces drive their treatment
-/// off this enum; the non-Writable values name the source so callers can
-/// localise the cause without re-querying the underlying systems.
+/// Whether a resource can be edited, and if not, why. The non-Writable
+/// values name the source.
 /// </summary>
 public enum WritableState
 {
@@ -135,11 +133,8 @@ public interface IResourceOperationService
     Task<ResourceLockState> GetLockStateAsync(ResourceKey resource);
 
     /// <summary>
-    /// Resolves whether the resource can be edited by the document editor and
-    /// at-rest display surfaces, combining the [resources].lock pattern, OS
-    /// read-only attribute, and read-only resource root sources. The non-
-    /// Writable values name the first source that fires in priority order:
-    /// Locked, ReadOnlyRoot, ReadOnlyAttribute.
+    /// Returns the writable state of the resource. When multiple sources apply,
+    /// the priority order is Locked > ReadOnlyRoot > ReadOnlyAttribute.
     /// </summary>
     Task<WritableState> GetWritableStateAsync(ResourceKey resource);
 

--- a/Source/Core/Celbridge.Foundation/Resources/IResourceOperationService.cs
+++ b/Source/Core/Celbridge.Foundation/Resources/IResourceOperationService.cs
@@ -37,6 +37,36 @@ public enum ResourceLockState
 }
 
 /// <summary>
+/// Whether a resource can be edited, and if not, why. Reported by
+/// GetWritableStateAsync. Editor and display surfaces drive their treatment
+/// off this enum; the non-Writable values name the source so callers can
+/// localise the cause without re-querying the underlying systems.
+/// </summary>
+public enum WritableState
+{
+    /// <summary>
+    /// The resource accepts edits.
+    /// </summary>
+    Writable,
+
+    /// <summary>
+    /// A [resources].lock pattern matches the resource.
+    /// </summary>
+    Locked,
+
+    /// <summary>
+    /// The underlying file carries the OS read-only attribute.
+    /// </summary>
+    ReadOnlyAttribute,
+
+    /// <summary>
+    /// The resource's root handler declares the root non-writable; every
+    /// resource under the root is read-only by construction.
+    /// </summary>
+    ReadOnlyRoot,
+}
+
+/// <summary>
 /// The workspace-scoped resource operation service. Layers session-local undo
 /// and redo, batched grouping, and soft-delete trash on top of the IResourceFileSystem
 /// gateway. Every method names its target with a ResourceKey; external
@@ -103,6 +133,15 @@ public interface IResourceOperationService
     /// prediction cannot drift from enforcement.
     /// </summary>
     Task<ResourceLockState> GetLockStateAsync(ResourceKey resource);
+
+    /// <summary>
+    /// Resolves whether the resource can be edited by the document editor and
+    /// at-rest display surfaces, combining the [resources].lock pattern, OS
+    /// read-only attribute, and read-only resource root sources. The non-
+    /// Writable values name the first source that fires in priority order:
+    /// Locked, ReadOnlyRoot, ReadOnlyAttribute.
+    /// </summary>
+    Task<WritableState> GetWritableStateAsync(ResourceKey resource);
 
     /// <summary>
     /// Read-only prediction of whether the resource can be deleted, renamed,

--- a/Source/Core/Celbridge.Foundation/Resources/ResourceFileSystemTypes.cs
+++ b/Source/Core/Celbridge.Foundation/Resources/ResourceFileSystemTypes.cs
@@ -94,4 +94,5 @@ public record FolderItem(
     ResourceKey Resource,
     bool IsFolder,
     long Size,
-    DateTime ModifiedUtc);
+    DateTime ModifiedUtc,
+    FileSystemAttributes Attributes);

--- a/Source/Core/Celbridge.Host/Services/IHostDocument.cs
+++ b/Source/Core/Celbridge.Host/Services/IHostDocument.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Celbridge.Resources;
 using StreamJsonRpc;
 
 namespace Celbridge.Host;
@@ -42,6 +43,7 @@ public static class DocumentRpcMethods
     public const string ContentLoaded = "document/contentLoaded";
     public const string RequestState = "document/requestState";
     public const string RestoreState = "document/restoreState";
+    public const string WritableStateChanged = "document/writableStateChanged";
 
     /// <summary>
     /// Validates the protocol version from the WebView client.
@@ -142,4 +144,13 @@ public static class HostDocumentExtensions
     /// </summary>
     public static Task RestoreStateAsync(this CelbridgeHost host, string state)
         => host.Rpc.InvokeAsync(DocumentRpcMethods.RestoreState, state);
+
+    /// <summary>
+    /// Notifies the WebView that the document's writable state has changed.
+    /// The state is sent as its string name ("Writable", "Locked",
+    /// "ReadOnlyAttribute", "ReadOnlyRoot"); the JS client treats anything
+    /// other than "Writable" as read-only.
+    /// </summary>
+    public static Task NotifyWritableStateChangedAsync(this CelbridgeHost host, WritableState state)
+        => host.Rpc.NotifyAsync(DocumentRpcMethods.WritableStateChanged, new { state = state.ToString() });
 }

--- a/Source/Core/Celbridge.Host/Services/IHostDocument.cs
+++ b/Source/Core/Celbridge.Host/Services/IHostDocument.cs
@@ -130,7 +130,7 @@ public static class HostDocumentExtensions
     /// across the reload, or to adopt the view state encoded in the on-disk file.
     /// </summary>
     public static Task NotifyExternalChangeAsync(this CelbridgeHost host, bool preserveViewState)
-        => host.Rpc.NotifyAsync(DocumentRpcMethods.ExternalChange, new { preserveViewState });
+        => host.Rpc.NotifyWithParameterObjectAsync(DocumentRpcMethods.ExternalChange, new { preserveViewState });
 
     /// <summary>
     /// Requests the WebView to return its current editor state as an opaque JSON string.
@@ -152,5 +152,5 @@ public static class HostDocumentExtensions
     /// other than "Writable" as read-only.
     /// </summary>
     public static Task NotifyWritableStateChangedAsync(this CelbridgeHost host, WritableState state)
-        => host.Rpc.NotifyAsync(DocumentRpcMethods.WritableStateChanged, new { state = state.ToString() });
+        => host.Rpc.NotifyWithParameterObjectAsync(DocumentRpcMethods.WritableStateChanged, new { state = state.ToString() });
 }

--- a/Source/Core/Celbridge.Host/Services/RpcTypes.cs
+++ b/Source/Core/Celbridge.Host/Services/RpcTypes.cs
@@ -13,8 +13,9 @@ public record DocumentMetadata(string FilePath, string ResourceKey, string FileN
 /// <summary>
 /// Result of the document/initialize request.
 /// Localization is handled by JS fetching from the extension's localization folder.
+/// WritableState is the string name of the document's writable state at handshake time.
 /// </summary>
-public record InitializeResult(string Content, DocumentMetadata Metadata, string? EditorStateJson = null);
+public record InitializeResult(string Content, DocumentMetadata Metadata, string WritableState, string? EditorStateJson = null);
 
 // =============================================================================
 // Document Operation Results

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -1,0 +1,143 @@
+# Document editor contributions
+
+A package contribution that takes over a file extension in the documents panel. The editor runs in a WebView2 and talks to the host through `https://shared.celbridge/celbridge-client/celbridge.js`. Read `packages_overview` first.
+
+## Manifest
+
+`packages/my-editor/package.toml`:
+
+```toml
+[package]
+id = "my-editor"
+name = "My Editor"
+version = "1.0.0"
+
+[contributes]
+document_editors = ["my-editor.document.toml"]
+
+[mod]
+requires_tools = ["document.*", "file.*"]
+```
+
+`packages/my-editor/my-editor.document.toml`:
+
+```toml
+[document]
+id = "my-editor-document"
+type = "custom"
+entry_point = "index.html"
+priority = "specialized"
+display_name = "MyEditor_Editor_Name"
+
+[[document_file_types]]
+extension = ".myext"
+display_name = "MyEditor_FileType_MyExt"
+
+[[document_templates]]
+id = "empty"
+display_name = "MyEditor_Template_Empty"
+template_file = "templates/empty.myext"
+default = true
+```
+
+`priority`: `"specialized"` wins over `"general"` for the same extension. `display_name` values are localization keys. Templates are optional.
+
+## JS handlers
+
+```javascript
+import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
+import { ContentLoadedReason } from 'https://shared.celbridge/celbridge-client/api/document-api.js';
+
+const client = celbridge;
+
+await client.initializeDocument({
+    onContent: async (content, metadata) => { /* load into editor */ },
+    onRequestSave: async () => { /* await client.document.save(serialised) */ },
+    onExternalChange: async () => { /* reload, then notifyContentLoaded(ExternalReload) */ },
+    onRequestState: () => { /* return opaque snapshot string or null */ },
+    onRestoreState: (stateJson) => { /* apply snapshot */ },
+    onWritableStateChanged: ({ state }) => { /* apply read-only state */ }
+});
+```
+
+- **`onContent(content, metadata)`** — initial load. `content` is string or base64; `metadata.resourceKey` is the resource key. Framework calls `notifyContentLoaded()` for you. Do not save here; suppress framework update events (see trap).
+- **`onRequestSave()`** — auto-save, tab close, programmatic flush. `await client.document.save(content)`. May fire while the tab is hidden.
+- **`onExternalChange(args)`** — file changed on disk. `client.document.load()`, apply with the spurious-update guard, then `client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload)`. Forward `args.preserveViewState`.
+- **`onRequestState()` / `onRestoreState(stateJson)`** — opaque string round-trip for scroll, selection, pending view state. Survives external reloads and session restore. Return `null` if nothing to preserve.
+- **`onWritableStateChanged({ state })`** — see below. Required.
+
+## `onWritableStateChanged` is required
+
+Fires once during `initializeDocument` with the initial state, then again whenever it changes mid-session. `state` is one of:
+
+- `"Writable"` — accept edits.
+- `"Locked"` — `[resources].lock` pattern match.
+- `"ReadOnlyAttribute"` — OS read-only bit set.
+- `"ReadOnlyRoot"` — non-writable resource root.
+
+Treat **anything other than `"Writable"`** as read-only. Same representation for all three non-writable states.
+
+Read-only-by-design editors register an empty handler — a stub, not a TODO:
+
+```javascript
+onWritableStateChanged: () => {}
+```
+
+A future edit-mode addition must deliberately remove the no-op, surfacing the read-only obligation at review time. Precedent: `Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/js/file-viewer.js`.
+
+## The spurious-update trap
+
+Many editor frameworks emit "update" events for non-edits — TipTap's `setEditable(false)` fires `onUpdate` with a no-op transaction, SpreadJS's command manager fires through `import`, ProseMirror's `replaceWith` fires the same event as a keystroke. Wired naively, these route through `notifyChanged` → auto-save → and on a locked file, either fail loudly or strip the OS read-only attribute and clobber the user's choice.
+
+**Gate `notifyChanged` on a `frameworkReadOnly` flag.** Single module-level boolean, checked at the top of every save-scheduling path:
+
+```javascript
+let frameworkReadOnly = false;
+
+function applyWritableState(state) {
+    frameworkReadOnly = state !== 'Writable';
+    // ...apply to editor surface...
+}
+
+editor.on('update', ({ transaction }) => {
+    if (frameworkReadOnly) return;
+    if (!transaction?.docChanged) return;
+    debounceNotifyChanged();
+});
+```
+
+The `docChanged` guard is the second line of defence — catches no-op transactions on the writable side too.
+
+**Suppress framework updates around framework-driven writes.** Initial load and external reload are not user edits:
+
+```javascript
+editor.commands.setContent(jsonContent, { emitUpdate: false });
+```
+
+Apply at every framework-driven `setContent` site.
+
+## Read-only representations
+
+| Editor surface | Signal |
+|---|---|
+| Code / Monaco | `editor.updateOptions({ readOnly: true })` plus disabled toolbar buttons |
+| Rich-text / TipTap, ProseMirror | `editor.setEditable(false, false)` plus disabled toolbar buttons |
+| Spreadsheet / SpreadJS | Translucent overlay absorbing pointer events (workbook surface is too multi-tiered to gate option-by-option) |
+| Canvas / iframe-wrapped | `pointer-events: none` on the surface, muted filter on the wrapper |
+| Presentation-only viewer | Explicit no-op handler |
+
+## Cross-references
+
+- **Localization** — `t('MyEditor_Editor_Name')` after `await client.initialize()`; strings live in `localization/<locale>.json` next to `index.html`.
+- **Secrets** — bundled-package descriptors can inject `client.secrets.<name>`. Non-bundled packages see an empty map.
+- **`requires_tools`** — every `cel.*` call must be declared under `[mod].requires_tools` in alias form (`"document.save"`). See `agent_instructions`.
+
+## Reference contributions
+
+| Editor | Path | Demonstrates |
+|---|---|---|
+| Notes | `Source/Modules/Celbridge.DocumentEditors/Editors/Notes/` | TipTap, spurious-update gating, toolbar dimming |
+| Spreadsheet | `Source/Modules/Celbridge.Spreadsheet/Package/` | SpreadJS, command-manager gating, translucent overlay, secret injection |
+| FileViewer | `Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/` | Explicit no-op |
+| SceneViewer | `Source/Modules/Celbridge.DocumentEditors/Editors/SceneViewer/` | Explicit no-op |
+| CodeEditor | `Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/` | Monaco `readOnly`, toolbar gating |

--- a/Source/Core/Celbridge.Tools/Guides/Tools/package_create.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/package_create.md
@@ -15,3 +15,5 @@ A JSON object:
 - `packageName` (string) — echoed package name.
 - `resource` (string) — resource key of the new package folder, e.g. `"packages/my-widget"`.
 - `manifestPath` (string) — resource key of the created manifest, e.g. `"packages/my-widget/package.toml"`.
+
+If you're contributing a document editor, also read `document_editor_contributions` for the manifest, handler, and read-only contract.

--- a/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Create.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Create.cs
@@ -15,7 +15,7 @@ public partial class PackageTools
     /// <summary>Create a new package skeleton at packages/{packageName}/ with stub manifest.</summary>
     [McpServerTool(Name = "package_create", Destructive = true)]
     [ToolAlias("package.create")]
-    [RelatedGuides("packages_overview")]
+    [RelatedGuides("packages_overview", "document_editor_contributions")]
     public async partial Task<CallToolResult> Create(string packageName)
     {
         if (!IsValidPackageName(packageName))

--- a/Source/Core/Celbridge.UserInterface/Helpers/ReadOnlyMessageHelper.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/ReadOnlyMessageHelper.cs
@@ -1,0 +1,35 @@
+using Celbridge.Resources;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Resolves the localised read-only message for a WritableState, or null when
+/// the state is Writable. Centralised so a single resw key is bound per state.
+/// </summary>
+public static class ReadOnlyMessageHelper
+{
+    /// <summary>
+    /// Returns the localised read-only message for the writable state, or null
+    /// when the resource is Writable. Bindings that consume this should treat
+    /// null as "no tooltip, no automation help text" so the tooltip element
+    /// collapses on writable resources.
+    /// </summary>
+    public static string? GetReadOnlyMessage(WritableState state, IStringLocalizer localizer)
+    {
+        var key = state switch
+        {
+            WritableState.Locked => "Resource_ReadOnly_Locked",
+            WritableState.ReadOnlyAttribute => "Resource_ReadOnly_ReadOnlyAttribute",
+            WritableState.ReadOnlyRoot => "Resource_ReadOnly_ReadOnlyRoot",
+            _ => null,
+        };
+
+        if (key is null)
+        {
+            return null;
+        }
+
+        return localizer.GetString(key).Value;
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerDialogViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerDialogViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Celbridge.Workspace;
+using Microsoft.Extensions.Localization;
 using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace Celbridge.UserInterface.ViewModels;
@@ -7,6 +8,7 @@ namespace Celbridge.UserInterface.ViewModels;
 public partial class ResourcePickerDialogViewModel : ObservableObject
 {
     private readonly IWorkspaceWrapper _workspaceWrapper;
+    private readonly IStringLocalizer _stringLocalizer;
 
     private IResourceRegistry? _registry;
     private IResourceFileSystem? _resourceFileSystem;
@@ -39,6 +41,7 @@ public partial class ResourcePickerDialogViewModel : ObservableObject
         IWorkspaceWrapper workspaceWrapper)
     {
         _workspaceWrapper = workspaceWrapper;
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         PropertyChanged += OnPropertyChanged;
     }
 
@@ -151,7 +154,8 @@ public partial class ResourcePickerDialogViewModel : ObservableObject
                 }
 
                 var resourceKey = registry.GetResourceKey(child);
-                items.Add(new ResourcePickerItem(child, resourceKey, fileResource.Icon));
+                var readOnlyMessage = ResolveReadOnlyMessage(child.WritableState);
+                items.Add(new ResourcePickerItem(child, resourceKey, fileResource.Icon, readOnlyMessage));
             }
         }
     }
@@ -170,5 +174,26 @@ public partial class ResourcePickerDialogViewModel : ObservableObject
         FilteredItems = _allItems
             .Where(item => item.DisplayTextLower.Contains(searchLower))
             .ToList();
+    }
+
+    // Maps the writable state to its localised tooltip text. Returns null for
+    // Writable so the picker item's ReadOnlyMessage stays empty and the binding
+    // collapses the tooltip element.
+    private string? ResolveReadOnlyMessage(WritableState state)
+    {
+        var key = state switch
+        {
+            WritableState.Locked => "Resource_ReadOnly_Locked",
+            WritableState.ReadOnlyAttribute => "Resource_ReadOnly_ReadOnlyAttribute",
+            WritableState.ReadOnlyRoot => "Resource_ReadOnly_ReadOnlyRoot",
+            _ => null,
+        };
+
+        if (key is null)
+        {
+            return null;
+        }
+
+        return _stringLocalizer.GetString(key).Value;
     }
 }

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerDialogViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Celbridge.UserInterface.Helpers;
 using Celbridge.Workspace;
 using Microsoft.Extensions.Localization;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -154,7 +155,7 @@ public partial class ResourcePickerDialogViewModel : ObservableObject
                 }
 
                 var resourceKey = registry.GetResourceKey(child);
-                var readOnlyMessage = ResolveReadOnlyMessage(child.WritableState);
+                var readOnlyMessage = ReadOnlyMessageHelper.GetReadOnlyMessage(child.WritableState, _stringLocalizer);
                 items.Add(new ResourcePickerItem(child, resourceKey, fileResource.Icon, readOnlyMessage));
             }
         }
@@ -176,24 +177,4 @@ public partial class ResourcePickerDialogViewModel : ObservableObject
             .ToList();
     }
 
-    // Maps the writable state to its localised tooltip text. Returns null for
-    // Writable so the picker item's ReadOnlyMessage stays empty and the binding
-    // collapses the tooltip element.
-    private string? ResolveReadOnlyMessage(WritableState state)
-    {
-        var key = state switch
-        {
-            WritableState.Locked => "Resource_ReadOnly_Locked",
-            WritableState.ReadOnlyAttribute => "Resource_ReadOnly_ReadOnlyAttribute",
-            WritableState.ReadOnlyRoot => "Resource_ReadOnly_ReadOnlyRoot",
-            _ => null,
-        };
-
-        if (key is null)
-        {
-            return null;
-        }
-
-        return _stringLocalizer.GetString(key).Value;
-    }
 }

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerItem.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/ResourcePickerItem.cs
@@ -19,7 +19,44 @@ public class ResourcePickerItem
     /// </summary>
     public string DisplayTextLower { get; }
 
-    public ResourcePickerItem(IResource resource, ResourceKey resourceKey, FileIconDefinition iconDefinition)
+    /// <summary>
+    /// The writable state of the underlying resource, sourced from the
+    /// ProjectTreeBuilder-populated cache on IResource.
+    /// </summary>
+    public WritableState WritableState => Resource.WritableState;
+
+    /// <summary>
+    /// Whether the resource refuses edits. Drives the dimming binding and the
+    /// visibility of the read-only tooltip.
+    /// </summary>
+    public bool IsReadOnly => WritableState != WritableState.Writable;
+
+    /// <summary>
+    /// Opacity for the icon and display text. Dimmed when read-only.
+    /// </summary>
+    public double NameOpacity => IsReadOnly ? 0.5 : 1.0;
+
+    /// <summary>
+    /// Localised explanation of why the resource is read-only. Empty when
+    /// writable. Drives AutomationProperties.HelpText so screen readers carry
+    /// the same signal as the visual dimming.
+    /// </summary>
+    public string ReadOnlyMessage { get; }
+
+    /// <summary>
+    /// The tooltip shown when the user hovers the item. Non-editable items show
+    /// the read-only reason; editable items have no tooltip (returns null so
+    /// the tooltip element does not render).
+    /// </summary>
+    public string? TooltipText => string.IsNullOrEmpty(ReadOnlyMessage)
+        ? null
+        : ReadOnlyMessage;
+
+    public ResourcePickerItem(
+        IResource resource,
+        ResourceKey resourceKey,
+        FileIconDefinition iconDefinition,
+        string? readOnlyMessage = null)
     {
         Resource = resource;
         ResourceKey = resourceKey;
@@ -31,5 +68,6 @@ public class ResourcePickerItem
             ? resourceKey.Path
             : resourceKey.ToString();
         DisplayTextLower = DisplayText.ToLowerInvariant();
+        ReadOnlyMessage = readOnlyMessage ?? string.Empty;
     }
 }

--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/ResourcePickerDialog.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/ResourcePickerDialog.xaml
@@ -113,19 +113,24 @@
       </ListView.ItemContainerStyle>
       <ListView.ItemTemplate>
         <DataTemplate x:DataType="vm:ResourcePickerItem">
-          <Grid MinHeight="32">
+          <Grid MinHeight="32"
+                ToolTipService.ToolTip="{x:Bind TooltipText}"
+                AutomationProperties.HelpText="{x:Bind ReadOnlyMessage}">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="24"/>
               <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
+            <!-- Icon dims with the name when the resource is read-only. -->
             <controls:FileIcon Grid.Column="0"
                                Size="16"
                                IconDefinition="{x:Bind IconDefinition}"
+                               Opacity="{x:Bind NameOpacity}"
                                VerticalAlignment="Center"/>
 
             <TextBlock Grid.Column="1"
                        Text="{x:Bind DisplayText}"
+                       Opacity="{x:Bind NameOpacity}"
                        VerticalAlignment="Center"
                        Margin="8,0,0,0"
                        TextTrimming="CharacterEllipsis"/>

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/document-api.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/document-api.js
@@ -146,4 +146,16 @@ export class DocumentAPI {
             handler(state);
         });
     }
+
+    /**
+     * Registers a handler for writable-state change notifications from the host.
+     * The handler receives a params object {state} where state is one of "Writable",
+     * "Locked", "ReadOnlyAttribute", or "ReadOnlyRoot". Anything other than "Writable"
+     * means the document must refuse edits; the specific reason is for tooltips and
+     * status text, not for behaviour branching.
+     * @param {Function} handler - Called with the notification params object.
+     */
+    onWritableStateChanged(handler) {
+        this.#transport.addEventListener('document/writableStateChanged', handler);
+    }
 }

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
@@ -196,6 +196,19 @@ export class Celbridge {
     async initializeDocument(handlers = {}) {
         const result = await this.initialize();
 
+        // Register the writable-state handler and seed it with the initial state
+        // from the handshake before applying content. The editor enters read-only
+        // mode (if applicable) before its first setValue, so the user never sees
+        // a brief writable window for a locked document.
+        if (handlers.onWritableStateChanged) {
+            // Subscribe the callback to future host-pushed state changes.
+            this.document.onWritableStateChanged(handlers.onWritableStateChanged);
+            if (result.writableState) {
+                // Invoke the callback directly with the initial state from the handshake.
+                handlers.onWritableStateChanged({ state: result.writableState });
+            }
+        }
+
         if (handlers.onContent) {
             await handlers.onContent(result.content, result.metadata);
         }
@@ -210,9 +223,6 @@ export class Celbridge {
         }
         if (handlers.onRestoreState) {
             this.document.onRestoreState(handlers.onRestoreState);
-        }
-        if (handlers.onWritableStateChanged) {
-            this.document.onWritableStateChanged(handlers.onWritableStateChanged);
         }
 
         this.document.notifyContentLoaded();

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
@@ -188,6 +188,9 @@ export class Celbridge {
      *   The returned string must round-trip through `onRestoreState` with equivalent editor behavior.
      * @param {Function} [handlers.onRestoreState] - Called with a state string previously returned
      *   from `onRequestState` to restore editor view state.
+     * @param {Function} [handlers.onWritableStateChanged] - Called with `{state}` when the document's
+     *   writable state changes. `state` is one of "Writable", "Locked", "ReadOnlyAttribute", or
+     *   "ReadOnlyRoot"; treat anything other than "Writable" as read-only.
      * @returns {Promise<InitializeResult>} - The initialization result with content and config.
      */
     async initializeDocument(handlers = {}) {
@@ -207,6 +210,9 @@ export class Celbridge {
         }
         if (handlers.onRestoreState) {
             this.document.onRestoreState(handlers.onRestoreState);
+        }
+        if (handlers.onWritableStateChanged) {
+            this.document.onWritableStateChanged(handlers.onWritableStateChanged);
         }
 
         this.document.notifyContentLoaded();

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
@@ -191,6 +191,22 @@ describe('Celbridge', () => {
             expect(handler).toHaveBeenCalledOnce();
         });
 
+        it('should dispatch writable-state-changed notifications with the state payload', async () => {
+            const { client, simulateResponse, simulateNotification } = createTestClient();
+
+            const initPromise = client.initialize();
+            simulateResponse(1, { content: '', metadata: {}, localization: {}, theme: {} });
+            await initPromise;
+
+            const handler = vi.fn();
+            client.document.onWritableStateChanged(handler);
+
+            simulateNotification('document/writableStateChanged', { state: 'Locked' });
+
+            expect(handler).toHaveBeenCalledOnce();
+            expect(handler).toHaveBeenCalledWith({ state: 'Locked' });
+        });
+
         it('should handle language change notifications', async () => {
             const { client, simulateResponse, simulateNotification } = createTestClient();
 

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
@@ -207,6 +207,46 @@ describe('Celbridge', () => {
             expect(handler).toHaveBeenCalledWith({ state: 'Locked' });
         });
 
+        it('initializeDocument seeds onWritableStateChanged from the initialize response before applying content', async () => {
+            const { client, simulateResponse } = createTestClient();
+
+            const onWritableStateChanged = vi.fn();
+            const onContent = vi.fn();
+            const initPromise = client.initializeDocument({ onContent, onWritableStateChanged });
+
+            simulateResponse(1, {
+                content: '# Locked file',
+                metadata: { filePath: '/locked.md', resourceKey: 'locked.md', fileName: 'locked.md' },
+                writableState: 'Locked',
+            });
+
+            await initPromise;
+
+            expect(onWritableStateChanged).toHaveBeenCalledOnce();
+            expect(onWritableStateChanged).toHaveBeenCalledWith({ state: 'Locked' });
+
+            // Ordering: the writable-state seed runs before content is applied, so the
+            // editor enters read-only mode before its first setValue.
+            expect(onWritableStateChanged.mock.invocationCallOrder[0])
+                .toBeLessThan(onContent.mock.invocationCallOrder[0]);
+        });
+
+        it('initializeDocument omits the writable-state seed when the response carries no value', async () => {
+            const { client, simulateResponse } = createTestClient();
+
+            const onWritableStateChanged = vi.fn();
+            const initPromise = client.initializeDocument({ onWritableStateChanged });
+
+            simulateResponse(1, {
+                content: '',
+                metadata: {},
+            });
+
+            await initPromise;
+
+            expect(onWritableStateChanged).not.toHaveBeenCalled();
+        });
+
         it('should handle language change notifications', async () => {
             const { client, simulateResponse, simulateNotification } = createTestClient();
 

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -279,7 +279,8 @@ export class EditorController {
         onInitialContent,
         onExternalReloadContent,
         onRequestState,
-        onRestoreState
+        onRestoreState,
+        onWritableStateChanged
     } = {}) {
         // Initialize the host connection, load content, and register handlers.
         // notifyContentLoaded() is called automatically after this completes.
@@ -308,6 +309,9 @@ export class EditorController {
                 // instrumentation.
                 log('editor: writable state', { state, readOnly });
                 this.#editor.updateOptions({ readOnly });
+                if (onWritableStateChanged) {
+                    onWritableStateChanged({ state, readOnly });
+                }
             },
             onRequestState,
             onRestoreState

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -301,6 +301,10 @@ export class EditorController {
             onExternalChange: async () => {
                 await this.#handleExternalChange(onExternalReloadContent);
             },
+            onWritableStateChanged: ({ state }) => {
+                const readOnly = state !== 'Writable';
+                this.#editor.updateOptions({ readOnly });
+            },
             onRequestState,
             onRestoreState
         });

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -303,6 +303,10 @@ export class EditorController {
             },
             onWritableStateChanged: ({ state }) => {
                 const readOnly = state !== 'Writable';
+                // Logged so a user-reported "stuck read-only" can be diagnosed
+                // from the WebView2 console without re-running with extra
+                // instrumentation.
+                log('editor: writable state', { state, readOnly });
                 this.#editor.updateOptions({ readOnly });
             },
             onRequestState,

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -275,6 +275,11 @@ export class EditorController {
         }
     }
 
+    /**
+     * Initialize the host connection, load content, and register handlers.
+     * notifyContentLoaded() is called automatically after this completes.
+     * The `onWritableStateChanged` callback receives `{state, readOnly}`.
+     */
     async initializeHost({
         onInitialContent,
         onExternalReloadContent,
@@ -282,8 +287,6 @@ export class EditorController {
         onRestoreState,
         onWritableStateChanged
     } = {}) {
-        // Initialize the host connection, load content, and register handlers.
-        // notifyContentLoaded() is called automatically after this completes.
         log('editor: initializeHost starting');
         await celbridge.initializeDocument({
             onContent: (content, metadata) => {
@@ -303,6 +306,10 @@ export class EditorController {
                 await this.#handleExternalChange(onExternalReloadContent);
             },
             onWritableStateChanged: ({ state }) => {
+                // Derive readOnly once and forward both fields so Code Editor
+                // consumers can destructure either without recomputing the
+                // predicate. Diverges from the celbridge.js contract, which
+                // forwards {state} only.
                 const readOnly = state !== 'Writable';
                 // Logged so a user-reported "stuck read-only" can be diagnosed
                 // from the WebView2 console without re-running with extra

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/main.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/main.js
@@ -9,7 +9,7 @@ import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
 import { EditorController } from './editor-controller.js';
 import { ViewMode } from './view-mode-controller.js';
 import { PreviewPipeline } from './preview-pipeline.js';
-import { initializeToolbar } from './toolbar.js';
+import { initializeToolbar, setToolbarReadOnly } from './toolbar.js';
 import { initializeLanguageMap, getLanguageForFile } from './language-mapper.js';
 import { log } from './logger.js';
 
@@ -112,7 +112,13 @@ async function initialize() {
                 previewPipeline?.handleExternalReload(content);
             },
             onRequestState: () => captureState(),
-            onRestoreState: (stateJson) => restoreState(stateJson)
+            onRestoreState: (stateJson) => restoreState(stateJson),
+            onWritableStateChanged: ({ readOnly }) => {
+                // Monaco's readOnly option blocks keyboard input, but the
+                // toolbar's mutating affordances (snippet insertion) wrap it
+                // and would otherwise sneak edits past the option.
+                setToolbarReadOnly(readOnly);
+            }
         });
     } catch (ex) {
         console.error('Failed to initialize host connection:', ex);

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/toolbar.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/toolbar.js
@@ -9,6 +9,15 @@ import { ViewMode } from './view-mode-controller.js';
 import { t } from 'https://shared.celbridge/celbridge-client/localization.js';
 import { getSnippetSet } from './snippets.js';
 
+// Module-scope state for the snippet button's effective disabled flag. The
+// button has nowhere to insert into when the editor pane is hidden (Preview
+// mode), and the writable-state contract forbids inserting into a read-only
+// document. Track both inputs and let `syncSnippetButton` apply the combined
+// state, so the two gates can fire in any order without one clobbering the
+// other.
+let snippetButtonViewMode = ViewMode.Source;
+let snippetButtonReadOnly = false;
+
 export function initializeToolbar({
     showViewMode,
     showSnippets,
@@ -58,11 +67,35 @@ export function initializeToolbar({
  * hidden, so the button goes disabled in Preview mode.
  */
 export function syncSnippetButtonForViewMode(activeMode) {
+    snippetButtonViewMode = activeMode;
+    syncSnippetButton();
+}
+
+/**
+ * Updates the toolbar's gating on the document's writable state. The snippet
+ * inserter mutates the editor buffer; when the document is read-only the
+ * button must visibly match the editor's actual behaviour. Pair the menu
+ * close with the disable so an open menu doesn't strand an active popup over
+ * a now-disabled trigger.
+ */
+export function setToolbarReadOnly(isReadOnly) {
+    snippetButtonReadOnly = isReadOnly === true;
+    syncSnippetButton();
+    if (snippetButtonReadOnly) {
+        const snippetMenu = document.getElementById('snippet-menu');
+        if (snippetMenu && !snippetMenu.hidden) {
+            closeMenu(snippetMenu);
+        }
+    }
+}
+
+function syncSnippetButton() {
     const snippetButton = document.getElementById('snippet-button');
     if (!snippetButton) {
         return;
     }
-    snippetButton.disabled = activeMode === ViewMode.Preview;
+    snippetButton.disabled = snippetButtonViewMode === ViewMode.Preview
+        || snippetButtonReadOnly;
 }
 
 function attachViewModeButtons(viewModeController) {

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/editor-controller.test.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/editor-controller.test.js
@@ -31,6 +31,7 @@ function createMockEditor(model) {
         setPosition: vi.fn(),
         setScrollTop: vi.fn(),
         onDidScrollChange: vi.fn(),
+        updateOptions: vi.fn(),
         focus: vi.fn(),
         layout: vi.fn(),
         dispose: vi.fn()
@@ -114,5 +115,22 @@ describe('EditorController.handleExternalChange', () => {
         expect(editor.setValue).toHaveBeenNthCalledWith(1, 'first reload');
         expect(editor.setValue).toHaveBeenNthCalledWith(2, 'second reload');
         expect(model.applyEdits).not.toHaveBeenCalled();
+    });
+
+    it('applies Monaco readOnly and forwards the writable state to the caller', async () => {
+        const onWritableStateChanged = vi.fn();
+
+        await controller.initializeHost({ onWritableStateChanged });
+        expect(__capturedHandlers.onWritableStateChanged).toBeTypeOf('function');
+
+        __capturedHandlers.onWritableStateChanged({ state: 'Locked' });
+
+        expect(editor.updateOptions).toHaveBeenCalledWith({ readOnly: true });
+        expect(onWritableStateChanged).toHaveBeenCalledWith({ state: 'Locked', readOnly: true });
+
+        __capturedHandlers.onWritableStateChanged({ state: 'Writable' });
+
+        expect(editor.updateOptions).toHaveBeenCalledWith({ readOnly: false });
+        expect(onWritableStateChanged).toHaveBeenLastCalledWith({ state: 'Writable', readOnly: false });
     });
 });

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/fixtures/localization-stub.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/fixtures/localization-stub.js
@@ -1,0 +1,13 @@
+// Test stub for the celbridge localization module. The real module is served
+// by the WebView host at https://shared.celbridge/...; vitest aliases that URL
+// to this file so toolbar.js can be imported under jsdom without the live host
+// environment. The stub is intentionally trivial: tests only need a callable
+// `t()` that returns something stable.
+
+export function t(key) {
+    return key;
+}
+
+export function setStrings() {}
+
+export function applyLocalization() {}

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/toolbar.test.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/toolbar.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    initializeToolbar,
+    setToolbarReadOnly,
+    syncSnippetButtonForViewMode
+} from '../js/toolbar.js';
+import { ViewMode } from '../js/view-mode-controller.js';
+
+function buildToolbarDom() {
+    document.body.innerHTML = `
+        <div id="toolbar" hidden>
+            <div id="view-mode-panel" class="toolbar-panel" hidden>
+                <button id="view-mode-preview" type="button"></button>
+                <button id="view-mode-split" type="button"></button>
+                <button id="view-mode-source" type="button" aria-pressed="true"></button>
+            </div>
+            <div id="snippet-separator" class="toolbar-separator" hidden></div>
+            <div id="snippet-panel" class="toolbar-panel" hidden>
+                <button id="snippet-button" type="button" aria-haspopup="true" aria-expanded="false"></button>
+            </div>
+        </div>
+        <div id="snippet-menu" class="snippet-menu" role="menu" hidden></div>
+    `;
+}
+
+function fakeViewModeController(initialMode = ViewMode.Source) {
+    let mode = initialMode;
+    return {
+        getMode: () => mode,
+        setMode: (next) => { mode = next; }
+    };
+}
+
+function initWithSnippets() {
+    initializeToolbar({
+        showViewMode: true,
+        showSnippets: true,
+        snippetSet: 'markdown',
+        viewModeController: fakeViewModeController(),
+        onInsertSnippet: vi.fn()
+    });
+}
+
+describe('toolbar read-only gating', () => {
+    beforeEach(() => {
+        // Reset module-level state between tests by re-setting the gates to
+        // their defaults. The toolbar module retains state across imports
+        // (ES module singletons), so leaning on initialization alone leaks
+        // earlier-test state into later ones.
+        buildToolbarDom();
+        syncSnippetButtonForViewMode(ViewMode.Source);
+        setToolbarReadOnly(false);
+    });
+
+    it('disables the snippet button when read-only', () => {
+        initWithSnippets();
+        const button = document.getElementById('snippet-button');
+
+        expect(button.disabled).toBe(false);
+
+        setToolbarReadOnly(true);
+        expect(button.disabled).toBe(true);
+    });
+
+    it('re-enables the snippet button when read-only clears in Source mode', () => {
+        initWithSnippets();
+        const button = document.getElementById('snippet-button');
+
+        setToolbarReadOnly(true);
+        setToolbarReadOnly(false);
+
+        expect(button.disabled).toBe(false);
+    });
+
+    it('keeps the snippet button disabled when read-only clears but Preview mode is active', () => {
+        initWithSnippets();
+        const button = document.getElementById('snippet-button');
+
+        syncSnippetButtonForViewMode(ViewMode.Preview);
+        setToolbarReadOnly(true);
+        setToolbarReadOnly(false);
+
+        // Read-only cleared, but Preview mode still hides the editor pane —
+        // the snippet inserter has nowhere to insert into.
+        expect(button.disabled).toBe(true);
+    });
+
+    it('closes an open snippet menu when entering read-only', () => {
+        initWithSnippets();
+        const menu = document.getElementById('snippet-menu');
+        menu.hidden = false;
+
+        setToolbarReadOnly(true);
+
+        expect(menu.hidden).toBe(true);
+    });
+});

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/vitest.config.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/vitest.config.js
@@ -9,7 +9,9 @@ export default defineConfig({
             'https://shared.celbridge/celbridge-client/celbridge.js':
                 fileURLToPath(new URL('./tests/fixtures/celbridge-stub.js', import.meta.url)),
             'https://shared.celbridge/celbridge-client/api/document-api.js':
-                fileURLToPath(new URL('./tests/fixtures/document-api-stub.js', import.meta.url))
+                fileURLToPath(new URL('./tests/fixtures/document-api-stub.js', import.meta.url)),
+            'https://shared.celbridge/celbridge-client/localization.js':
+                fileURLToPath(new URL('./tests/fixtures/localization-stub.js', import.meta.url))
         }
     }
 });

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/js/file-viewer.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/js/file-viewer.js
@@ -93,7 +93,13 @@ async function initializeEditor() {
                 }
 
                 client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload);
-            }
+            },
+            // The file viewer is a read-only presentation layer with no edit
+            // mode, so writable-state changes have nothing to apply. Register
+            // an explicit no-op so adding edit affordances later forces a
+            // deliberate removal of this handler, surfacing the read-only
+            // contract in code review.
+            onWritableStateChanged: () => {}
         });
     } catch (e) {
         console.error('[FileViewer] Failed to initialize:', e);

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note.js
@@ -9,6 +9,7 @@ import { ContentLoadedReason, PROJECT_HOST_URL, projectUrl } from 'https://share
 import { createImageExtension, init as initImagePopover, toggleImage } from './note-image-popover.js';
 import { init as initLinkPopover, toggleLink } from './note-link-popover.js';
 import { createTableExtensions, init as initTablePopover, toggleTable } from './note-table-popover.js';
+import { hideAllPopovers } from './popover-utils.js';
 
 // ---------------------------------------------------------------------------
 // Table clipboard handling
@@ -102,6 +103,13 @@ let changeTimer = null;
 const CHANGE_DEBOUNCE_MS = 300;
 let projectBaseUrl = '';
 let documentBaseUrl = '';
+let isReadOnly = false;
+
+// Toolbar actions that don't mutate the document (and so stay enabled in
+// read-only mode). The TOC toggles a UI panel, undo/redo run editor commands
+// that no-op against a read-only buffer but are conceptually mutating so they
+// dim with the rest.
+const NON_MUTATING_TOOLBAR_ACTIONS = new Set(['toc']);
 
 // Get the client instance
 const client = celbridge;
@@ -205,7 +213,18 @@ const editor = new Editor({
         ...tableExtensions,
     ],
     content: '',
-    onUpdate: () => {
+    onUpdate: ({ transaction }) => {
+        // Guard against TipTap firing onUpdate without an actual content
+        // change. setEditable() emits update by default with a no-op
+        // transaction, which would otherwise mark the buffer modified and
+        // trigger an auto-save — and on a file that was just flipped to
+        // read-only, that save would strip the attribute and clobber the
+        // user's read-only choice. We also pass emitUpdate=false from
+        // applyReadOnlyState, but the docChanged check is the durable
+        // guarantee.
+        if (!transaction?.docChanged) {
+            return;
+        }
         // Debounce change notifications
         if (changeTimer) clearTimeout(changeTimer);
         changeTimer = setTimeout(() => {
@@ -369,12 +388,44 @@ document.getElementById('toc-close').addEventListener('click', () => {
     toggleToc();
 });
 
+// Applies the document's writable state to the TipTap editor and the
+// toolbar. TipTap's setEditable disables typing, paste, and drop on the
+// content surface; the toolbar handler short-circuits separately so the
+// mutating buttons can't smuggle commands past the editable flag. Open
+// mutating popovers are dismissed so a previously-spawned link/image/table
+// editor doesn't strand over a now-read-only document.
+function applyReadOnlyState(readOnly) {
+    isReadOnly = readOnly === true;
+    if (editor && typeof editor.setEditable === 'function') {
+        // Pass emitUpdate=false so TipTap doesn't fire a no-op update event
+        // that the onUpdate handler would misread as "the user typed
+        // something" and use to schedule notifyChanged. Without this,
+        // toggling read-only externally would round-trip through a save and
+        // overwrite the user's read-only attribute on disk.
+        editor.setEditable(!isReadOnly, false);
+    }
+    toolbarEl.querySelectorAll('.toolbar-btn[data-action]').forEach(btn => {
+        const action = btn.dataset.action;
+        if (NON_MUTATING_TOOLBAR_ACTIONS.has(action)) {
+            return;
+        }
+        btn.disabled = isReadOnly;
+    });
+    if (isReadOnly) {
+        hideAllPopovers();
+    }
+}
+
 // Main toolbar click handler
 toolbarEl.addEventListener('click', (e) => {
     const btn = e.target.closest('.toolbar-btn[data-action]');
     if (!btn) return;
 
     const action = btn.dataset.action;
+
+    if (isReadOnly && !NON_MUTATING_TOOLBAR_ACTIONS.has(action)) {
+        return;
+    }
 
     switch (action) {
         case 'bold': editor.chain().focus().toggleBold().run(); break;
@@ -475,7 +526,13 @@ async function initializeEditor() {
                         console.warn('[Note] Failed to parse content as JSON, using empty document');
                     }
                 }
-                editor.commands.setContent(jsonContent);
+                // Suppress the update event: loading the document is initialization,
+                // not a user edit. Without this, the empty-to-loaded transition fires
+                // onUpdate with docChanged=true, which schedules notifyChanged and
+                // triggers an auto-save attempt before the user has touched anything.
+                // For a locked file the policy denies the write and the user sees a
+                // bogus "save failed" alert seconds after opening.
+                editor.commands.setContent(jsonContent, { emitUpdate: false });
 
                 // Show the editor
                 editorWrapperEl.classList.add('visible');
@@ -496,7 +553,10 @@ async function initializeEditor() {
                 try {
                     const { content } = await client.document.load();
                     const jsonContent = content ? JSON.parse(content) : { type: 'doc', content: [{ type: 'paragraph' }] };
-                    editor.commands.setContent(jsonContent);
+                    // emitUpdate=false: an external reload is the disk overwriting the
+                    // buffer, not a user edit. Letting it fire onUpdate would queue an
+                    // immediate counter-save that races the reload we just took.
+                    editor.commands.setContent(jsonContent, { emitUpdate: false });
                 } catch (e) {
                     console.error('[Note] Failed to reload content:', e);
                 }
@@ -525,6 +585,9 @@ async function initializeEditor() {
                 } catch (e) {
                     console.error('[Note] Failed to restore state:', e);
                 }
+            },
+            onWritableStateChanged: ({ state }) => {
+                applyReadOnlyState(state !== 'Writable');
             }
         });
     } catch (e) {

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/SceneViewer/screenplay.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/SceneViewer/screenplay.js
@@ -48,7 +48,12 @@ async function initializeEditor() {
                 // editor state to preserve, but emitting the signal keeps the reload contract
                 // uniform across editors and avoids the framework's 5s timeout.
                 client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload);
-            }
+            },
+            // Screenplay is a read-only presentation layer with no edit mode,
+            // so writable-state changes have nothing to apply. The explicit
+            // no-op locks in the read-only contract: a future edit-mode
+            // addition has to deliberately remove this handler.
+            onWritableStateChanged: () => {}
         });
     } catch (e) {
         console.error('[Screenplay] Failed to initialize:', e);

--- a/Source/Modules/Celbridge.Spreadsheet/Package/index.html
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/index.html
@@ -40,6 +40,18 @@
             pointer-events: auto;
             text-decoration: none;
         }
+
+        /* Read-only overlay. Toggled by showReadOnlyOverlay() in
+           spreadsheet.js; sits above the designer + badge so it absorbs
+           every pointer event before SpreadJS sees it. */
+        #readonly-overlay {
+            position: fixed;
+            inset: 0;
+            z-index: 20000;
+            background: rgba(220, 220, 220, 0.35);
+            display: none;
+            cursor: not-allowed;
+        }
     </style>
 
 </head>

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -224,11 +224,8 @@ function applyWritableState(state) {
     showReadOnlyOverlay(frameworkReadOnly);
 }
 
-// Translucent full-viewport overlay above the SpreadJS designer. Absorbs all
-// pointer events; the visual wash is the read-only cue. Chosen over gating
-// individual SpreadJS options because that surface is too large to cover
-// reliably (sheet protection, workbook tabs, designer ribbon are all
-// separate tiers).
+// Visual cue and pointer-event sink. Not the durable read-only block — the
+// frameworkReadOnly gates above are what stop saves.
 function showReadOnlyOverlay(visible) {
     let overlay = document.getElementById('readonly-overlay');
     if (!overlay) {

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -12,6 +12,11 @@ const client = celbridge;
 
 let designer = null;
 
+// True when the host has signalled the file is read-only. Drives the
+// translucent overlay and gates the notifyChanged paths below so events
+// fired during the locked window can't queue a save.
+let frameworkReadOnly = false;
+
 async function deserializeExcelData(base64Data, viewState = null, preserveView = true) {
     if (!base64Data) {
         client.document.notifyImportComplete(true);
@@ -174,20 +179,22 @@ function listenForChanges() {
     const workbook = designer.getWorkbook();
     const commandManager = workbook.commandManager();
 
-    // SpreadJS doesn't have a unified way to detect when the spreadsheet is modified,
-    // but as all modifications are performed via the command system we can just
-    // listen for any executing commands and assume that the data has changed.
-    // Note that mouse-driven selection changes do not flow through commandManager,
-    // so the SelectionChanged hook in bindSheetEvents covers that gap.
+    // Every edit flows through a command, so listening to all commands stands
+    // in for a "doc modified" signal SpreadJS doesn't expose directly. Mouse-
+    // driven selection changes bypass commandManager — SelectionChanged in
+    // bindSheetEvents covers that gap.
     commandManager.addListener('appListener', (args) => {
+        if (frameworkReadOnly) return;
         client.document.notifyChanged();
     });
 
-    // ActiveSheetChanged is workbook-scoped and survives spread.import().
-    // SelectionChanged is sheet-scoped and is dropped when import rebuilds
-    // worksheets, so it's re-bound from bindSheetEvents after every import.
+    // ActiveSheetChanged is workbook-scoped and survives spread.import();
+    // SelectionChanged is per-sheet and gets dropped on import, so it's
+    // re-bound from bindSheetEvents.
     workbook.bind(GC.Spread.Sheets.Events.ActiveSheetChanged, () => {
-        client.document.notifyChanged();
+        if (!frameworkReadOnly) {
+            client.document.notifyChanged();
+        }
         bindSheetEvents();
     });
 
@@ -203,11 +210,43 @@ function bindSheetEvents() {
             const sheet = workbook.getSheet(i);
             sheet.unbind(GC.Spread.Sheets.Events.SelectionChanged);
             sheet.bind(GC.Spread.Sheets.Events.SelectionChanged, () => {
+                if (frameworkReadOnly) return;
                 client.document.notifyChanged();
             });
         }
     } catch (error) {
         console.warn('[Spreadsheet] Failed to bind sheet selection events:', error);
+    }
+}
+
+function applyWritableState(state) {
+    frameworkReadOnly = state !== 'Writable';
+    showReadOnlyOverlay(frameworkReadOnly);
+}
+
+// Translucent full-viewport overlay above the SpreadJS designer. Absorbs all
+// pointer events; the visual wash is the read-only cue. Chosen over gating
+// individual SpreadJS options because that surface is too large to cover
+// reliably (sheet protection, workbook tabs, designer ribbon are all
+// separate tiers).
+function showReadOnlyOverlay(visible) {
+    let overlay = document.getElementById('readonly-overlay');
+    if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.id = 'readonly-overlay';
+        overlay.setAttribute('aria-label', 'Spreadsheet is read-only');
+        overlay.setAttribute('role', 'status');
+        document.body.appendChild(overlay);
+    }
+    overlay.style.display = visible ? 'block' : 'none';
+
+    // Drop focus so a keypress can't land in a cell editor that was active
+    // when the file got locked externally.
+    if (visible
+        && document.activeElement
+        && document.activeElement !== document.body
+        && typeof document.activeElement.blur === 'function') {
+        document.activeElement.blur();
     }
 }
 
@@ -266,7 +305,11 @@ async function initializeEditor() {
                     client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload);
                 },
                 onRequestState: () => null,
-                onRestoreState: () => {}
+                onRestoreState: () => {},
+                // No designer to protect, but the bridge contract still
+                // requires an explicit handler so the editor-unavailable
+                // path matches the live-editor path.
+                onWritableStateChanged: () => {}
             });
             return;
         }
@@ -329,6 +372,9 @@ async function initializeEditor() {
                 } catch (e) {
                     console.warn('[Spreadsheet] Failed to restore view state:', e);
                 }
+            },
+            onWritableStateChanged: ({ state }) => {
+                applyWritableState(state);
             }
         });
     } catch (e) {

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -134,8 +134,11 @@ public class DocumentTabViewModelTests
     }
 
     [Test]
-    public async Task CloseDocument_SchedulesResourceUpdate_WhenSaveFailsOnCachedWritable()
+    public async Task CloseDocument_SchedulesResourceUpdate_WhenSaveFailsAndViewStillReportsWritable()
     {
+        // A save failure against a view whose WritableState still reads Writable
+        // suggests an external attribute flip slipped past the watcher. The close
+        // path schedules a resource update so the cache catches up.
         var documentView = Substitute.For<IDocumentView>();
         documentView.CanClose().Returns(Task.FromResult(true));
         documentView.HasUnsavedChanges.Returns(true);

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -19,7 +19,11 @@ public class DocumentTabViewModelTests
     private ICommandService _commandService = null!;
     private ILogger<DocumentTabViewModel> _logger = null!;
     private IResourceFileSystem _resourceFileSystem = null!;
+    private IResourceRegistry _resourceRegistry = null!;
+    private IResourceOperationService _resourceOperations = null!;
+    private IResourceService _resourceService = null!;
     private IWorkspaceWrapper _workspaceWrapper = null!;
+    private readonly List<DocumentTabViewModel> _createdViewModels = new();
 
     [SetUp]
     public void Setup()
@@ -32,17 +36,50 @@ public class DocumentTabViewModelTests
         var existingFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.None);
         _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>()).Returns(Result<StorageItemInfo>.Ok(existingFileInfo));
 
-        var resourceRegistry = Substitute.For<IResourceRegistry>();
+        _resourceRegistry = Substitute.For<IResourceRegistry>();
+        // Default to "not in registry" so stale OnResourceRegistryUpdatedMessage
+        // handlers from prior tests (kept alive by the WeakReferenceMessenger)
+        // don't null-deref when a new test broadcasts a registry-updated message.
+        _resourceRegistry.GetResource(Arg.Any<ResourceKey>())
+            .Returns(Result<IResource>.Fail("not found"));
 
-        var resourceService = Substitute.For<IResourceService>();
-        resourceService.Registry.Returns(resourceRegistry);
-        resourceService.FileSystem.Returns(_resourceFileSystem);
+        _resourceOperations = Substitute.For<IResourceOperationService>();
+        _resourceOperations.GetWritableStateAsync(Arg.Any<ResourceKey>()).Returns(WritableState.Writable);
+
+        _resourceService = Substitute.For<IResourceService>();
+        _resourceService.Registry.Returns(_resourceRegistry);
+        _resourceService.FileSystem.Returns(_resourceFileSystem);
+        _resourceService.Operations.Returns(_resourceOperations);
 
         var workspaceService = Substitute.For<IWorkspaceService>();
-        workspaceService.ResourceService.Returns(resourceService);
+        workspaceService.ResourceService.Returns(_resourceService);
 
         _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
         _workspaceWrapper.WorkspaceService.Returns(workspaceService);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // The shared WeakReferenceMessenger keeps live registrations across tests
+        // until GC. Unregister every view model the test created so its message
+        // handlers don't fire against torn-down test state in later tests.
+        foreach (var viewModel in _createdViewModels)
+        {
+            _messengerService.UnregisterAll(viewModel);
+        }
+        _createdViewModels.Clear();
+    }
+
+    private DocumentTabViewModel CreateViewModel(ResourceKey fileResource, IDocumentView? documentView = null)
+    {
+        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
+        {
+            FileResource = fileResource,
+            DocumentView = documentView!,
+        };
+        _createdViewModels.Add(viewModel);
+        return viewModel;
     }
 
     [Test]
@@ -53,11 +90,7 @@ public class DocumentTabViewModelTests
         documentView.HasUnsavedChanges.Returns(true);
         documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Fail("simulated save failure")));
 
-        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
-        {
-            FileResource = new ResourceKey("locked.md"),
-            DocumentView = documentView,
-        };
+        var viewModel = CreateViewModel(new ResourceKey("locked.md"), documentView);
 
         var result = await viewModel.CloseDocument(forceClose: false);
 
@@ -74,11 +107,7 @@ public class DocumentTabViewModelTests
         documentView.HasUnsavedChanges.Returns(true);
         documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Ok()));
 
-        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
-        {
-            FileResource = new ResourceKey("writable.md"),
-            DocumentView = documentView,
-        };
+        var viewModel = CreateViewModel(new ResourceKey("writable.md"), documentView);
 
         var result = await viewModel.CloseDocument(forceClose: false);
 
@@ -94,11 +123,7 @@ public class DocumentTabViewModelTests
         documentView.CanClose().Returns(Task.FromResult(false));
         documentView.HasUnsavedChanges.Returns(true);
 
-        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
-        {
-            FileResource = new ResourceKey("vetoed.md"),
-            DocumentView = documentView,
-        };
+        var viewModel = CreateViewModel(new ResourceKey("vetoed.md"), documentView);
 
         var result = await viewModel.CloseDocument(forceClose: false);
 
@@ -106,5 +131,94 @@ public class DocumentTabViewModelTests
         result.Value.Should().Be(CloseDocumentOutcome.Cancelled);
         await documentView.DidNotReceive().SaveDocument();
         await documentView.DidNotReceive().PrepareToClose();
+    }
+
+    [Test]
+    public async Task CloseDocument_SchedulesResourceUpdate_WhenSaveFailsOnCachedWritable()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(true));
+        documentView.HasUnsavedChanges.Returns(true);
+        documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Fail("simulated save failure")));
+        documentView.WritableState.Returns(WritableState.Writable);
+
+        var viewModel = CreateViewModel(new ResourceKey("stale.md"), documentView);
+
+        await viewModel.CloseDocument(forceClose: false);
+
+        _commandService.ReceivedWithAnyArgs(1).Execute<IUpdateResourcesCommand>();
+    }
+
+    [Test]
+    public async Task CloseDocument_DoesNotScheduleResourceUpdate_WhenCacheAlreadyKnowsNonWritable()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(true));
+        documentView.HasUnsavedChanges.Returns(true);
+        documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Fail("simulated save failure")));
+        documentView.WritableState.Returns(WritableState.Locked);
+
+        var viewModel = CreateViewModel(new ResourceKey("locked.md"), documentView);
+
+        await viewModel.CloseDocument(forceClose: false);
+
+        _commandService.DidNotReceiveWithAnyArgs().Execute<IUpdateResourcesCommand>();
+    }
+
+    [Test]
+    public void ResourceRegistryUpdated_RequeriesAndAppliesNewWritableState_WhenStateHasChanged()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.WritableState.Returns(WritableState.Writable);
+
+        var fileResource = new ResourceKey("file.md");
+        var resource = Substitute.For<IResource>();
+        _resourceRegistry.GetResource(fileResource).Returns(Result<IResource>.Ok(resource));
+        _resourceOperations.GetWritableStateAsync(fileResource).Returns(WritableState.ReadOnlyAttribute);
+
+        var viewModel = CreateViewModel(fileResource, documentView);
+
+        _messengerService.Send(new ResourceRegistryUpdatedMessage());
+
+        documentView.Received(1).SetWritableState(WritableState.ReadOnlyAttribute);
+    }
+
+    [Test]
+    public void ResourceRegistryUpdated_RequeriesAndAppliesNewWritableState_OnUnsetDirection()
+    {
+        // Mirrors the user-visible "clear read-only externally" path: the cached
+        // state transitions from ReadOnlyAttribute back to Writable and the editor
+        // must lose its read-only signal.
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.WritableState.Returns(WritableState.ReadOnlyAttribute);
+
+        var fileResource = new ResourceKey("file.md");
+        var resource = Substitute.For<IResource>();
+        _resourceRegistry.GetResource(fileResource).Returns(Result<IResource>.Ok(resource));
+        _resourceOperations.GetWritableStateAsync(fileResource).Returns(WritableState.Writable);
+
+        var viewModel = CreateViewModel(fileResource, documentView);
+
+        _messengerService.Send(new ResourceRegistryUpdatedMessage());
+
+        documentView.Received(1).SetWritableState(WritableState.Writable);
+    }
+
+    [Test]
+    public void ResourceRegistryUpdated_SkipsSetWritableState_WhenStateIsUnchanged()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.WritableState.Returns(WritableState.Writable);
+
+        var fileResource = new ResourceKey("file.md");
+        var resource = Substitute.For<IResource>();
+        _resourceRegistry.GetResource(fileResource).Returns(Result<IResource>.Ok(resource));
+        _resourceOperations.GetWritableStateAsync(fileResource).Returns(WritableState.Writable);
+
+        var viewModel = CreateViewModel(fileResource, documentView);
+
+        _messengerService.Send(new ResourceRegistryUpdatedMessage());
+
+        documentView.DidNotReceive().SetWritableState(Arg.Any<WritableState>());
     }
 }

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -1,0 +1,110 @@
+using Celbridge.Commands;
+using Celbridge.Documents.ViewModels;
+using Celbridge.Messaging;
+using Celbridge.Messaging.Services;
+using Celbridge.Resources;
+using Celbridge.Workspace;
+
+namespace Celbridge.Tests.Documents;
+
+/// <summary>
+/// Tests for DocumentTabViewModel close-path behaviour. The save-failure tolerance is
+/// load-bearing for locked or otherwise read-only documents, where the save will never
+/// succeed and the close path must still complete.
+/// </summary>
+[TestFixture]
+public class DocumentTabViewModelTests
+{
+    private IMessengerService _messengerService = null!;
+    private ICommandService _commandService = null!;
+    private ILogger<DocumentTabViewModel> _logger = null!;
+    private IResourceFileSystem _resourceFileSystem = null!;
+    private IWorkspaceWrapper _workspaceWrapper = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _messengerService = new MessengerService();
+        _commandService = Substitute.For<ICommandService>();
+        _logger = Substitute.For<ILogger<DocumentTabViewModel>>();
+
+        _resourceFileSystem = Substitute.For<IResourceFileSystem>();
+        var existingFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.None);
+        _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>()).Returns(Result<StorageItemInfo>.Ok(existingFileInfo));
+
+        var resourceRegistry = Substitute.For<IResourceRegistry>();
+
+        var resourceService = Substitute.For<IResourceService>();
+        resourceService.Registry.Returns(resourceRegistry);
+        resourceService.FileSystem.Returns(_resourceFileSystem);
+
+        var workspaceService = Substitute.For<IWorkspaceService>();
+        workspaceService.ResourceService.Returns(resourceService);
+
+        _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+        _workspaceWrapper.WorkspaceService.Returns(workspaceService);
+    }
+
+    [Test]
+    public async Task CloseDocument_CompletesAsClosed_WhenSaveFails()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(true));
+        documentView.HasUnsavedChanges.Returns(true);
+        documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Fail("simulated save failure")));
+
+        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
+        {
+            FileResource = new ResourceKey("locked.md"),
+            DocumentView = documentView,
+        };
+
+        var result = await viewModel.CloseDocument(forceClose: false);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(CloseDocumentOutcome.Closed);
+        await documentView.Received(1).PrepareToClose();
+    }
+
+    [Test]
+    public async Task CloseDocument_CompletesAsClosed_WhenSaveSucceeds()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(true));
+        documentView.HasUnsavedChanges.Returns(true);
+        documentView.SaveDocument().Returns(Task.FromResult<Result>(Result.Ok()));
+
+        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
+        {
+            FileResource = new ResourceKey("writable.md"),
+            DocumentView = documentView,
+        };
+
+        var result = await viewModel.CloseDocument(forceClose: false);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(CloseDocumentOutcome.Closed);
+        await documentView.Received(1).PrepareToClose();
+    }
+
+    [Test]
+    public async Task CloseDocument_ReturnsCancelled_WhenViewVetoesClose()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(false));
+        documentView.HasUnsavedChanges.Returns(true);
+
+        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
+        {
+            FileResource = new ResourceKey("vetoed.md"),
+            DocumentView = documentView,
+        };
+
+        var result = await viewModel.CloseDocument(forceClose: false);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(CloseDocumentOutcome.Cancelled);
+        await documentView.DidNotReceive().SaveDocument();
+        await documentView.DidNotReceive().PrepareToClose();
+    }
+}

--- a/Source/Tests/FileSystem/FakeFileSystem.cs
+++ b/Source/Tests/FileSystem/FakeFileSystem.cs
@@ -207,19 +207,21 @@ public sealed class FakeFileSystem : ILocalFileSystem
         var entries = new List<FileSystemEntry>(folderPaths.Count + filePaths.Count);
         foreach (var folder in folderPaths)
         {
-            entries.Add(new FileSystemEntry(folder, IsFolder: true, Size: 0, ModifiedUtc: DateTime.UtcNow));
+            entries.Add(new FileSystemEntry(folder, IsFolder: true, Size: 0, ModifiedUtc: DateTime.UtcNow, Attributes: FileSystemAttributes.None));
         }
         foreach (var file in filePaths)
         {
             long size = 0;
             DateTime modifiedUtc = default;
+            var attributes = FileSystemAttributes.None;
             if (_files.TryGetValue(file, out var fileEntry))
             {
                 size = fileEntry.Bytes.Length;
                 modifiedUtc = fileEntry.ModifiedUtc;
+                attributes = fileEntry.Attributes;
             }
 
-            entries.Add(new FileSystemEntry(file, IsFolder: false, Size: size, ModifiedUtc: modifiedUtc));
+            entries.Add(new FileSystemEntry(file, IsFolder: false, Size: size, ModifiedUtc: modifiedUtc, Attributes: attributes));
         }
 
         IReadOnlyList<FileSystemEntry> list = entries;

--- a/Source/Tests/Host/CelbridgeHostTests.cs
+++ b/Source/Tests/Host/CelbridgeHostTests.cs
@@ -1,4 +1,5 @@
 using Celbridge.Host;
+using Celbridge.Resources;
 
 namespace Celbridge.Tests.Host;
 
@@ -66,6 +67,28 @@ public class CelbridgeHostTests
         _channel.SentMessages.Should().HaveCount(1);
         _channel.SentMessages[0].Should().Contain("document/externalChange");
         _channel.SentMessages[0].Should().Contain("preserveViewState");
+    }
+
+    [Test]
+    public async Task NotifyWritableStateChangedAsync_SendsCorrectMethodWithStateName()
+    {
+        _host.StartListening();
+
+        await _host.NotifyWritableStateChangedAsync(WritableState.Locked);
+
+        _channel.SentMessages.Should().HaveCount(1);
+        _channel.SentMessages[0].Should().Contain("document/writableStateChanged");
+        _channel.SentMessages[0].Should().Contain("\"state\":\"Locked\"");
+    }
+
+    [Test]
+    public async Task NotifyWritableStateChangedAsync_SendsWritableWhenDocumentIsEditable()
+    {
+        _host.StartListening();
+
+        await _host.NotifyWritableStateChangedAsync(WritableState.Writable);
+
+        _channel.SentMessages[0].Should().Contain("\"state\":\"Writable\"");
     }
 
     [Test]

--- a/Source/Tests/Resources/GetWritableStateTests.cs
+++ b/Source/Tests/Resources/GetWritableStateTests.cs
@@ -148,6 +148,60 @@ public class GetWritableStateTests
         state.Should().Be(WritableState.Locked);
     }
 
+    [Test]
+    public void WritableStatePriority_LockedTakesPriority_OverReadOnlyRoot()
+    {
+        // Pinned at the helper so a future refactor that swaps the branch order
+        // is caught. The live fallback can't reach this scenario today
+        // (ResourcePolicy.Evaluate short-circuits non-default roots), but the
+        // helper's contract is the source of truth for priority and a future
+        // policy implementation could produce it.
+        var policy = Substitute.For<IResourcePolicy>();
+        policy.Evaluate(Arg.Any<ResourceKey>(), ResourceAction.Write, Arg.Any<bool>())
+            .Returns(Result.Fail("locked"));
+
+        var bundledHandler = Substitute.For<IResourceRootHandler>();
+        bundledHandler.Capabilities.Returns(new ResourceRootCapabilities(IsWritable: false, IsWatched: false));
+        var rootHandlerRegistry = Substitute.For<IRootHandlerRegistry>();
+        rootHandlerRegistry.RootHandlers.Returns(new Dictionary<string, IResourceRootHandler>
+        {
+            ["bundled"] = bundledHandler,
+        });
+
+        var state = WritableStatePriority.Compute(
+            new ResourceKey("bundled:docs/readme.md"),
+            isFolder: false,
+            attributes: FileSystemAttributes.None,
+            policy,
+            rootHandlerRegistry);
+
+        state.Should().Be(WritableState.Locked);
+    }
+
+    [Test]
+    public async Task ReadOnlyRootTakesPriority_OverReadOnlyAttribute()
+    {
+        // A read-only-root file with the OS read-only bit also set reports
+        // ReadOnlyRoot. The structural source names the more durable cause
+        // (bundled root never becomes writable; the attribute can be cleared).
+        var bundledHandler = Substitute.For<IResourceRootHandler>();
+        bundledHandler.Capabilities.Returns(new ResourceRootCapabilities(IsWritable: false, IsWatched: false));
+        _rootHandlerRegistry.RootHandlers.Returns(new Dictionary<string, IResourceRootHandler>
+        {
+            ["bundled"] = bundledHandler,
+        });
+
+        var readOnlyFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.ReadOnly);
+        _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>())
+            .Returns(Result<StorageItemInfo>.Ok(readOnlyFileInfo));
+
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("bundled:docs/readme.md"));
+
+        state.Should().Be(WritableState.ReadOnlyRoot);
+    }
+
     private ResourceOperationService CreateOperationService()
     {
         return new ResourceOperationService(

--- a/Source/Tests/Resources/GetWritableStateTests.cs
+++ b/Source/Tests/Resources/GetWritableStateTests.cs
@@ -1,0 +1,152 @@
+using Celbridge.Projects;
+using Celbridge.Resources;
+using Celbridge.Resources.Services;
+using Celbridge.Tests.FileSystem;
+using Celbridge.Workspace;
+
+namespace Celbridge.Tests.Resources;
+
+/// <summary>
+/// Tests the four outcomes of ResourceOperationService.GetWritableStateAsync:
+/// writable, configured lock pattern, OS read-only attribute, and read-only
+/// root. The query is the single source of truth for the editor and at-rest
+/// dimming surfaces, so each source needs its own coverage.
+/// </summary>
+[TestFixture]
+public class GetWritableStateTests
+{
+    private IResourceFileSystem _resourceFileSystem = null!;
+    private IRootHandlerRegistry _rootHandlerRegistry = null!;
+    private IResourceService _resourceService = null!;
+    private IWorkspaceWrapper _workspaceWrapper = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _resourceFileSystem = Substitute.For<IResourceFileSystem>();
+
+        // Default file probe: an existing regular file with no read-only bit.
+        // Per-test overrides reset this for the ReadOnlyAttribute case.
+        var writableFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.None);
+        _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>())
+            .Returns(Result<StorageItemInfo>.Ok(writableFileInfo));
+
+        _rootHandlerRegistry = Substitute.For<IRootHandlerRegistry>();
+        _rootHandlerRegistry.RootHandlers.Returns(new Dictionary<string, IResourceRootHandler>());
+
+        _resourceService = Substitute.For<IResourceService>();
+        _resourceService.FileSystem.Returns(_resourceFileSystem);
+        _resourceService.RootHandlers.Returns(_rootHandlerRegistry);
+        _resourceService.Policy.Returns(TestResourcePolicy.CreateDefault());
+
+        var workspaceService = Substitute.For<IWorkspaceService>();
+        workspaceService.ResourceService.Returns(_resourceService);
+
+        _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+        _workspaceWrapper.WorkspaceService.Returns(workspaceService);
+        _workspaceWrapper.IsWorkspacePageLoaded.Returns(false);
+    }
+
+    [Test]
+    public async Task ReturnsWritable_ForRegularFile()
+    {
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("notes/todo.md"));
+
+        state.Should().Be(WritableState.Writable);
+    }
+
+    [Test]
+    public async Task ReturnsLocked_ForFileMatchingLockPattern()
+    {
+        var policy = BuildPolicyWithLockPattern("assets/**");
+        _resourceService.Policy.Returns(policy);
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("assets/logo.png"));
+
+        state.Should().Be(WritableState.Locked);
+    }
+
+    [Test]
+    public async Task ReturnsReadOnlyRoot_ForFileOnNonWritableRoot()
+    {
+        var bundledHandler = Substitute.For<IResourceRootHandler>();
+        bundledHandler.Capabilities.Returns(new ResourceRootCapabilities(IsWritable: false, IsWatched: false));
+        _rootHandlerRegistry.RootHandlers.Returns(new Dictionary<string, IResourceRootHandler>
+        {
+            ["bundled"] = bundledHandler,
+        });
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("bundled:docs/readme.md"));
+
+        state.Should().Be(WritableState.ReadOnlyRoot);
+    }
+
+    [Test]
+    public async Task ReturnsReadOnlyAttribute_WhenFileCarriesReadOnlyBit()
+    {
+        var readOnlyFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.ReadOnly);
+        _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>())
+            .Returns(Result<StorageItemInfo>.Ok(readOnlyFileInfo));
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("notes/todo.md"));
+
+        state.Should().Be(WritableState.ReadOnlyAttribute);
+    }
+
+    [Test]
+    public async Task LockedTakesPriority_OverReadOnlyAttribute()
+    {
+        // A locked file with the OS read-only bit also set reports Locked.
+        // Locked names a configured policy a user can edit; ReadOnlyAttribute
+        // names ambient state. Locked is the more actionable cause.
+        var policy = BuildPolicyWithLockPattern("assets/**");
+        _resourceService.Policy.Returns(policy);
+
+        var readOnlyFileInfo = new StorageItemInfo(StorageItemKind.File, 0, DateTime.UtcNow, FileSystemAttributes.ReadOnly);
+        _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>())
+            .Returns(Result<StorageItemInfo>.Ok(readOnlyFileInfo));
+
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("assets/logo.png"));
+
+        state.Should().Be(WritableState.Locked);
+    }
+
+    private ResourceOperationService CreateOperationService()
+    {
+        return new ResourceOperationService(
+            Substitute.For<ILogger<ResourceOperationService>>(),
+            _workspaceWrapper,
+            TestFileSystem.CreateLocal());
+    }
+
+    private static ResourcePolicy BuildPolicyWithLockPattern(string pattern)
+    {
+        var section = new ResourcesSection
+        {
+            Lock = new[] { pattern },
+        };
+        var config = new ProjectConfig { Resources = section };
+
+        var project = Substitute.For<IProject>();
+        project.Config.Returns(config);
+        project.ProjectFolderPath.Returns(@"C:\fake\project");
+
+        var projectService = Substitute.For<IProjectService>();
+        projectService.CurrentProject.Returns(project);
+
+        var fileSystem = Substitute.For<ILocalFileSystem>();
+        fileSystem.ReadAllTextAsync(Arg.Any<string>())
+            .Returns(Task.FromResult(Result<string>.Fail("ignore-file not found")));
+
+        var policy = new ResourcePolicy(projectService, fileSystem);
+        policy.InitializeAsync().GetAwaiter().GetResult();
+        return policy;
+    }
+}

--- a/Source/Tests/Resources/GetWritableStateTests.cs
+++ b/Source/Tests/Resources/GetWritableStateTests.cs
@@ -1,5 +1,6 @@
 using Celbridge.Projects;
 using Celbridge.Resources;
+using Celbridge.Resources.Models;
 using Celbridge.Resources.Services;
 using Celbridge.Tests.FileSystem;
 using Celbridge.Workspace;
@@ -16,6 +17,7 @@ namespace Celbridge.Tests.Resources;
 public class GetWritableStateTests
 {
     private IResourceFileSystem _resourceFileSystem = null!;
+    private IResourceRegistry _resourceRegistry = null!;
     private IRootHandlerRegistry _rootHandlerRegistry = null!;
     private IResourceService _resourceService = null!;
     private IWorkspaceWrapper _workspaceWrapper = null!;
@@ -31,10 +33,17 @@ public class GetWritableStateTests
         _resourceFileSystem.GetInfoAsync(Arg.Any<ResourceKey>())
             .Returns(Result<StorageItemInfo>.Ok(writableFileInfo));
 
+        // These tests exercise the live-computation fallback for keys outside
+        // the registry, so GetResource returns Fail for every key.
+        _resourceRegistry = Substitute.For<IResourceRegistry>();
+        _resourceRegistry.GetResource(Arg.Any<ResourceKey>())
+            .Returns(Result<IResource>.Fail("not in registry"));
+
         _rootHandlerRegistry = Substitute.For<IRootHandlerRegistry>();
         _rootHandlerRegistry.RootHandlers.Returns(new Dictionary<string, IResourceRootHandler>());
 
         _resourceService = Substitute.For<IResourceService>();
+        _resourceService.Registry.Returns(_resourceRegistry);
         _resourceService.FileSystem.Returns(_resourceFileSystem);
         _resourceService.RootHandlers.Returns(_rootHandlerRegistry);
         _resourceService.Policy.Returns(TestResourcePolicy.CreateDefault());
@@ -96,6 +105,27 @@ public class GetWritableStateTests
         var state = await operationService.GetWritableStateAsync(new ResourceKey("notes/todo.md"));
 
         state.Should().Be(WritableState.ReadOnlyAttribute);
+    }
+
+    [Test]
+    public async Task ReturnsCachedState_WhenResourceIsInRegistry()
+    {
+        // ProjectTreeBuilder populates IResource.WritableState during the
+        // project walk; the query short-circuits on a registry hit and never
+        // touches the policy, root handlers, or the file system.
+        var cachedResource = new FolderResource("assets", null);
+        cachedResource.WritableState = WritableState.Locked;
+
+        _resourceRegistry.GetResource(Arg.Any<ResourceKey>())
+            .Returns(Result<IResource>.Ok(cachedResource));
+
+        var operationService = CreateOperationService();
+
+        var state = await operationService.GetWritableStateAsync(new ResourceKey("assets"));
+
+        state.Should().Be(WritableState.Locked);
+        // The cached path bypasses the gateway entirely.
+        await _resourceFileSystem.DidNotReceive().GetInfoAsync(Arg.Any<ResourceKey>());
     }
 
     [Test]

--- a/Source/Tests/Resources/LocalResourceFileSystemTests.cs
+++ b/Source/Tests/Resources/LocalResourceFileSystemTests.cs
@@ -18,6 +18,7 @@ public class LocalResourceFileSystemTests
     private IResourceRegistry _resourceRegistry = null!;
     private IRootHandlerRegistry _rootHandlerRegistry = null!;
     private IResourceScanner _resourceScanner = null!;
+    private IResourceOperationService _operationService = null!;
     private IMessengerService _messengerService = null!;
     private LocalResourceFileSystem _resourceFileSystem = null!;
 
@@ -49,9 +50,17 @@ public class LocalResourceFileSystemTests
         _rootHandlerRegistry.GetResourceKey(Arg.Any<string>())
             .Returns(Result<ResourceKey>.Fail("not stubbed"));
 
+        // Default the writable cache to Writable so existing tests behave as
+        // they did before the read-only-strip gate was added. The two tests
+        // that exercise the gate override this stub explicitly.
+        _operationService = Substitute.For<IResourceOperationService>();
+        _operationService.GetWritableStateAsync(Arg.Any<ResourceKey>())
+            .Returns(Task.FromResult(WritableState.Writable));
+
         var resourceService = Substitute.For<IResourceService>();
         resourceService.Registry.Returns(_resourceRegistry);
         resourceService.RootHandlers.Returns(_rootHandlerRegistry);
+        resourceService.Operations.Returns(_operationService);
 
         var workspaceService = Substitute.For<IWorkspaceService>();
         workspaceService.ResourceService.Returns(resourceService);
@@ -854,6 +863,63 @@ public class LocalResourceFileSystemTests
         var result = await _resourceFileSystem.CreateFolderAsync(folder);
 
         result.IsFailure.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task WriteAllBytesAsync_StripsReadOnlyAttribute_WhenStateIsWritable()
+    {
+        // The cache reports Writable, so an on-disk read-only attribute is
+        // treated as stale. The write strips it and succeeds.
+        var resource = new ResourceKey("writable.bin");
+        var path = Path.Combine(_tempFolder, "writable.bin");
+        await File.WriteAllBytesAsync(path, new byte[] { 0x00 });
+        new FileInfo(path).IsReadOnly = true;
+
+        _resourceRegistry.ResolveResourcePath(resource).Returns(Result<string>.Ok(path));
+        _operationService.GetWritableStateAsync(resource)
+            .Returns(Task.FromResult(WritableState.Writable));
+
+        var bytes = new byte[] { 0xAA, 0xBB };
+        var result = await _resourceFileSystem.WriteAllBytesAsync(resource, bytes);
+
+        result.IsSuccess.Should().BeTrue();
+        new FileInfo(path).IsReadOnly.Should().BeFalse();
+        (await File.ReadAllBytesAsync(path)).Should().Equal(bytes);
+    }
+
+    [Test]
+    public async Task WriteAllBytesAsync_PreservesReadOnlyAttribute_AndFails_WhenStateIsReadOnlyAttribute()
+    {
+        // The cache reports ReadOnlyAttribute, so the gate refuses to strip
+        // the on-disk attribute. The underlying write throws
+        // UnauthorizedAccessException, which the gateway surfaces as a
+        // failure, and the read-only attribute is preserved.
+        var resource = new ResourceKey("readonly.bin");
+        var path = Path.Combine(_tempFolder, "readonly.bin");
+        var originalBytes = new byte[] { 0x01, 0x02 };
+        await File.WriteAllBytesAsync(path, originalBytes);
+        new FileInfo(path).IsReadOnly = true;
+
+        try
+        {
+            _resourceRegistry.ResolveResourcePath(resource).Returns(Result<string>.Ok(path));
+            _operationService.GetWritableStateAsync(resource)
+                .Returns(Task.FromResult(WritableState.ReadOnlyAttribute));
+
+            var result = await _resourceFileSystem.WriteAllBytesAsync(resource, new byte[] { 0xAA, 0xBB });
+
+            result.IsFailure.Should().BeTrue();
+            new FileInfo(path).IsReadOnly.Should().BeTrue();
+            (await File.ReadAllBytesAsync(path)).Should().Equal(originalBytes);
+        }
+        finally
+        {
+            // Tear-down needs the file to be writable so the temp-folder delete works.
+            if (File.Exists(path))
+            {
+                new FileInfo(path).IsReadOnly = false;
+            }
+        }
     }
 
     [Test]

--- a/Source/Tests/Resources/ProjectTreeBuilderTestHelper.cs
+++ b/Source/Tests/Resources/ProjectTreeBuilderTestHelper.cs
@@ -22,7 +22,8 @@ internal static class ProjectTreeBuilderTestHelper
     public static ProjectTreeBuilder Build(
         string projectFolderPath,
         IFileIconService? fileIconService = null,
-        bool useProjectIgnoreFile = false)
+        bool useProjectIgnoreFile = false,
+        string[]? lockPatterns = null)
     {
         var resourceRegistry = Substitute.For<IResourceRegistry>();
         resourceRegistry.ProjectFolderPath.Returns(projectFolderPath);
@@ -46,7 +47,7 @@ internal static class ProjectTreeBuilderTestHelper
         // Build the policy into a local before configuring the substitute: when
         // it stands up its own substitutes, doing so inline inside Returns(...)
         // would corrupt NSubstitute's last-call context.
-        var policy = BuildPolicy(projectFolderPath, useProjectIgnoreFile);
+        var policy = BuildPolicy(projectFolderPath, useProjectIgnoreFile, lockPatterns);
         resourceService.Policy.Returns(policy);
 
         var workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
@@ -62,15 +63,20 @@ internal static class ProjectTreeBuilderTestHelper
         return new ProjectTreeBuilder(fileIconService ?? new FileIconService(), workspaceWrapper);
     }
 
-    private static IResourcePolicy BuildPolicy(string projectFolderPath, bool useProjectIgnoreFile)
+    private static IResourcePolicy BuildPolicy(string projectFolderPath, bool useProjectIgnoreFile, string[]? lockPatterns)
     {
-        if (!useProjectIgnoreFile)
+        if (!useProjectIgnoreFile
+            && (lockPatterns is null || lockPatterns.Length == 0))
         {
             return TestResourcePolicy.CreateDefault();
         }
 
+        var resources = lockPatterns is null
+            ? new ResourcesSection()
+            : new ResourcesSection { Lock = lockPatterns };
+
         var project = Substitute.For<IProject>();
-        project.Config.Returns(new ProjectConfig());
+        project.Config.Returns(new ProjectConfig { Resources = resources });
         project.ProjectFolderPath.Returns(projectFolderPath);
 
         var projectService = Substitute.For<IProjectService>();

--- a/Source/Tests/Resources/ProjectTreeBuilderTests.cs
+++ b/Source/Tests/Resources/ProjectTreeBuilderTests.cs
@@ -1,3 +1,4 @@
+using Celbridge.Resources;
 using Celbridge.Resources.Models;
 using Celbridge.Resources.Services;
 
@@ -102,6 +103,62 @@ public class ProjectTreeBuilderTests
         var names = buildResult.Value.Children.Select(c => c.Name).ToList();
         names.Should().Contain(new[] { "src", "visible.txt", ".editorconfig" });
         names.Should().NotContain(new[] { ".vscode", "secret.txt" });
+    }
+
+    [Test]
+    public async Task BuildTree_PopulatesWritableState_ForRegularFile()
+    {
+        File.WriteAllText(Path.Combine(_projectFolderPath, "notes.txt"), "x");
+
+        var buildResult = await _builder.BuildTreeAsync();
+
+        buildResult.IsSuccess.Should().BeTrue();
+        var file = buildResult.Value.Children.Single(c => c.Name == "notes.txt");
+        file.WritableState.Should().Be(WritableState.Writable);
+    }
+
+    [Test]
+    public async Task BuildTree_PopulatesLockedWritableState_ForFileMatchingLockPattern()
+    {
+        File.WriteAllText(Path.Combine(_projectFolderPath, "config.toml"), "x");
+        File.WriteAllText(Path.Combine(_projectFolderPath, "notes.txt"), "y");
+
+        var builder = ProjectTreeBuilderTestHelper.Build(_projectFolderPath, lockPatterns: new[] { "config.toml" });
+        var buildResult = await builder.BuildTreeAsync();
+
+        buildResult.IsSuccess.Should().BeTrue();
+        var configFile = buildResult.Value.Children.Single(c => c.Name == "config.toml");
+        configFile.WritableState.Should().Be(WritableState.Locked);
+
+        // A sibling that does not match the lock pattern stays writable.
+        var notesFile = buildResult.Value.Children.Single(c => c.Name == "notes.txt");
+        notesFile.WritableState.Should().Be(WritableState.Writable);
+    }
+
+    [Test]
+    public async Task BuildTree_PopulatesReadOnlyAttributeWritableState_ForFileWithReadOnlyBit()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("OS read-only attribute behaviour is exercised on Windows.");
+        }
+
+        var readOnlyPath = Path.Combine(_projectFolderPath, "frozen.txt");
+        File.WriteAllText(readOnlyPath, "x");
+        File.SetAttributes(readOnlyPath, File.GetAttributes(readOnlyPath) | FileAttributes.ReadOnly);
+        try
+        {
+            var buildResult = await _builder.BuildTreeAsync();
+
+            buildResult.IsSuccess.Should().BeTrue();
+            var file = buildResult.Value.Children.Single(c => c.Name == "frozen.txt");
+            file.WritableState.Should().Be(WritableState.ReadOnlyAttribute);
+        }
+        finally
+        {
+            // Clear the bit so TearDown can delete the temp folder cleanly.
+            File.SetAttributes(readOnlyPath, File.GetAttributes(readOnlyPath) & ~FileAttributes.ReadOnly);
+        }
     }
 
     [Test]

--- a/Source/Tests/UserInterface/ReadOnlyMessageHelperTests.cs
+++ b/Source/Tests/UserInterface/ReadOnlyMessageHelperTests.cs
@@ -1,0 +1,63 @@
+using Celbridge.Resources;
+using Celbridge.UserInterface.Helpers;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Tests for the state-to-resw-key mapping that drives every read-only dimming
+/// surface (explorer tree, file picker, future breadcrumb). Pinning the key per
+/// state catches a renamed resw entry before it breaks tooltips in production.
+/// </summary>
+[TestFixture]
+public class ReadOnlyMessageHelperTests
+{
+    private IStringLocalizer _localizer = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _localizer = Substitute.For<IStringLocalizer>();
+        // IStringLocalizer.GetString(string) is an extension method that calls
+        // the indexer at runtime, so the indexer is what NSubstitute can stub.
+        _localizer[Arg.Any<string>()].Returns(callInfo =>
+        {
+            // Echo "localized:<key>" so each test can assert on which key was
+            // looked up without having to wire a full resw stub.
+            var key = (string)callInfo[0];
+            return new LocalizedString(key, $"localized:{key}");
+        });
+    }
+
+    [Test]
+    public void Writable_ReturnsNull_SoTooltipBindingCollapses()
+    {
+        var message = ReadOnlyMessageHelper.GetReadOnlyMessage(WritableState.Writable, _localizer);
+
+        message.Should().BeNull();
+    }
+
+    [Test]
+    public void Locked_ResolvesResource_ReadOnly_Locked_Key()
+    {
+        var message = ReadOnlyMessageHelper.GetReadOnlyMessage(WritableState.Locked, _localizer);
+
+        message.Should().Be("localized:Resource_ReadOnly_Locked");
+    }
+
+    [Test]
+    public void ReadOnlyAttribute_ResolvesResource_ReadOnly_ReadOnlyAttribute_Key()
+    {
+        var message = ReadOnlyMessageHelper.GetReadOnlyMessage(WritableState.ReadOnlyAttribute, _localizer);
+
+        message.Should().Be("localized:Resource_ReadOnly_ReadOnlyAttribute");
+    }
+
+    [Test]
+    public void ReadOnlyRoot_ResolvesResource_ReadOnly_ReadOnlyRoot_Key()
+    {
+        var message = ReadOnlyMessageHelper.GetReadOnlyMessage(WritableState.ReadOnlyRoot, _localizer);
+
+        message.Should().Be("localized:Resource_ReadOnly_ReadOnlyRoot");
+    }
+}

--- a/Source/Tests/UserInterface/ResourcePickerItemTests.cs
+++ b/Source/Tests/UserInterface/ResourcePickerItemTests.cs
@@ -1,0 +1,82 @@
+using Celbridge.Resources;
+using Celbridge.UserInterface;
+using Celbridge.UserInterface.ViewModels;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Tests for the read-only state surface that the resource picker uses to render
+/// dimming, tooltip, and assistive-tech labelling.
+/// </summary>
+[TestFixture]
+public class ResourcePickerItemTests
+{
+    private static readonly FileIconDefinition Icon =
+        new("a", "#FFFFFF", "Segoe Fluent Icons", "16");
+
+    [Test]
+    public void Writable_ResourceProducesFullOpacityNoTooltipNoHelpText()
+    {
+        var resource = Substitute.For<IResource>();
+        resource.WritableState.Returns(WritableState.Writable);
+
+        var item = new ResourcePickerItem(resource, new ResourceKey("docs/photo.png"), Icon);
+
+        item.IsReadOnly.Should().BeFalse();
+        item.NameOpacity.Should().Be(1.0);
+        item.TooltipText.Should().BeNull();
+        item.ReadOnlyMessage.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Locked_ResourceProducesDimmedOpacityAndTooltip()
+    {
+        var resource = Substitute.For<IResource>();
+        resource.WritableState.Returns(WritableState.Locked);
+
+        var item = new ResourcePickerItem(
+            resource,
+            new ResourceKey("Data/frozen.bin"),
+            Icon,
+            readOnlyMessage: "Locked by project configuration.");
+
+        item.IsReadOnly.Should().BeTrue();
+        item.NameOpacity.Should().Be(0.5);
+        item.TooltipText.Should().Be("Locked by project configuration.");
+        item.ReadOnlyMessage.Should().Be("Locked by project configuration.");
+    }
+
+    [Test]
+    public void ReadOnlyAttribute_ResourceProducesDimmedOpacityAndTooltip()
+    {
+        var resource = Substitute.For<IResource>();
+        resource.WritableState.Returns(WritableState.ReadOnlyAttribute);
+
+        var item = new ResourcePickerItem(
+            resource,
+            new ResourceKey("notes.txt"),
+            Icon,
+            readOnlyMessage: "File is read-only on disk.");
+
+        item.IsReadOnly.Should().BeTrue();
+        item.NameOpacity.Should().Be(0.5);
+        item.TooltipText.Should().Be("File is read-only on disk.");
+    }
+
+    [Test]
+    public void ReadOnlyRoot_ResourceProducesDimmedOpacityAndTooltip()
+    {
+        var resource = Substitute.For<IResource>();
+        resource.WritableState.Returns(WritableState.ReadOnlyRoot);
+
+        var item = new ResourcePickerItem(
+            resource,
+            new ResourceKey("bundled:image.png"),
+            Icon,
+            readOnlyMessage: "Bundled package — read-only by design.");
+
+        item.IsReadOnly.Should().BeTrue();
+        item.NameOpacity.Should().Be(0.5);
+        item.TooltipText.Should().Be("Bundled package — read-only by design.");
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -240,6 +240,12 @@ public class DocumentsService : IDocumentsService, IDisposable
                 .WithErrors(setFileResult);
         }
 
+        // Queried after SetFileResource so the operation service sees the
+        // resolved file kind through the gateway.
+        var operationService = _workspaceWrapper.WorkspaceService.ResourceService.Operations;
+        var writableState = await operationService.GetWritableStateAsync(fileResource);
+        documentView.SetWritableState(writableState);
+
         var loadResult = await documentView.LoadContent();
         if (loadResult.IsFailure)
         {

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -240,8 +240,10 @@ public class DocumentsService : IDocumentsService, IDisposable
                 .WithErrors(setFileResult);
         }
 
-        // Queried after SetFileResource so the operation service sees the
-        // resolved file kind through the gateway.
+        // Applied after SetFileResource and before LoadContent so the editor
+        // enters read-only mode before its first setValue. For ContributionDocumentView
+        // the state ships through the document/initialize handshake; for editors
+        // that drive their surface directly, OnWritableStateChanged fires here.
         var operationService = _workspaceWrapper.WorkspaceService.ResourceService.Operations;
         var writableState = await operationService.GetWritableStateAsync(fileResource);
         documentView.SetWritableState(writableState);

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -131,6 +131,9 @@ public partial class DocumentTabViewModel : ObservableObject
         {
             // This open document's resource has been renamed just prior to this registry update.
             // Tell the document service to update the file resource for the document.
+            // The writable-state refresh below is skipped on this path: DocumentsService
+            // re-binds the document for the new key (see OpenDocument), which calls
+            // SetWritableState through the open flow.
 
             var oldResource = _pendingResourceKeyChangedMessage.SourceResource;
             var newResource = _pendingResourceKeyChangedMessage.DestResource;

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -7,7 +8,8 @@ namespace Celbridge.Documents.ViewModels;
 
 /// <summary>
 /// Describes the result of a successful call to DocumentTabViewModel.CloseDocument.
-/// A Result.Fail is still reserved for genuine errors (save failure, etc.).
+/// Result.Fail is reserved for genuine framework errors. A failing save during close
+/// is logged and the close proceeds, discarding the unsaved edits.
 /// </summary>
 public enum CloseDocumentOutcome
 {
@@ -26,6 +28,7 @@ public partial class DocumentTabViewModel : ObservableObject
 {
     private readonly IMessengerService _messengerService;
     private readonly ICommandService _commandService;
+    private readonly ILogger<DocumentTabViewModel> _logger;
     private readonly IResourceRegistry _resourceRegistry;
 
     [ObservableProperty]
@@ -80,10 +83,12 @@ public partial class DocumentTabViewModel : ObservableObject
     public DocumentTabViewModel(
         IMessengerService messengerService,
         ICommandService commandService,
+        ILogger<DocumentTabViewModel> logger,
         IWorkspaceWrapper workspaceWrapper)
     {
         _messengerService = messengerService;
         _commandService = commandService;
+        _logger = logger;
         _workspaceWrapper = workspaceWrapper;
         _resourceRegistry = workspaceWrapper.WorkspaceService.ResourceService.Registry;
 
@@ -211,8 +216,10 @@ public partial class DocumentTabViewModel : ObservableObject
             var saveResult = await DocumentView.SaveDocument();
             if (saveResult.IsFailure)
             {
-                return Result<CloseDocumentOutcome>.Fail($"Saving document failed for file resource: '{FileResource}'")
-                    .WithErrors(saveResult);
+                // A non-editable document (locked file, read-only attribute) or any other
+                // permanently-refused save would otherwise jam the close path forever.
+                // Discard the unsaved edits and proceed to teardown.
+                _logger.LogWarning(saveResult, $"Saving document failed during close. Discarding unsaved edits for file resource: '{FileResource}'");
             }
         }
 

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -138,33 +138,46 @@ public partial class DocumentTabViewModel : ObservableObject
 
             var documentMessage = new DocumentResourceChangedMessage(oldResource, newResource);
             _messengerService.Send(documentMessage);
+            return;
         }
-        else
-        {
-            // Check if the open document is in the updated resource registry
-            var getResult = _resourceRegistry.GetResource(FileResource);
-            if (getResult.IsFailure)
-            {
-                // The file may have been temporarily deleted as part of a "write temp, delete original,
-                // rename temp" save pattern used by some editors and coding agents. Check if the file
-                // still exists on disk before closing. The resource registry may not have caught up
-                // with the rename yet.
-                var resourceFileSystem = _workspaceWrapper.WorkspaceService.ResourceService.FileSystem;
-                var infoResult = await resourceFileSystem.GetInfoAsync(FileResource);
-                if (infoResult.IsSuccess
-                    && infoResult.Value.Kind == StorageItemKind.File)
-                {
-                    return;
-                }
 
-                // The resource no longer exists, so close the document.
-                // We force the close operation because the resource no longer exists.
-                // We use a command instead of calling CloseDocument() directly to help avoid race conditions.
-                _commandService.Execute<ICloseDocumentCommand>(command =>
-                {
-                    command.FileResource = FileResource;
-                    command.ForceClose = true;
-                });
+        // Check if the open document is in the updated resource registry
+        var getResult = _resourceRegistry.GetResource(FileResource);
+        if (getResult.IsFailure)
+        {
+            // The file may have been temporarily deleted as part of a "write temp, delete original,
+            // rename temp" save pattern used by some editors and coding agents. Check if the file
+            // still exists on disk before closing. The resource registry may not have caught up
+            // with the rename yet.
+            var resourceFileSystem = _workspaceWrapper.WorkspaceService.ResourceService.FileSystem;
+            var infoResult = await resourceFileSystem.GetInfoAsync(FileResource);
+            if (infoResult.IsSuccess
+                && infoResult.Value.Kind == StorageItemKind.File)
+            {
+                return;
+            }
+
+            // The resource no longer exists, so close the document.
+            // We force the close operation because the resource no longer exists.
+            // We use a command instead of calling CloseDocument() directly to help avoid race conditions.
+            _commandService.Execute<ICloseDocumentCommand>(command =>
+            {
+                command.FileResource = FileResource;
+                command.ForceClose = true;
+            });
+            return;
+        }
+
+        // Re-apply the writable state to the open document so external attribute
+        // changes (or any other source-of-truth refresh) propagate into the editor's
+        // read-only signal without reopening the document.
+        if (DocumentView is not null)
+        {
+            var operationService = _workspaceWrapper.WorkspaceService.ResourceService.Operations;
+            var refreshedState = await operationService.GetWritableStateAsync(FileResource);
+            if (refreshedState != DocumentView.WritableState)
+            {
+                DocumentView.SetWritableState(refreshedState);
             }
         }
     }
@@ -220,6 +233,15 @@ public partial class DocumentTabViewModel : ObservableObject
                 // permanently-refused save would otherwise jam the close path forever.
                 // Discard the unsaved edits and proceed to teardown.
                 _logger.LogWarning(saveResult, $"Saving document failed during close. Discarding unsaved edits for file resource: '{FileResource}'");
+
+                // If the cached writable state still reads Writable, an external
+                // attribute change probably slipped past the watcher. Schedule a
+                // resource update so the cache catches up; debouncing inside the
+                // resource service coalesces bursts.
+                if (DocumentView.WritableState == WritableState.Writable)
+                {
+                    _commandService.Execute<IUpdateResourcesCommand>();
+                }
             }
         }
 

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentHandler.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentHandler.cs
@@ -1,6 +1,7 @@
 using Celbridge.Documents.ViewModels;
 using Celbridge.Host;
 using Celbridge.Logging;
+using Celbridge.Resources;
 
 namespace Celbridge.Documents.Views;
 
@@ -13,6 +14,7 @@ internal sealed class ContributionDocumentHandler : IHostDocument
     private readonly ContributionDocumentViewModel _viewModel;
     private readonly ILogger _logger;
     private readonly Func<DocumentMetadata> _createMetadata;
+    private readonly Func<WritableState> _getWritableState;
     private readonly Func<bool> _completeSave;
 
     /// <summary>
@@ -31,11 +33,13 @@ internal sealed class ContributionDocumentHandler : IHostDocument
         ContributionDocumentViewModel viewModel,
         ILogger logger,
         Func<DocumentMetadata> createMetadata,
+        Func<WritableState> getWritableState,
         Func<bool> completeSave)
     {
         _viewModel = viewModel;
         _logger = logger;
         _createMetadata = createMetadata;
+        _getWritableState = getWritableState;
         _completeSave = completeSave;
     }
 
@@ -45,8 +49,9 @@ internal sealed class ContributionDocumentHandler : IHostDocument
 
         var content = await _viewModel.LoadTextContentAsync();
         var metadata = _createMetadata();
+        var writableState = _getWritableState().ToString();
 
-        return new InitializeResult(content, metadata);
+        return new InitializeResult(content, metadata, writableState);
     }
 
     public async Task<LoadResult> LoadAsync()

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -315,6 +315,11 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput
                 TryRegisterWithToolBridge();
             }
 
+            // The writable state was applied to the base class before LoadContent
+            // ran, so the host wasn't up to push it then. Push it now so the JS
+            // client sees the correct state on its first content-loaded pass.
+            await Host.NotifyWritableStateChangedAsync(WritableState);
+
             var entryPoint = Contribution.EntryPoint;
             var entryUrl = $"https://{Contribution.Package.HostName}/{entryPoint}";
             WebView.CoreWebView2.Navigate(entryUrl);
@@ -426,6 +431,30 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput
         if (WebView?.CoreWebView2 is not null)
         {
             ApplyThemeToWebView();
+        }
+    }
+
+    protected override void OnWritableStateChanged()
+    {
+        // Skip when the host isn't up yet; InitContributionViewAsync pushes the
+        // current state once after setup so the JS client sees it on first load.
+        if (Host is null)
+        {
+            return;
+        }
+
+        _ = NotifyWritableStateAsync();
+    }
+
+    private async Task NotifyWritableStateAsync()
+    {
+        try
+        {
+            await Host!.NotifyWritableStateChangedAsync(WritableState);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to notify contribution of writable-state change");
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -286,8 +286,9 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput
             _documentHandler = new ContributionDocumentHandler(
                 _viewModel,
                 _logger,
-                CreateDocumentMetadata, // Callback to construct document metadata on demand
-                CompleteSave);          // Callback to update state when saving has completed 
+                CreateDocumentMetadata,    // Callback to construct document metadata on demand
+                () => WritableState,       // Callback to read the current writable state at initialize time
+                CompleteSave);             // Callback to update state when saving has completed
 
             _documentHandler.ContentLoaded += SetContentLoaded;
 
@@ -314,11 +315,6 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput
             {
                 TryRegisterWithToolBridge();
             }
-
-            // The writable state was applied to the base class before LoadContent
-            // ran, so the host wasn't up to push it then. Push it now so the JS
-            // client sees the correct state on its first content-loaded pass.
-            await Host.NotifyWritableStateChangedAsync(WritableState);
 
             var entryPoint = Contribution.EntryPoint;
             var entryUrl = $"https://{Contribution.Package.HostName}/{entryPoint}";

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -432,8 +432,9 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput
 
     protected override void OnWritableStateChanged()
     {
-        // Skip when the host isn't up yet; InitContributionViewAsync pushes the
-        // current state once after setup so the JS client sees it on first load.
+        // Skip when the host isn't up yet; the initial state ships through the
+        // document/initialize handshake (InitializeResult.WritableState) so the
+        // JS client sees it on first load.
         if (Host is null)
         {
             return;

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentView.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentView.cs
@@ -104,6 +104,32 @@ public abstract partial class DocumentView : UserControl, IDocumentView
 
     public abstract Task<Result> LoadContent();
 
+    public WritableState WritableState { get; private set; } = WritableState.Writable;
+
+    /// <summary>
+    /// Applies a writable state to the document view. Stores the value and
+    /// invokes OnWritableStateChanged so concrete views can apply the state
+    /// to their native editor surface.
+    /// </summary>
+    public void SetWritableState(WritableState state)
+    {
+        if (WritableState == state)
+        {
+            return;
+        }
+
+        WritableState = state;
+        OnWritableStateChanged();
+    }
+
+    /// <summary>
+    /// Hook for concrete views to react to a writable-state change. Subclasses
+    /// override to apply the state to their native editor surface.
+    /// </summary>
+    protected virtual void OnWritableStateChanged()
+    {
+    }
+
     public virtual bool HasUnsavedChanges => false;
 
     public virtual Result<bool> UpdateSaveTimer(double deltaTime)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -529,6 +529,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         int savedCount = 0;
         int pendingSaveCount = 0;
         List<ResourceKey> failedSaves = new();
+        bool updateResourcesRequired = false;
 
         for (int i = 0; i < SectionContainer.SectionCount; i++)
         {
@@ -555,6 +556,14 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
                     {
                         // Make a note of the failed save and continue saving other documents
                         failedSaves.Add(documentTab.ViewModel.FileResource);
+
+                        // A failed save against a cache that still reads Writable
+                        // suggests an external attribute flip slipped past the
+                        // watcher. Schedule a resource update so the cache catches up.
+                        if (documentView.WritableState == WritableState.Writable)
+                        {
+                            updateResourcesRequired = true;
+                        }
                     }
                     else
                     {
@@ -562,6 +571,13 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
                     }
                 }
             }
+        }
+
+        if (updateResourcesRequired)
+        {
+            // Debounced inside the resource service so a burst of failures from
+            // many open files collapses into one project-tree rebuild.
+            _commandService.Execute<IUpdateResourcesCommand>();
         }
 
         if (failedSaves.Count > 0)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -554,15 +554,24 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
                     var saveResult = await documentView.SaveDocument();
                     if (saveResult.IsFailure)
                     {
-                        // Make a note of the failed save and continue saving other documents
-                        failedSaves.Add(documentTab.ViewModel.FileResource);
-
-                        // A failed save against a cache that still reads Writable
-                        // suggests an external attribute flip slipped past the
-                        // watcher. Schedule a resource update so the cache catches up.
+                        // A save failure against a document whose cached state is
+                        // not Writable is the expected outcome of the read-only
+                        // gate in LocalResourceFileSystem. Log it for diagnostics
+                        // but do not surface an alert, otherwise every auto-save
+                        // tick on a locked file with buffered changes would spam
+                        // the user.
                         if (documentView.WritableState == WritableState.Writable)
                         {
+                            failedSaves.Add(documentTab.ViewModel.FileResource);
+
+                            // A failed save against a cache that still reads Writable
+                            // suggests an external attribute flip slipped past the
+                            // watcher. Schedule a resource update so the cache catches up.
                             updateResourcesRequired = true;
+                        }
+                        else
+                        {
+                            _logger.LogDebug($"Skipped save for non-writable document: '{documentTab.ViewModel.FileResource}'");
                         }
                     }
                     else

--- a/Source/Workspace/Celbridge.Documents/Views/TextBoxDocumentView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/TextBoxDocumentView.xaml
@@ -9,6 +9,7 @@
     <Grid HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch">
         <TextBox
+            x:Name="DocumentTextBox"
             AcceptsReturn="True"
             IsSpellCheckEnabled="False"
             Text="{x:Bind ViewModel.Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/Source/Workspace/Celbridge.Documents/Views/TextBoxDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/TextBoxDocumentView.xaml.cs
@@ -32,4 +32,11 @@ public sealed partial class TextBoxDocumentView : DocumentView
     {
         return await ViewModel.SaveDocumentContent();
     }
+
+    protected override void OnWritableStateChanged()
+    {
+        // WinUI TextBox.IsReadOnly keeps caret, selection, and copy working and
+        // silently refuses typing.
+        DocumentTextBox.IsReadOnly = WritableState != WritableState.Writable;
+    }
 }

--- a/Source/Workspace/Celbridge.Explorer/Models/ResourceViewItem.cs
+++ b/Source/Workspace/Celbridge.Explorer/Models/ResourceViewItem.cs
@@ -62,9 +62,61 @@ public partial class ResourceViewItem : ObservableObject
         IsProjectFolder ? Visibility.Collapsed : (HasChildren ? Visibility.Visible : Visibility.Collapsed);
 
     /// <summary>
+    /// The writable state of the underlying resource, sourced from the
+    /// ProjectTreeBuilder-populated cache on IResource.
+    /// </summary>
+    public WritableState WritableState => Resource.WritableState;
+
+    /// <summary>
+    /// Whether the resource refuses edits. Drives the dimming binding and the
+    /// visibility of the read-only tooltip.
+    /// </summary>
+    public bool IsReadOnly => WritableState != WritableState.Writable;
+
+    /// <summary>
+    /// Opacity for the resource name. Dimmed when read-only.
+    /// </summary>
+    public double NameOpacity => IsReadOnly ? 0.5 : 1.0;
+
+    /// <summary>
+    /// Localised explanation of why the resource is read-only. Empty when
+    /// writable. Drives AutomationProperties.HelpText so screen readers carry
+    /// the same signal as the visual dimming.
+    /// </summary>
+    public string ReadOnlyMessage { get; }
+
+    /// <summary>
+    /// The tooltip shown when the user hovers the item. The project folder
+    /// retains its existing affordance hint; non-editable items show the
+    /// read-only reason; editable items have no tooltip (returns null so the
+    /// tooltip element does not render).
+    /// </summary>
+    public string? TooltipText
+    {
+        get
+        {
+            if (IsProjectFolder)
+            {
+                return "Double-click to open in File Explorer";
+            }
+
+            return string.IsNullOrEmpty(ReadOnlyMessage)
+                ? null
+                : ReadOnlyMessage;
+        }
+    }
+
+    /// <summary>
     /// Creates a new ResourceViewItem for the given resource.
     /// </summary>
-    public ResourceViewItem(IResource resource, int indentLevel, bool isExpanded, bool hasChildren, bool isProjectFolder = false, string? displayName = null)
+    public ResourceViewItem(
+        IResource resource,
+        int indentLevel,
+        bool isExpanded,
+        bool hasChildren,
+        bool isProjectFolder = false,
+        string? displayName = null,
+        string? readOnlyMessage = null)
     {
         Resource = resource;
         IndentLevel = indentLevel;
@@ -72,5 +124,6 @@ public partial class ResourceViewItem : ObservableObject
         HasChildren = hasChildren;
         IsProjectFolder = isProjectFolder;
         Name = displayName ?? resource.Name;
+        ReadOnlyMessage = readOnlyMessage ?? string.Empty;
     }
 }

--- a/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -4,6 +4,7 @@ using Celbridge.Explorer.Models;
 using Celbridge.Logging;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Localization;
 
 namespace Celbridge.Explorer.ViewModels;
 
@@ -14,6 +15,7 @@ public partial class ResourceTreeViewModel : ObservableObject
 {
     private readonly ILogger<ResourceTreeViewModel> _logger;
     private readonly IMessengerService _messengerService;
+    private readonly IStringLocalizer _stringLocalizer;
     private readonly IResourceRegistry _resourceRegistry;
     private readonly IFolderStateService _folderStateService;
     private readonly IDataTransferService _dataTransferService;
@@ -65,6 +67,7 @@ public partial class ResourceTreeViewModel : ObservableObject
     {
         _logger = logger;
         _messengerService = messengerService;
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _resourceRegistry = workspaceWrapper.WorkspaceService.ResourceService.Registry;
         _folderStateService = workspaceWrapper.WorkspaceService.ExplorerService.FolderStateService;
         _dataTransferService = workspaceWrapper.WorkspaceService.DataTransferService;
@@ -187,13 +190,15 @@ public partial class ResourceTreeViewModel : ObservableObject
     {
         foreach (var resource in resources)
         {
+            var readOnlyMessage = ResolveReadOnlyMessage(resource.WritableState);
+
             if (resource is IFolderResource folderResource)
             {
                 var hasChildren = folderResource.Children.Count > 0;
                 var resourceKey = _resourceRegistry.GetResourceKey(folderResource);
                 var isExpanded = _folderStateService.IsExpanded(resourceKey);
 
-                var item = new ResourceViewItem(resource, indentLevel, isExpanded, hasChildren);
+                var item = new ResourceViewItem(resource, indentLevel, isExpanded, hasChildren, readOnlyMessage: readOnlyMessage);
                 items.Add(item);
 
                 // Only add children if the folder is expanded
@@ -207,10 +212,31 @@ public partial class ResourceTreeViewModel : ObservableObject
             }
             else if (resource is IFileResource)
             {
-                var item = new ResourceViewItem(resource, indentLevel, false, false);
+                var item = new ResourceViewItem(resource, indentLevel, false, false, readOnlyMessage: readOnlyMessage);
                 items.Add(item);
             }
         }
+    }
+
+    // Maps the writable state to its localised tooltip text. Returns null for
+    // Writable so the view item's ReadOnlyMessage stays empty and the binding
+    // collapses the tooltip element.
+    private string? ResolveReadOnlyMessage(WritableState state)
+    {
+        var key = state switch
+        {
+            WritableState.Locked => "ResourceTree_ReadOnly_Locked",
+            WritableState.ReadOnlyAttribute => "ResourceTree_ReadOnly_ReadOnlyAttribute",
+            WritableState.ReadOnlyRoot => "ResourceTree_ReadOnly_ReadOnlyRoot",
+            _ => null,
+        };
+
+        if (key is null)
+        {
+            return null;
+        }
+
+        return _stringLocalizer.GetString(key).Value;
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -225,9 +225,9 @@ public partial class ResourceTreeViewModel : ObservableObject
     {
         var key = state switch
         {
-            WritableState.Locked => "ResourceTree_ReadOnly_Locked",
-            WritableState.ReadOnlyAttribute => "ResourceTree_ReadOnly_ReadOnlyAttribute",
-            WritableState.ReadOnlyRoot => "ResourceTree_ReadOnly_ReadOnlyRoot",
+            WritableState.Locked => "Resource_ReadOnly_Locked",
+            WritableState.ReadOnlyAttribute => "Resource_ReadOnly_ReadOnlyAttribute",
+            WritableState.ReadOnlyRoot => "Resource_ReadOnly_ReadOnlyRoot",
             _ => null,
         };
 

--- a/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using Celbridge.DataTransfer;
 using Celbridge.Explorer.Models;
 using Celbridge.Logging;
+using Celbridge.UserInterface.Helpers;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.Localization;
@@ -190,7 +191,7 @@ public partial class ResourceTreeViewModel : ObservableObject
     {
         foreach (var resource in resources)
         {
-            var readOnlyMessage = ResolveReadOnlyMessage(resource.WritableState);
+            var readOnlyMessage = ReadOnlyMessageHelper.GetReadOnlyMessage(resource.WritableState, _stringLocalizer);
 
             if (resource is IFolderResource folderResource)
             {
@@ -216,27 +217,6 @@ public partial class ResourceTreeViewModel : ObservableObject
                 items.Add(item);
             }
         }
-    }
-
-    // Maps the writable state to its localised tooltip text. Returns null for
-    // Writable so the view item's ReadOnlyMessage stays empty and the binding
-    // collapses the tooltip element.
-    private string? ResolveReadOnlyMessage(WritableState state)
-    {
-        var key = state switch
-        {
-            WritableState.Locked => "Resource_ReadOnly_Locked",
-            WritableState.ReadOnlyAttribute => "Resource_ReadOnly_ReadOnlyAttribute",
-            WritableState.ReadOnlyRoot => "Resource_ReadOnly_ReadOnlyRoot",
-            _ => null,
-        };
-
-        if (key is null)
-        {
-            return null;
-        }
-
-        return _stringLocalizer.GetString(key).Value;
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml
@@ -19,19 +19,14 @@
       <Grid Margin="{x:Bind IndentMargin}"
             Padding="8,0,0,0"
             MinHeight="32"
-            Background="{ThemeResource SubtleFillColorTransparentBrush}">
+            Background="{ThemeResource SubtleFillColorTransparentBrush}"
+            ToolTipService.ToolTip="{x:Bind TooltipText}"
+            AutomationProperties.HelpText="{x:Bind ReadOnlyMessage}">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="32"/>
           <ColumnDefinition Width="Auto"/>
           <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-
-        <!-- Tooltip for project folder -->
-        <ToolTipService.ToolTip>
-          <ToolTip Visibility="{x:Bind IsProjectFolder}">
-            <TextBlock Text="Double-click to open in File Explorer"/>
-          </ToolTip>
-        </ToolTipService.ToolTip>
 
         <!-- Expand/Collapse chevron button (hidden for project folder) -->
         <Button Grid.Column="0"
@@ -43,16 +38,18 @@
                     FontSize="12"/>
         </Button>
 
-        <!-- Resource icon -->
+        <!-- Resource icon. Dims with the name when the resource is read-only. -->
         <local:ResourceIcon Grid.Column="1"
                             Resource="{x:Bind Resource}"
+                            Opacity="{x:Bind NameOpacity}"
                             Margin="0,0,8,0"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Left" />
 
-        <!-- Resource name (semi-bold for project folder) -->
+        <!-- Resource name (semi-bold for project folder, dimmed when read-only) -->
         <TextBlock Grid.Column="2"
                    Text="{x:Bind Name}"
+                   Opacity="{x:Bind NameOpacity}"
                    VerticalAlignment="Center"
                    TextTrimming="CharacterEllipsis"
                    FontWeight="{x:Bind IsProjectFolder, Converter={StaticResource ProjectFolderFontWeightConverter}}" />

--- a/Source/Workspace/Celbridge.Resources/Models/Resource.cs
+++ b/Source/Workspace/Celbridge.Resources/Models/Resource.cs
@@ -24,4 +24,6 @@ public abstract partial class Resource : ObservableObject, IResource
 
     public IFolderResource? ParentFolder { get; init; }
 
+    [ObservableProperty]
+    private WritableState _writableState = WritableState.Writable;
 }

--- a/Source/Workspace/Celbridge.Resources/Services/LocalResourceFileSystem.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/LocalResourceFileSystem.cs
@@ -707,7 +707,8 @@ public sealed class LocalResourceFileSystem : IResourceFileSystem
                 Resource: childKey,
                 IsFolder: entry.IsFolder,
                 Size: entry.Size,
-                ModifiedUtc: entry.ModifiedUtc));
+                ModifiedUtc: entry.ModifiedUtc,
+                Attributes: entry.Attributes));
         }
 
         IReadOnlyList<FolderItem> result = entries;

--- a/Source/Workspace/Celbridge.Resources/Services/LocalResourceFileSystem.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/LocalResourceFileSystem.cs
@@ -870,12 +870,22 @@ public sealed class LocalResourceFileSystem : IResourceFileSystem
             return ensureParentResult;
         }
 
-        // Clear read-only so the write is not blocked by an attribute the user
-        // already chose to override by saving.
-        var clearReadOnlyResult = await _fileSystem.SetAttributesAsync(resourcePath, FileSystemAttributes.ReadOnly, set: false);
-        if (clearReadOnlyResult.IsFailure)
+        // Only strip the on-disk read-only attribute when the writable cache
+        // confirms the resource is writable. If the cache reports any non-
+        // writable state, leave the attribute in place and let the underlying
+        // write fail. This stops a stale attribute (cleared by an external
+        // tool but not yet seen by the watcher) from blocking a legitimate
+        // save, while also stopping auto-save from clobbering a read-only
+        // mark the user just applied.
+        var operationService = _workspaceWrapper.WorkspaceService.ResourceService.Operations;
+        var writableState = await operationService.GetWritableStateAsync(resource);
+        if (writableState == WritableState.Writable)
         {
-            _logger.LogDebug(clearReadOnlyResult.FirstException, $"Could not clear read-only attribute before writing '{resource}'");
+            var clearReadOnlyResult = await _fileSystem.SetAttributesAsync(resourcePath, FileSystemAttributes.ReadOnly, set: false);
+            if (clearReadOnlyResult.IsFailure)
+            {
+                _logger.LogDebug(clearReadOnlyResult.FirstException, $"Could not clear read-only attribute before writing '{resource}'");
+            }
         }
 
         var writeResult = await _fileSystem.WriteAllBytesAsync(resourcePath, bytes);

--- a/Source/Workspace/Celbridge.Resources/Services/ProjectTreeBuilder.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ProjectTreeBuilder.cs
@@ -58,7 +58,12 @@ public sealed class ProjectTreeBuilder : IProjectTreeBuilder
         foreach (var folderItem in folderItems)
         {
             var childName = folderItem.Resource.ResourceName;
-            var writableState = ComputeWritableState(folderItem, policy, rootHandlerRegistry);
+            var writableState = WritableStatePriority.Compute(
+                folderItem.Resource,
+                folderItem.IsFolder,
+                folderItem.Attributes,
+                policy,
+                rootHandlerRegistry);
 
             if (folderItem.IsFolder)
             {
@@ -91,34 +96,6 @@ public sealed class ProjectTreeBuilder : IProjectTreeBuilder
         // EnumerateFolderAsync yields folders-first, ordinal order, which matches
         // the tree's required ordering, so no re-sort is needed here.
         return Result.Ok();
-    }
-
-    // Priority mirrors IResourceOperationService.GetWritableStateAsync:
-    // Locked > ReadOnlyRoot > ReadOnlyAttribute. Configured locks dominate
-    // ambient state so a locked file on a read-only root reports Locked.
-    private static WritableState ComputeWritableState(
-        FolderItem folderItem,
-        IResourcePolicy policy,
-        IRootHandlerRegistry rootHandlerRegistry)
-    {
-        var writeResult = policy.Evaluate(folderItem.Resource, ResourceAction.Write, folderItem.IsFolder);
-        if (writeResult.IsFailure)
-        {
-            return WritableState.Locked;
-        }
-
-        if (rootHandlerRegistry.RootHandlers.TryGetValue(folderItem.Resource.Root, out var handler)
-            && !handler.Capabilities.IsWritable)
-        {
-            return WritableState.ReadOnlyRoot;
-        }
-
-        if ((folderItem.Attributes & FileSystemAttributes.ReadOnly) != 0)
-        {
-            return WritableState.ReadOnlyAttribute;
-        }
-
-        return WritableState.Writable;
     }
 
     private static string GetFileExtension(string fileName)

--- a/Source/Workspace/Celbridge.Resources/Services/ProjectTreeBuilder.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ProjectTreeBuilder.cs
@@ -38,7 +38,10 @@ public sealed class ProjectTreeBuilder : IProjectTreeBuilder
 
     private async Task<Result> SynchronizeFolderAsync(FolderResource folderResource, ResourceKey folderKey)
     {
-        var resourceFileSystem = _workspaceWrapper.WorkspaceService.ResourceService.FileSystem;
+        var resourceService = _workspaceWrapper.WorkspaceService.ResourceService;
+        var resourceFileSystem = resourceService.FileSystem;
+        var policy = resourceService.Policy;
+        var rootHandlerRegistry = resourceService.RootHandlers;
 
         var enumerateResult = await resourceFileSystem.EnumerateFolderAsync(folderKey);
         if (enumerateResult.IsFailure)
@@ -55,10 +58,12 @@ public sealed class ProjectTreeBuilder : IProjectTreeBuilder
         foreach (var folderItem in folderItems)
         {
             var childName = folderItem.Resource.ResourceName;
+            var writableState = ComputeWritableState(folderItem, policy, rootHandlerRegistry);
 
             if (folderItem.IsFolder)
             {
                 var childFolder = new FolderResource(childName, folderResource);
+                childFolder.WritableState = writableState;
 
                 var childResult = await SynchronizeFolderAsync(childFolder, folderItem.Resource);
                 if (childResult.IsFailure)
@@ -77,13 +82,43 @@ public sealed class ProjectTreeBuilder : IProjectTreeBuilder
                     ? getIconResult.Value
                     : _fileIconService.DefaultFileIcon;
 
-                folderResource.AddChild(new FileResource(childName, folderResource, iconDefinition));
+                var fileResource = new FileResource(childName, folderResource, iconDefinition);
+                fileResource.WritableState = writableState;
+                folderResource.AddChild(fileResource);
             }
         }
 
         // EnumerateFolderAsync yields folders-first, ordinal order, which matches
         // the tree's required ordering, so no re-sort is needed here.
         return Result.Ok();
+    }
+
+    // Priority mirrors IResourceOperationService.GetWritableStateAsync:
+    // Locked > ReadOnlyRoot > ReadOnlyAttribute. Configured locks dominate
+    // ambient state so a locked file on a read-only root reports Locked.
+    private static WritableState ComputeWritableState(
+        FolderItem folderItem,
+        IResourcePolicy policy,
+        IRootHandlerRegistry rootHandlerRegistry)
+    {
+        var writeResult = policy.Evaluate(folderItem.Resource, ResourceAction.Write, folderItem.IsFolder);
+        if (writeResult.IsFailure)
+        {
+            return WritableState.Locked;
+        }
+
+        if (rootHandlerRegistry.RootHandlers.TryGetValue(folderItem.Resource.Root, out var handler)
+            && !handler.Capabilities.IsWritable)
+        {
+            return WritableState.ReadOnlyRoot;
+        }
+
+        if ((folderItem.Attributes & FileSystemAttributes.ReadOnly) != 0)
+        {
+            return WritableState.ReadOnlyAttribute;
+        }
+
+        return WritableState.Writable;
     }
 
     private static string GetFileExtension(string fileName)

--- a/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
@@ -237,6 +237,38 @@ public class ResourceOperationService : IResourceOperationService
         return await FindLockingDescendantAsync(resource);
     }
 
+    public async Task<WritableState> GetWritableStateAsync(ResourceKey resource)
+    {
+        // The info probe is also reused for the OS-attribute check below so the
+        // gateway is only hit once.
+        var infoResult = await ResourceFileSystem.GetInfoAsync(resource);
+        bool isFolder = infoResult.IsSuccess
+            && infoResult.Value.Kind == StorageItemKind.Folder;
+
+        // Priority: Locked > ReadOnlyRoot > ReadOnlyAttribute. Configured locks
+        // dominate ambient state so a locked file on a read-only root still
+        // reports as Locked, which is the more actionable cause for the user.
+        var writeResult = Policy.Evaluate(resource, ResourceAction.Write, isFolder);
+        if (writeResult.IsFailure)
+        {
+            return WritableState.Locked;
+        }
+
+        if (RootHandlerRegistry.RootHandlers.TryGetValue(resource.Root, out var handler)
+            && !handler.Capabilities.IsWritable)
+        {
+            return WritableState.ReadOnlyRoot;
+        }
+
+        if (infoResult.IsSuccess
+            && (infoResult.Value.Attributes & FileSystemAttributes.ReadOnly) != 0)
+        {
+            return WritableState.ReadOnlyAttribute;
+        }
+
+        return WritableState.Writable;
+    }
+
     public async Task<ResourceLockState> GetLockStateAsync(ResourceKey resource)
     {
         var infoResult = await ResourceFileSystem.GetInfoAsync(resource);

--- a/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
@@ -248,33 +248,17 @@ public class ResourceOperationService : IResourceOperationService
         }
 
         // Live fallback for external keys not in the registry. The info probe is
-        // reused for the OS-attribute check below so the gateway is only hit once.
+        // reused so the priority helper sees both the file kind (for the policy
+        // probe) and the on-disk attributes (for the ReadOnlyAttribute source)
+        // without a second gateway hit.
         var infoResult = await ResourceFileSystem.GetInfoAsync(resource);
         bool isFolder = infoResult.IsSuccess
             && infoResult.Value.Kind == StorageItemKind.Folder;
+        var attributes = infoResult.IsSuccess
+            ? infoResult.Value.Attributes
+            : FileSystemAttributes.None;
 
-        // Priority: Locked > ReadOnlyRoot > ReadOnlyAttribute. Configured locks
-        // dominate ambient state so a locked file on a read-only root still
-        // reports as Locked, which is the more actionable cause for the user.
-        var writeResult = Policy.Evaluate(resource, ResourceAction.Write, isFolder);
-        if (writeResult.IsFailure)
-        {
-            return WritableState.Locked;
-        }
-
-        if (RootHandlerRegistry.RootHandlers.TryGetValue(resource.Root, out var handler)
-            && !handler.Capabilities.IsWritable)
-        {
-            return WritableState.ReadOnlyRoot;
-        }
-
-        if (infoResult.IsSuccess
-            && (infoResult.Value.Attributes & FileSystemAttributes.ReadOnly) != 0)
-        {
-            return WritableState.ReadOnlyAttribute;
-        }
-
-        return WritableState.Writable;
+        return WritableStatePriority.Compute(resource, isFolder, attributes, Policy, RootHandlerRegistry);
     }
 
     public async Task<ResourceLockState> GetLockStateAsync(ResourceKey resource)

--- a/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/ResourceOperationService.cs
@@ -239,8 +239,16 @@ public class ResourceOperationService : IResourceOperationService
 
     public async Task<WritableState> GetWritableStateAsync(ResourceKey resource)
     {
-        // The info probe is also reused for the OS-attribute check below so the
-        // gateway is only hit once.
+        // Tree-cached fast path: ProjectTreeBuilder populates IResource.WritableState
+        // during the project walk, so any key in the registry answers without a syscall.
+        var getResult = ResourceRegistry.GetResource(resource);
+        if (getResult.IsSuccess)
+        {
+            return getResult.Value.WritableState;
+        }
+
+        // Live fallback for external keys not in the registry. The info probe is
+        // reused for the OS-attribute check below so the gateway is only hit once.
         var infoResult = await ResourceFileSystem.GetInfoAsync(resource);
         bool isFolder = infoResult.IsSuccess
             && infoResult.Value.Kind == StorageItemKind.Folder;

--- a/Source/Workspace/Celbridge.Resources/Services/WritableStatePriority.cs
+++ b/Source/Workspace/Celbridge.Resources/Services/WritableStatePriority.cs
@@ -1,0 +1,40 @@
+namespace Celbridge.Resources.Services;
+
+/// <summary>
+/// Computes the writable state for a resource from its policy verdict, root
+/// handler, and on-disk attributes. Priority is Locked > ReadOnlyRoot >
+/// ReadOnlyAttribute — configured locks dominate ambient state.
+/// </summary>
+public static class WritableStatePriority
+{
+    /// <summary>
+    /// Evaluates the three writable-state sources in priority order and returns
+    /// the first that fires, or Writable when none does.
+    /// </summary>
+    public static WritableState Compute(
+        ResourceKey resource,
+        bool isFolder,
+        FileSystemAttributes attributes,
+        IResourcePolicy policy,
+        IRootHandlerRegistry rootHandlerRegistry)
+    {
+        var writeResult = policy.Evaluate(resource, ResourceAction.Write, isFolder);
+        if (writeResult.IsFailure)
+        {
+            return WritableState.Locked;
+        }
+
+        if (rootHandlerRegistry.RootHandlers.TryGetValue(resource.Root, out var handler)
+            && !handler.Capabilities.IsWritable)
+        {
+            return WritableState.ReadOnlyRoot;
+        }
+
+        if ((attributes & FileSystemAttributes.ReadOnly) != 0)
+        {
+            return WritableState.ReadOnlyAttribute;
+        }
+
+        return WritableState.Writable;
+    }
+}


### PR DESCRIPTION
This pull request introduces a unified writable state model for resources and documents, enabling precise tracking and communication of read-only reasons (such as project locks, OS attributes, or read-only roots) across the backend, host, and JavaScript editors. It updates core data structures, APIs, and protocols to support this, and provides documentation and helpers for consistent UI messaging and extension authoring.

**Writable State Model & API Updates:**

* Introduced the `WritableState` enum to represent and distinguish reasons for non-editability (Writable, Locked, ReadOnlyAttribute, ReadOnlyRoot) and added it to `IResource`, `IDocumentView`, and related interfaces for consistent access and mutation. [[1]](diffhunk://#diff-2a74624053c8f399acca7eecd2dff28c00fde7c8e80a34509a30373f8d3cceadR39-R66) [[2]](diffhunk://#diff-d81765e486b48333db1b53e1f8ca37952ad2911d240e61d37a185c3244f2f555R49-R58) [[3]](diffhunk://#diff-298ec3106364787d8ffea4db9bedfc930e553f817c9dfea090f641cdba96e7f6R22-R26)
* Added `GetWritableStateAsync` to `IResourceOperationService` to query the writable state, prioritizing sources as Locked > ReadOnlyRoot > ReadOnlyAttribute.

**File System & Data Structure Enhancements:**

* Extended `FileSystemEntry` and `FolderItem` records to include `FileSystemAttributes`, ensuring read-only status can be efficiently surfaced from directory walks. [[1]](diffhunk://#diff-497bedde1bcfc2365371e2011fe0ac35c274fe3867716746cab92f505503aaf1L77-R88) [[2]](diffhunk://#diff-25c46d32db154143550831484ec07157a4976d1f7f2f31aacd12b6ed33bcc26cL97-R98) [[3]](diffhunk://#diff-34535cae8c5f6beb004f7c9e3c394c3ebe999e4ac6492d803b747880113263a2R170-R195)
* Updated `FileSystemMonitor` to watch for attribute changes, ensuring UI and state remain in sync with OS-level read-only changes.

**Host Protocol & JavaScript Integration:**

* Extended the host–WebView protocol: `InitializeResult` now includes the writable state, and a new `document/writableStateChanged` notification informs editors of mid-session state changes. [[1]](diffhunk://#diff-35c17b7f25590290acec65aac2a57ed8ec9c2d760ebb4e18a46f3a7f9236e1e5R16-R18) [[2]](diffhunk://#diff-7d57c398fe6736583f7e33637d420468a4b0c02846eaac4555f1252a19f8849dR46) [[3]](diffhunk://#diff-7d57c398fe6736583f7e33637d420468a4b0c02846eaac4555f1252a19f8849dR147-R155)
* Updated host notification helpers to use parameter objects and added `NotifyWritableStateChangedAsync`. [[1]](diffhunk://#diff-7d57c398fe6736583f7e33637d420468a4b0c02846eaac4555f1252a19f8849dL131-R133) [[2]](diffhunk://#diff-7d57c398fe6736583f7e33637d420468a4b0c02846eaac4555f1252a19f8849dR147-R155)

**Localization & UI Messaging:**

* Added localized strings for each read-only reason and centralized their retrieval in `ReadOnlyMessageHelper`, ensuring tooltips and automation help texts are accurate and consistent. [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R204-R212) [[2]](diffhunk://#diff-5383fcc852461358e52f167b0cec784dd9f80db32485cf2de2175194821f2d76R1-R35)

**Documentation & Extension Authoring:**

* Added a comprehensive guide (`document_editor_contributions.md`) detailing manifest requirements, JS handler contracts (including the required `onWritableStateChanged`), and best practices for handling read-only states in custom editors. [[1]](diffhunk://#diff-b0466c7475ca96248d7a3956a729049b265aee62caa32247eb0ab3a764dae6d4R1-R143) [[2]](diffhunk://#diff-1d0d48ed0f8edcf44f71b059943ab857aa11621d631f66e03c229d5b711f6f8bR18-R19) [[3]](diffhunk://#diff-c94271406d604ca63f88b883638389ab7680d01ccfaddd19d763d345410382ceL18-R18)

These changes lay the groundwork for reliable, user-friendly read-only handling across the platform and provide clear guidance for extension authors.