### PR TITLE
Block policy-denied downloads and clean staging

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -1015,6 +1015,12 @@ Do you wish to continue?</value>
   <data name="WebView_NavigationPrompt_OpenInBrowser" xml:space="preserve">
     <value>Open in system browser</value>
   </data>
+  <data name="WebView_DownloadBlocked_Title" xml:space="preserve">
+    <value>Download blocked</value>
+  </data>
+  <data name="WebView_DownloadBlocked_Message" xml:space="preserve">
+    <value>Download of '{0}' was blocked by the resource policy specified in '{1}'.</value>
+  </data>
   <data name="Explorer_OpenWith" xml:space="preserve">
     <value>Open with...</value>
   </data>

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/tools-api.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/tools-api.js
@@ -14,11 +14,8 @@
 //   - Extra positional arguments throw CelToolError(InvalidArgs).
 //   - Arrays and plain objects passed to `string`-typed parameters are JSON-stringified
 //     automatically (for editsJson, resources, files, etc.).
-//   - After auto-stringify, each argument is type-checked against the descriptor's
-//     parameter type. A mismatch throws CelToolError(InvalidArgs) naming the parameter
-//     and the expected vs actual types — surfaces argument-order swaps at the call site
-//     instead of as an opaque JSON deserialization error from the host. `undefined` and
-//     `null` skip validation so callers can leave defaulted slots empty.
+//   - Each argument is type-checked against the descriptor's parameter type; a mismatch
+//     throws CelToolError(InvalidArgs). `undefined` and `null` skip validation.
 
 /**
  * Error codes for tool proxy failures. Wire codes are JSON-RPC application error codes
@@ -123,20 +120,12 @@ function isPlainObject(value) {
 }
 
 /**
- * Returns a human-readable description of how `value`'s runtime type fails to match the
- * descriptor's JSON Schema `expectedType`, or `null` when the value is acceptable.
- *
- * Permissive on purpose:
- * - `undefined` and `null` always pass — they let callers skip optional positional slots.
- * - An empty or unrecognised `expectedType` passes — descriptors without type info do not
- *   gate dispatch (the host's deserializer remains the final authority).
- *
- * Recognised schema types: "string", "boolean", "integer", "number", "array", "object".
- * "integer" requires the value to be a finite whole number.
- *
- * @param {string} expectedType - The descriptor's parameter type (JSON Schema name).
- * @param {*} value - The argument value passed by the caller.
- * @returns {string|null} - Mismatch description for the error message, or null on match.
+ * Returns a short "expects X, got Y" string when `value` does not satisfy the descriptor's
+ * JSON Schema `expectedType`, or `null` when it does. `undefined`, `null`, and unknown
+ * `expectedType` values pass.
+ * @param {string} expectedType
+ * @param {*} value
+ * @returns {string|null}
  */
 function describeTypeMismatch(expectedType, value) {
     if (value === undefined || value === null) {
@@ -188,8 +177,7 @@ function describeTypeMismatch(expectedType, value) {
 }
 
 /**
- * Maps a runtime value to a short type name used in error messages. Distinguishes
- * arrays and `null` from generic "object" so the message is actionable.
+ * Short type name used in error messages; distinguishes arrays and null from object.
  * @param {*} value
  * @returns {string}
  */
@@ -296,9 +284,7 @@ function buildLeafFunction(descriptor, invoke) {
             }
         }
 
-        // Validate each argument against the descriptor's parameter type. Auto-stringify
-        // runs first, so an array/object passed to a string-typed param is already a
-        // string by the time it reaches here.
+        // Validate each argument against the descriptor's parameter type.
         for (const [parameterName, value] of Object.entries(argumentsObject)) {
             const expectedType = parameterTypes[parameterName];
             const mismatchMessage = describeTypeMismatch(expectedType, value);

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/tools-api.test.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/tools-api.test.js
@@ -197,9 +197,6 @@ describe('buildCelProxy', () => {
     });
 
     it('rejects a boolean-typed parameter receiving a string (positional-arg swap)', () => {
-        // Reproduces the story-builder export bug: explorer.delete(resource, showDialog, referencePolicy)
-        // called with the second and third arguments swapped. The host error was an opaque
-        // System.Text.Json failure; the proxy now flags it at the call site.
         const proxy = buildCelProxy(
             [descriptor('explorer.delete', [
                 { name: 'resource', type: 'string' },

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -575,6 +575,28 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput
             }
             var saveResourceKey = getResourceResult.Value;
 
+            // Probe the destination before staging so policy denials surface to
+            // the user up front instead of after the transfer completes.
+            var probeResult = await ResourceFileSystem.GetInfoAsync(saveResourceKey);
+            if (probeResult.IsFailure)
+            {
+                args.Cancel = true;
+                _logger.LogError($"Download blocked: {probeResult.FirstErrorMessage}");
+
+                var dialogService = _serviceProvider.GetRequiredService<IDialogService>();
+                var stringLocalizer = _serviceProvider.GetRequiredService<IStringLocalizer>();
+                var projectService = _serviceProvider.GetRequiredService<IProjectService>();
+                var projectFileName = Path.GetFileName(projectService.CurrentProject?.ProjectFilePath ?? string.Empty);
+
+                var title = stringLocalizer.GetString("WebView_DownloadBlocked_Title");
+                var message = stringLocalizer.GetString(
+                    "WebView_DownloadBlocked_Message",
+                    filename,
+                    projectFileName);
+                await dialogService.ShowAlertDialogAsync(title, message);
+                return;
+            }
+
             // Stage the download under the project's temp: root so the staging
             // location lives alongside the rest of the workspace's scratch space
             // and the wipe-on-load policy bounds orphan accumulation.
@@ -606,13 +628,16 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput
                             command.DestResource = saveResourceKey;
                         });
 
-                        // Move semantics: the gateway doesn't support cross-root
-                        // moves (temp: -> project:), so the import above copied
-                        // bytes. Delete the staging copy here so we don't carry two
-                        // copies on disk until temp: is wiped on next workspace load.
-                        if (importResult.IsSuccess)
+                        // The import copies bytes (no cross-root move from temp:
+                        // to project:), so the staging copy is always redundant
+                        // afterwards. Delete it on failure too, or it leaks.
+                        await ResourceFileSystem.DeleteAsync(downloadResource);
+
+                        if (importResult.IsFailure)
                         {
-                            await ResourceFileSystem.DeleteAsync(downloadResource);
+                            // The user-facing toast is raised by AddResourceCommand.
+                            _logger.LogError(
+                                $"Failed to import downloaded file to '{saveResourceKey}'. {importResult.DiagnosticReport}");
                         }
                     }
                     else if (s.State == CoreWebView2DownloadState.Interrupted)

--- a/Source/Workspace/Celbridge.Resources/Helpers/AddResourceHelper.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/AddResourceHelper.cs
@@ -59,23 +59,6 @@ public class AddResourceHelper
 
         var resourceFileSystem = _workspaceWrapper.WorkspaceService.ResourceService.FileSystem;
 
-        // Fail if the parent folder for a new file does not exist.
-        // Folder creation is allowed to materialize missing intermediate
-        // ancestors via the gateway's idempotent CreateFolderAsync.
-        if (resourceType == ResourceType.File)
-        {
-            var parentKey = destResource.GetParent();
-            if (!parentKey.IsEmpty)
-            {
-                var parentInfoResult = await resourceFileSystem.GetInfoAsync(parentKey);
-                if (parentInfoResult.IsFailure
-                    || parentInfoResult.Value.Kind != StorageItemKind.Folder)
-                {
-                    return Result.Fail($"Failed to create resource. Parent folder does not exist: '{parentKey}'");
-                }
-            }
-        }
-
         var createResult = resourceType == ResourceType.File
             ? await CreateFileAsync(sourcePath, destResource, resourceOpService, resourceFileSystem)
             : await CreateFolderAsync(sourcePath, destResource, resourceOpService, resourceFileSystem, _fileSystem);


### PR DESCRIPTION
Add localized strings for download-blocked dialog and make WebViewDocumentView probe the destination resource before staging so policy denials surface immediately; cancel the download, log the error and show an alert when denied. Always delete the staging copy after import (and delete it on failure) and log import failures. Remove the parent-folder existence check in AddResourceHelper so folder materialization is delegated to the gateway. Also tidy up comments/docs and test noise in the client tools-api (simplify type-checking/docs and remove an explanatory test comment).