### PR TITLE
Add credential service with DPAPI protector and Workshop connection UI

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -411,6 +411,54 @@
   <data name="SettingsPage_ApplicationTheme" xml:space="preserve">
     <value>Application Theme</value>
   </data>
+  <data name="SettingsPage_WorkshopSection" xml:space="preserve">
+    <value>Workshop</value>
+  </data>
+  <data name="SettingsPage_WorkshopUrl" xml:space="preserve">
+    <value>Workshop URL</value>
+  </data>
+  <data name="SettingsPage_ApplicationKey" xml:space="preserve">
+    <value>Application Key</value>
+  </data>
+  <data name="SettingsPage_SaveConnection" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="SettingsPage_ClearConnection" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="SettingsPage_ReplaceKey" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="SettingsPage_CancelReplaceKey" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="SettingsPage_CredentialStoreUnavailable" xml:space="preserve">
+    <value>Credential storage is not available on this platform. The Workshop connection cannot be configured.</value>
+  </data>
+  <data name="SettingsPage_StoredConnectionUnreadable" xml:space="preserve">
+    <value>The stored Workshop connection could not be read. Enter the Workshop URL and Application Key again, or clear the connection.</value>
+  </data>
+  <data name="SettingsPage_InvalidWorkshopUrl" xml:space="preserve">
+    <value>The Workshop URL must be an https:// address. http:// is only allowed for localhost.</value>
+  </data>
+  <data name="SettingsPage_EmptyApplicationKey" xml:space="preserve">
+    <value>Enter an Application Key.</value>
+  </data>
+  <data name="SettingsPage_SaveConnectionFailed" xml:space="preserve">
+    <value>Failed to save the Workshop connection.</value>
+  </data>
+  <data name="SettingsPage_ClearConnectionFailed" xml:space="preserve">
+    <value>Failed to clear the Workshop connection.</value>
+  </data>
+  <data name="SettingsPage_ConnectionSaved" xml:space="preserve">
+    <value>Workshop connection saved.</value>
+  </data>
+  <data name="SettingsPage_ConnectionSavedPrefixWarning" xml:space="preserve">
+    <value>Workshop connection saved. The Application Key does not start with 'kpf_', so check that it was entered correctly.</value>
+  </data>
+  <data name="SettingsPage_ConnectionCleared" xml:space="preserve">
+    <value>Workshop connection cleared.</value>
+  </data>
   <data name="NewProjectDialog_CreateSubfolder" xml:space="preserve">
     <value>Create directory for project</value>
   </data>

--- a/Source/Core/Celbridge.Foundation/Credentials/CredentialConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Credentials/CredentialConstants.cs
@@ -1,0 +1,13 @@
+namespace Celbridge.Credentials;
+
+/// <summary>
+/// Constants shared by the credential store and the surfaces that present it.
+/// </summary>
+public static class CredentialConstants
+{
+    /// <summary>
+    /// The prefix of a well-formed Workshop Application Key, shaped like
+    /// "kpf_(prefix)_(secret)". The prefix identifies the key and is not secret.
+    /// </summary>
+    public const string ApplicationKeyPrefix = "kpf_";
+}

--- a/Source/Core/Celbridge.Foundation/Credentials/ICredentialService.cs
+++ b/Source/Core/Celbridge.Foundation/Credentials/ICredentialService.cs
@@ -8,6 +8,13 @@ namespace Celbridge.Credentials;
 public record WorkshopConnection(string WorkshopUrl, string ApplicationKey);
 
 /// <summary>
+/// Summary of the stored Workshop connection, readable without decrypting it.
+/// KeyHint is the identifying prefix of the stored Application Key, or empty
+/// when the key has no recognisable prefix or the stored entry is unreadable.
+/// </summary>
+public record WorkshopConnectionSummary(bool IsStored, string KeyHint);
+
+/// <summary>
 /// Application-scoped store for sensitive credentials, encrypted at rest.
 /// Stored values are retrievable only by host-side services through this typed
 /// API and must never appear on agent-readable surfaces such as tool results,
@@ -21,6 +28,13 @@ public interface ICredentialService
     /// features should degrade with a clear message.
     /// </summary>
     bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets a summary of the stored Workshop connection without decrypting it,
+    /// so display surfaces can identify the stored key. Reports a stored entry
+    /// even when it is corrupt, so callers can offer clear and replace.
+    /// </summary>
+    Task<Result<WorkshopConnectionSummary>> GetWorkshopConnectionSummaryAsync();
 
     /// <summary>
     /// Gets the stored Workshop connection. Fails with an actionable message

--- a/Source/Core/Celbridge.Foundation/Credentials/ICredentialService.cs
+++ b/Source/Core/Celbridge.Foundation/Credentials/ICredentialService.cs
@@ -1,0 +1,40 @@
+namespace Celbridge.Credentials;
+
+/// <summary>
+/// A Workshop server URL paired with the Application Key issued by that server.
+/// The two values are stored and retrieved together because a key is only
+/// meaningful against the server that issued it.
+/// </summary>
+public record WorkshopConnection(string WorkshopUrl, string ApplicationKey);
+
+/// <summary>
+/// Application-scoped store for sensitive credentials, encrypted at rest.
+/// Stored values are retrievable only by host-side services through this typed
+/// API and must never appear on agent-readable surfaces such as tool results,
+/// log messages, the WebView, scripting APIs, or subprocess environments.
+/// </summary>
+public interface ICredentialService
+{
+    /// <summary>
+    /// Returns true when the current platform provides a safe store for
+    /// credentials. When false, all store operations fail and dependent
+    /// features should degrade with a clear message.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets the stored Workshop connection. Fails with an actionable message
+    /// when no connection is stored or the stored entry cannot be read.
+    /// </summary>
+    Task<Result<WorkshopConnection>> GetWorkshopConnectionAsync();
+
+    /// <summary>
+    /// Stores the Workshop connection, replacing any existing one.
+    /// </summary>
+    Task<Result> SetWorkshopConnectionAsync(WorkshopConnection connection);
+
+    /// <summary>
+    /// Removes the stored Workshop connection. Succeeds when no connection is stored.
+    /// </summary>
+    Task<Result> ClearWorkshopConnectionAsync();
+}

--- a/Source/Core/Celbridge.Foundation/Settings/FeatureFlagConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Settings/FeatureFlagConstants.cs
@@ -13,7 +13,7 @@ public static class FeatureFlagConstants
 
     /// <summary>
     /// MCP tool system and cel Python API. When disabled, the MCP server does not start
-    /// and the Python terminal is not launched.
+    /// and the Python terminal launches without the cel proxy.
     /// </summary>
     public const string McpTools = "mcp-tools";
 

--- a/Source/Core/Celbridge.Settings/Celbridge.Settings.csproj
+++ b/Source/Core/Celbridge.Settings/Celbridge.Settings.csproj
@@ -27,5 +27,13 @@
       <ProjectReference Include="..\..\Core\Celbridge.Foundation\Celbridge.Foundation.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Celbridge.Tests" />
+  </ItemGroup>
+
 </Project>
 

--- a/Source/Core/Celbridge.Settings/GlobalUsings.cs
+++ b/Source/Core/Celbridge.Settings/GlobalUsings.cs
@@ -1,1 +1,3 @@
 global using Celbridge.Core;
+
+global using Path = System.IO.Path;

--- a/Source/Core/Celbridge.Settings/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.Settings/ServiceConfiguration.cs
@@ -1,3 +1,4 @@
+using Celbridge.Credentials;
 using Celbridge.Settings.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +14,8 @@ public static class ServiceConfiguration
 
         services.AddSingleton<IEditorSettings, EditorSettings>();
         services.AddSingleton<IFeatureFlags, FeatureFlags>();
+        services.AddSingleton<ICredentialProtector, DpapiCredentialProtector>();
+        services.AddSingleton<ICredentialService, CredentialService>();
 
         if (IsStorageAPIAvailable)
         {

--- a/Source/Core/Celbridge.Settings/Services/CredentialService.cs
+++ b/Source/Core/Celbridge.Settings/Services/CredentialService.cs
@@ -1,0 +1,315 @@
+using System.Text;
+using System.Text.Json;
+using Celbridge.Credentials;
+using Celbridge.FileSystem;
+using Celbridge.Logging;
+
+namespace Celbridge.Settings.Services;
+
+/// <summary>
+/// On-disk shape of the credential store file: a version number and one
+/// protected entry per credential.
+/// </summary>
+internal sealed record CredentialStoreDocument(int Version, WorkshopConnectionEntry? WorkshopConnection);
+
+/// <summary>
+/// Stored form of the Workshop connection: the protected connection payload as
+/// base64, plus the unprotected key prefix used as a display hint.
+/// </summary>
+internal sealed record WorkshopConnectionEntry(string ProtectedData, string KeyHint);
+
+/// <summary>
+/// Stores credentials as platform-protected blobs in a JSON document in the
+/// application data folder. All file access is serialized so concurrent
+/// callers cannot interleave reads and writes.
+/// </summary>
+internal sealed class CredentialService : ICredentialService
+{
+    private const int StoreVersion = 1;
+    private const string ApplicationKeyPrefix = "kpf_";
+
+    private const string UnavailableMessage = "Credential storage is not available on this platform";
+    private const string NotConfiguredMessage = "No Workshop connection is configured. Enter the Workshop URL and Application Key on the Settings page.";
+    private const string CorruptStoreMessage = "The stored Workshop connection could not be read. Enter the Workshop URL and Application Key again on the Settings page.";
+
+    private static readonly JsonSerializerOptions DocumentJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly ILogger<CredentialService> _logger;
+    private readonly ILocalFileSystem _fileSystem;
+    private readonly ICredentialProtector _protector;
+    private readonly string _credentialsFilePath;
+    private readonly SemaphoreSlim _storeSemaphore = new(1, 1);
+
+    public CredentialService(
+        ILogger<CredentialService> logger,
+        ILocalFileSystem fileSystem,
+        ICredentialProtector protector)
+        : this(logger, fileSystem, protector, GetDefaultCredentialsFilePath())
+    {}
+
+    internal CredentialService(
+        ILogger<CredentialService> logger,
+        ILocalFileSystem fileSystem,
+        ICredentialProtector protector,
+        string credentialsFilePath)
+    {
+        _logger = logger;
+        _fileSystem = fileSystem;
+        _protector = protector;
+        _credentialsFilePath = credentialsFilePath;
+    }
+
+    public bool IsAvailable => _protector.IsAvailable;
+
+    public async Task<Result<WorkshopConnection>> GetWorkshopConnectionAsync()
+    {
+        if (!IsAvailable)
+        {
+            return Result.Fail(UnavailableMessage);
+        }
+
+        await _storeSemaphore.WaitAsync();
+        try
+        {
+            var infoResult = await _fileSystem.GetInfoAsync(_credentialsFilePath);
+            if (infoResult.IsFailure)
+            {
+                return Result<WorkshopConnection>.Fail("Failed to query the credential store file")
+                    .WithErrors(infoResult);
+            }
+
+            var storeInfo = infoResult.Value;
+            if (storeInfo.Kind != StorageItemKind.File)
+            {
+                return Result.Fail(NotConfiguredMessage);
+            }
+
+            var readResult = await _fileSystem.ReadAllTextAsync(_credentialsFilePath);
+            if (readResult.IsFailure)
+            {
+                return Result<WorkshopConnection>.Fail("Failed to read the credential store file")
+                    .WithErrors(readResult);
+            }
+
+            var documentText = readResult.Value;
+            var document = ParseDocument(documentText);
+            if (document is null)
+            {
+                return Result.Fail(CorruptStoreMessage);
+            }
+
+            var entry = document.WorkshopConnection;
+            if (entry is null ||
+                string.IsNullOrEmpty(entry.ProtectedData))
+            {
+                return Result.Fail(NotConfiguredMessage);
+            }
+
+            byte[] protectedData;
+            try
+            {
+                protectedData = Convert.FromBase64String(entry.ProtectedData);
+            }
+            catch (FormatException)
+            {
+                _logger.LogError("The stored Workshop connection entry is not valid base64");
+
+                return Result.Fail(CorruptStoreMessage);
+            }
+
+            var unprotectResult = _protector.Unprotect(protectedData);
+            if (unprotectResult.IsFailure)
+            {
+                _logger.LogError(unprotectResult, "Failed to unprotect the stored Workshop connection");
+
+                return Result.Fail(CorruptStoreMessage);
+            }
+
+            var plainData = unprotectResult.Value;
+            var connection = ParseConnectionPayload(plainData);
+            if (connection is null ||
+                string.IsNullOrEmpty(connection.WorkshopUrl) ||
+                string.IsNullOrEmpty(connection.ApplicationKey))
+            {
+                // The decrypted payload is sensitive, so no parse detail is
+                // attached to the error or written to the log.
+                _logger.LogError("The stored Workshop connection payload is invalid");
+
+                return Result.Fail(CorruptStoreMessage);
+            }
+
+            return connection;
+        }
+        finally
+        {
+            _storeSemaphore.Release();
+        }
+    }
+
+    public async Task<Result> SetWorkshopConnectionAsync(WorkshopConnection connection)
+    {
+        if (!IsAvailable)
+        {
+            return Result.Fail(UnavailableMessage);
+        }
+
+        if (connection is null)
+        {
+            return Result.Fail("Workshop connection is required");
+        }
+
+        if (string.IsNullOrWhiteSpace(connection.WorkshopUrl))
+        {
+            return Result.Fail("Workshop URL must not be empty");
+        }
+
+        if (string.IsNullOrWhiteSpace(connection.ApplicationKey))
+        {
+            return Result.Fail("Application Key must not be empty");
+        }
+
+        var payloadJson = JsonSerializer.Serialize(connection);
+        var payloadData = Encoding.UTF8.GetBytes(payloadJson);
+
+        var protectResult = _protector.Protect(payloadData);
+        if (protectResult.IsFailure)
+        {
+            return Result.Fail("Failed to protect the Workshop connection")
+                .WithErrors(protectResult);
+        }
+
+        var protectedData = protectResult.Value;
+        var entry = new WorkshopConnectionEntry(
+            Convert.ToBase64String(protectedData),
+            GetKeyDisplayHint(connection.ApplicationKey));
+
+        var document = new CredentialStoreDocument(StoreVersion, entry);
+        var documentText = JsonSerializer.Serialize(document, DocumentJsonOptions);
+
+        await _storeSemaphore.WaitAsync();
+        try
+        {
+            var folderPath = Path.GetDirectoryName(_credentialsFilePath);
+            if (!string.IsNullOrEmpty(folderPath))
+            {
+                var createFolderResult = await _fileSystem.CreateFolderAsync(folderPath);
+                if (createFolderResult.IsFailure)
+                {
+                    return Result.Fail("Failed to create the credential store folder")
+                        .WithErrors(createFolderResult);
+                }
+            }
+
+            var writeResult = await _fileSystem.WriteAllTextAsync(_credentialsFilePath, documentText);
+            if (writeResult.IsFailure)
+            {
+                return Result.Fail("Failed to write the credential store file")
+                    .WithErrors(writeResult);
+            }
+
+            return Result.Ok();
+        }
+        finally
+        {
+            _storeSemaphore.Release();
+        }
+    }
+
+    public async Task<Result> ClearWorkshopConnectionAsync()
+    {
+        if (!IsAvailable)
+        {
+            return Result.Fail(UnavailableMessage);
+        }
+
+        await _storeSemaphore.WaitAsync();
+        try
+        {
+            var infoResult = await _fileSystem.GetInfoAsync(_credentialsFilePath);
+            if (infoResult.IsFailure)
+            {
+                return Result.Fail("Failed to query the credential store file")
+                    .WithErrors(infoResult);
+            }
+
+            var storeInfo = infoResult.Value;
+            if (storeInfo.Kind != StorageItemKind.File)
+            {
+                return Result.Ok();
+            }
+
+            // The Workshop connection is the only entry today, so clearing it
+            // removes the whole store file. This also recovers from a
+            // corrupted file without needing to parse it.
+            var deleteResult = await _fileSystem.DeleteFileAsync(_credentialsFilePath);
+            if (deleteResult.IsFailure)
+            {
+                return Result.Fail("Failed to delete the credential store file")
+                    .WithErrors(deleteResult);
+            }
+
+            return Result.Ok();
+        }
+        finally
+        {
+            _storeSemaphore.Release();
+        }
+    }
+
+    private static string GetDefaultCredentialsFilePath()
+    {
+        var appDataFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        return Path.Combine(appDataFolderPath, "Celbridge", "credentials.json");
+    }
+
+    private static CredentialStoreDocument? ParseDocument(string documentText)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<CredentialStoreDocument>(documentText);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static WorkshopConnection? ParseConnectionPayload(byte[] plainData)
+    {
+        try
+        {
+            var payloadJson = Encoding.UTF8.GetString(plainData);
+
+            return JsonSerializer.Deserialize<WorkshopConnection>(payloadJson);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the identifying prefix of an Application Key shaped like
+    /// "kpf_(prefix)_(secret)", or an empty string when the key does not match
+    /// that shape, so that no secret material can leak into the hint.
+    /// </summary>
+    private static string GetKeyDisplayHint(string applicationKey)
+    {
+        if (!applicationKey.StartsWith(ApplicationKeyPrefix, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var separatorIndex = applicationKey.IndexOf('_', ApplicationKeyPrefix.Length);
+        if (separatorIndex < 0)
+        {
+            return string.Empty;
+        }
+
+        return applicationKey.Substring(0, separatorIndex);
+    }
+}

--- a/Source/Core/Celbridge.Settings/Services/CredentialService.cs
+++ b/Source/Core/Celbridge.Settings/Services/CredentialService.cs
@@ -8,7 +8,12 @@ namespace Celbridge.Settings.Services;
 
 /// <summary>
 /// On-disk shape of the credential store file: a version number and one
-/// protected entry per credential.
+/// protected entry per credential. New credential types are added as nullable
+/// entry properties without a version bump; a missing property deserializes as
+/// null and reports as not configured. Adding a second entry requires changing
+/// Set and Clear from whole-file rewrite and delete to read-modify-write.
+/// Version increments only when the document is reshaped, paired with a
+/// read-side migration.
 /// </summary>
 internal sealed record CredentialStoreDocument(int Version, WorkshopConnectionEntry? WorkshopConnection);
 
@@ -31,6 +36,7 @@ internal sealed class CredentialService : ICredentialService
     private const string UnavailableMessage = "Credential storage is not available on this platform";
     private const string NotConfiguredMessage = "No Workshop connection is configured. Enter the Workshop URL and Application Key on the Settings page.";
     private const string CorruptStoreMessage = "The stored Workshop connection could not be read. Enter the Workshop URL and Application Key again on the Settings page.";
+    private const string NewerStoreVersionMessage = "The credential store was written by a newer version of Celbridge and cannot be read by this version.";
 
     private static readonly JsonSerializerOptions DocumentJsonOptions = new()
     {
@@ -99,6 +105,11 @@ internal sealed class CredentialService : ICredentialService
             if (document is null)
             {
                 return Result.Fail(CorruptStoreMessage);
+            }
+
+            if (document.Version > StoreVersion)
+            {
+                return Result.Fail(NewerStoreVersionMessage);
             }
 
             var entry = document.WorkshopConnection;

--- a/Source/Core/Celbridge.Settings/Services/CredentialService.cs
+++ b/Source/Core/Celbridge.Settings/Services/CredentialService.cs
@@ -31,7 +31,6 @@ internal sealed record WorkshopConnectionEntry(string ProtectedData, string KeyH
 internal sealed class CredentialService : ICredentialService
 {
     private const int StoreVersion = 1;
-    private const string ApplicationKeyPrefix = "kpf_";
 
     private const string UnavailableMessage = "Credential storage is not available on this platform";
     private const string NotConfiguredMessage = "No Workshop connection is configured. Enter the Workshop URL and Application Key on the Settings page.";
@@ -69,6 +68,60 @@ internal sealed class CredentialService : ICredentialService
     }
 
     public bool IsAvailable => _protector.IsAvailable;
+
+    public async Task<Result<WorkshopConnectionSummary>> GetWorkshopConnectionSummaryAsync()
+    {
+        if (!IsAvailable)
+        {
+            return Result.Fail(UnavailableMessage);
+        }
+
+        await _storeSemaphore.WaitAsync();
+        try
+        {
+            var infoResult = await _fileSystem.GetInfoAsync(_credentialsFilePath);
+            if (infoResult.IsFailure)
+            {
+                return Result<WorkshopConnectionSummary>.Fail("Failed to query the credential store file")
+                    .WithErrors(infoResult);
+            }
+
+            var storeInfo = infoResult.Value;
+            if (storeInfo.Kind != StorageItemKind.File)
+            {
+                return new WorkshopConnectionSummary(false, string.Empty);
+            }
+
+            var readResult = await _fileSystem.ReadAllTextAsync(_credentialsFilePath);
+            if (readResult.IsFailure)
+            {
+                return Result<WorkshopConnectionSummary>.Fail("Failed to read the credential store file")
+                    .WithErrors(readResult);
+            }
+
+            var documentText = readResult.Value;
+            var document = ParseDocument(documentText);
+            if (document is null)
+            {
+                // An unparseable store still counts as a stored entry so that
+                // display surfaces can offer clear and replace as recovery.
+                return new WorkshopConnectionSummary(true, string.Empty);
+            }
+
+            var entry = document.WorkshopConnection;
+            if (entry is null ||
+                string.IsNullOrEmpty(entry.ProtectedData))
+            {
+                return new WorkshopConnectionSummary(false, string.Empty);
+            }
+
+            return new WorkshopConnectionSummary(true, entry.KeyHint ?? string.Empty);
+        }
+        finally
+        {
+            _storeSemaphore.Release();
+        }
+    }
 
     public async Task<Result<WorkshopConnection>> GetWorkshopConnectionAsync()
     {
@@ -310,12 +363,12 @@ internal sealed class CredentialService : ICredentialService
     /// </summary>
     private static string GetKeyDisplayHint(string applicationKey)
     {
-        if (!applicationKey.StartsWith(ApplicationKeyPrefix, StringComparison.Ordinal))
+        if (!applicationKey.StartsWith(CredentialConstants.ApplicationKeyPrefix, StringComparison.Ordinal))
         {
             return string.Empty;
         }
 
-        var separatorIndex = applicationKey.IndexOf('_', ApplicationKeyPrefix.Length);
+        var separatorIndex = applicationKey.IndexOf('_', CredentialConstants.ApplicationKeyPrefix.Length);
         if (separatorIndex < 0)
         {
             return string.Empty;

--- a/Source/Core/Celbridge.Settings/Services/DpapiCredentialProtector.cs
+++ b/Source/Core/Celbridge.Settings/Services/DpapiCredentialProtector.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+
+namespace Celbridge.Settings.Services;
+
+/// <summary>
+/// Windows credential protector backed by DPAPI with CurrentUser scope.
+/// Reports itself unavailable on other platforms.
+/// </summary>
+internal sealed class DpapiCredentialProtector : ICredentialProtector
+{
+    public bool IsAvailable => OperatingSystem.IsWindows();
+
+    public Result<byte[]> Protect(byte[] plainData)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return Result.Fail("DPAPI credential protection is only available on Windows");
+        }
+
+        try
+        {
+            var protectedData = ProtectedData.Protect(plainData, optionalEntropy: null, DataProtectionScope.CurrentUser);
+
+            return protectedData;
+        }
+        catch (Exception ex)
+        {
+            return Result<byte[]>.Fail("Failed to protect credential data")
+                .WithException(ex);
+        }
+    }
+
+    public Result<byte[]> Unprotect(byte[] protectedData)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return Result.Fail("DPAPI credential protection is only available on Windows");
+        }
+
+        try
+        {
+            var plainData = ProtectedData.Unprotect(protectedData, optionalEntropy: null, DataProtectionScope.CurrentUser);
+
+            return plainData;
+        }
+        catch (Exception ex)
+        {
+            return Result<byte[]>.Fail("Failed to unprotect credential data")
+                .WithException(ex);
+        }
+    }
+}

--- a/Source/Core/Celbridge.Settings/Services/ICredentialProtector.cs
+++ b/Source/Core/Celbridge.Settings/Services/ICredentialProtector.cs
@@ -1,0 +1,26 @@
+namespace Celbridge.Settings.Services;
+
+/// <summary>
+/// Platform backend that encrypts and decrypts credential data at rest.
+/// Each platform supplies its own implementation (DPAPI on Windows); where no
+/// safe store exists the protector reports itself unavailable and the
+/// credential service degrades rather than storing plaintext.
+/// </summary>
+internal interface ICredentialProtector
+{
+    /// <summary>
+    /// Returns true when the current platform provides a safe store for
+    /// protected data.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Encrypts the given data for the current user.
+    /// </summary>
+    Result<byte[]> Protect(byte[] plainData);
+
+    /// <summary>
+    /// Decrypts data previously returned by Protect for the same user.
+    /// </summary>
+    Result<byte[]> Unprotect(byte[] protectedData);
+}

--- a/Source/Core/Celbridge.UserInterface/Helpers/WorkshopConnectionValidation.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WorkshopConnectionValidation.cs
@@ -1,0 +1,39 @@
+using Celbridge.Credentials;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Save-time validation rules for the Workshop connection settings.
+/// </summary>
+public static class WorkshopConnectionValidation
+{
+    /// <summary>
+    /// Returns true when the URL is an absolute https address, or an http
+    /// address on the loopback host (the localhost development exception).
+    /// </summary>
+    public static bool IsValidWorkshopUrl(string workshopUrl)
+    {
+        if (!Uri.TryCreate(workshopUrl.Trim(), UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (uri.Scheme == Uri.UriSchemeHttps)
+        {
+            return true;
+        }
+
+        return uri.Scheme == Uri.UriSchemeHttp &&
+               uri.IsLoopback;
+    }
+
+    /// <summary>
+    /// Returns true when the key starts with the expected Application Key
+    /// prefix. A typo guard for display, not a gate: keys without the prefix
+    /// are still accepted.
+    /// </summary>
+    public static bool HasExpectedKeyPrefix(string applicationKey)
+    {
+        return applicationKey.StartsWith(CredentialConstants.ApplicationKeyPrefix, StringComparison.Ordinal);
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Pages/SettingsPageViewModel.cs
@@ -1,7 +1,278 @@
-﻿namespace Celbridge.UserInterface.ViewModels.Pages;
+using Celbridge.Credentials;
+
+namespace Celbridge.UserInterface.ViewModels.Pages;
 
 public partial class SettingsPageViewModel : ObservableObject
 {
-    public SettingsPageViewModel()
-    { }
+    private const string MaskedKeyDisplay = "********";
+
+    private readonly Logging.ILogger<SettingsPageViewModel> _logger;
+    private readonly ICredentialService _credentialService;
+    private readonly IStringLocalizer _stringLocalizer;
+
+    [ObservableProperty]
+    private string _workshopUrl = string.Empty;
+
+    [ObservableProperty]
+    private string _applicationKey = string.Empty;
+
+    [ObservableProperty]
+    private string _storedKeyDisplay = string.Empty;
+
+    [ObservableProperty]
+    private bool _isStoreAvailable;
+
+    [ObservableProperty]
+    private bool _isKeyEntryVisible;
+
+    [ObservableProperty]
+    private bool _isStoredKeyVisible;
+
+    [ObservableProperty]
+    private bool _isClearVisible;
+
+    [ObservableProperty]
+    private bool _isCancelReplaceVisible;
+
+    [ObservableProperty]
+    private string _statusText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isStatusVisible;
+
+    [ObservableProperty]
+    private bool _isWarningVisible;
+
+    [ObservableProperty]
+    private string _errorText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isErrorVisible;
+
+    private bool _isConnectionStored;
+    private bool _isReplacingKey;
+
+    public SettingsPageViewModel(
+        Logging.ILogger<SettingsPageViewModel> logger,
+        ICredentialService credentialService,
+        IStringLocalizer stringLocalizer)
+    {
+        _logger = logger;
+        _credentialService = credentialService;
+        _stringLocalizer = stringLocalizer;
+    }
+
+    public async Task InitializeAsync()
+    {
+        IsStoreAvailable = _credentialService.IsAvailable;
+        if (!IsStoreAvailable)
+        {
+            ShowError(_stringLocalizer.GetString("SettingsPage_CredentialStoreUnavailable"));
+            UpdateViewState();
+            return;
+        }
+
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
+        if (summaryResult.IsFailure)
+        {
+            _logger.LogError(summaryResult, "Failed to read the Workshop connection summary");
+            ShowError(_stringLocalizer.GetString("SettingsPage_StoredConnectionUnreadable"));
+            UpdateViewState();
+            return;
+        }
+
+        var summary = summaryResult.Value;
+        _isConnectionStored = summary.IsStored;
+
+        if (_isConnectionStored)
+        {
+            StoredKeyDisplay = FormatStoredKeyDisplay(summary.KeyHint);
+
+            var getResult = await _credentialService.GetWorkshopConnectionAsync();
+            if (getResult.IsSuccess)
+            {
+                var connection = getResult.Value;
+                WorkshopUrl = connection.WorkshopUrl;
+            }
+            else
+            {
+                // A stored entry that cannot be decrypted. The clear and
+                // replace affordances stay active so the user can recover.
+                _logger.LogError(getResult, "Failed to read the stored Workshop connection");
+                ShowError(_stringLocalizer.GetString("SettingsPage_StoredConnectionUnreadable"));
+            }
+        }
+
+        UpdateViewState();
+    }
+
+    [RelayCommand]
+    private async Task SaveWorkshopConnectionAsync()
+    {
+        ClearMessages();
+
+        var workshopUrl = WorkshopUrl.Trim();
+        if (!WorkshopConnectionValidation.IsValidWorkshopUrl(workshopUrl))
+        {
+            ShowError(_stringLocalizer.GetString("SettingsPage_InvalidWorkshopUrl"));
+            return;
+        }
+
+        string applicationKey;
+        var isNewKey = !_isConnectionStored ||
+                       _isReplacingKey;
+        if (isNewKey)
+        {
+            applicationKey = ApplicationKey.Trim();
+            if (string.IsNullOrEmpty(applicationKey))
+            {
+                ShowError(_stringLocalizer.GetString("SettingsPage_EmptyApplicationKey"));
+                return;
+            }
+        }
+        else
+        {
+            // A URL-only update reuses the stored key, read at the point of use.
+            var getResult = await _credentialService.GetWorkshopConnectionAsync();
+            if (getResult.IsFailure)
+            {
+                _logger.LogError(getResult, "Failed to read the stored Workshop connection");
+                ShowError(_stringLocalizer.GetString("SettingsPage_StoredConnectionUnreadable"));
+                return;
+            }
+
+            var storedConnection = getResult.Value;
+            applicationKey = storedConnection.ApplicationKey;
+        }
+
+        var connection = new WorkshopConnection(workshopUrl, applicationKey);
+        var setResult = await _credentialService.SetWorkshopConnectionAsync(connection);
+        if (setResult.IsFailure)
+        {
+            _logger.LogError(setResult, "Failed to store the Workshop connection");
+            ShowError(_stringLocalizer.GetString("SettingsPage_SaveConnectionFailed"));
+            return;
+        }
+
+        ApplicationKey = string.Empty;
+        _isConnectionStored = true;
+        _isReplacingKey = false;
+
+        await RefreshStoredKeyDisplayAsync();
+
+        // The prefix check is a typo guard, not a gate: the connection is
+        // saved either way and the warning invites a double check.
+        if (isNewKey &&
+            !WorkshopConnectionValidation.HasExpectedKeyPrefix(applicationKey))
+        {
+            ShowWarning(_stringLocalizer.GetString("SettingsPage_ConnectionSavedPrefixWarning"));
+        }
+        else
+        {
+            ShowStatus(_stringLocalizer.GetString("SettingsPage_ConnectionSaved"));
+        }
+
+        UpdateViewState();
+    }
+
+    [RelayCommand]
+    private async Task ClearWorkshopConnectionAsync()
+    {
+        ClearMessages();
+
+        var clearResult = await _credentialService.ClearWorkshopConnectionAsync();
+        if (clearResult.IsFailure)
+        {
+            _logger.LogError(clearResult, "Failed to clear the Workshop connection");
+            ShowError(_stringLocalizer.GetString("SettingsPage_ClearConnectionFailed"));
+            return;
+        }
+
+        _isConnectionStored = false;
+        _isReplacingKey = false;
+        WorkshopUrl = string.Empty;
+        ApplicationKey = string.Empty;
+        StoredKeyDisplay = string.Empty;
+
+        ShowStatus(_stringLocalizer.GetString("SettingsPage_ConnectionCleared"));
+        UpdateViewState();
+    }
+
+    [RelayCommand]
+    private void ReplaceApplicationKey()
+    {
+        ClearMessages();
+        _isReplacingKey = true;
+        UpdateViewState();
+    }
+
+    [RelayCommand]
+    private void CancelReplaceApplicationKey()
+    {
+        ClearMessages();
+        _isReplacingKey = false;
+        ApplicationKey = string.Empty;
+        UpdateViewState();
+    }
+
+    private async Task RefreshStoredKeyDisplayAsync()
+    {
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
+        if (summaryResult.IsSuccess)
+        {
+            var summary = summaryResult.Value;
+            StoredKeyDisplay = FormatStoredKeyDisplay(summary.KeyHint);
+        }
+    }
+
+    private void UpdateViewState()
+    {
+        IsKeyEntryVisible = IsStoreAvailable &&
+                            (!_isConnectionStored || _isReplacingKey);
+        IsStoredKeyVisible = IsStoreAvailable &&
+                             _isConnectionStored &&
+                             !_isReplacingKey;
+        IsClearVisible = IsStoreAvailable &&
+                         _isConnectionStored;
+        IsCancelReplaceVisible = IsStoreAvailable &&
+                                 _isConnectionStored &&
+                                 _isReplacingKey;
+    }
+
+    private void ShowStatus(string statusText)
+    {
+        StatusText = statusText;
+        IsStatusVisible = true;
+    }
+
+    private void ShowWarning(string warningText)
+    {
+        StatusText = warningText;
+        IsWarningVisible = true;
+    }
+
+    private void ShowError(string errorText)
+    {
+        ErrorText = errorText;
+        IsErrorVisible = true;
+    }
+
+    private void ClearMessages()
+    {
+        StatusText = string.Empty;
+        IsStatusVisible = false;
+        IsWarningVisible = false;
+        ErrorText = string.Empty;
+        IsErrorVisible = false;
+    }
+
+    private static string FormatStoredKeyDisplay(string keyHint)
+    {
+        if (string.IsNullOrEmpty(keyHint))
+        {
+            return MaskedKeyDisplay;
+        }
+
+        return $"{keyHint}_...";
+    }
 }

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Celbridge.UserInterface.Views.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,47 +7,113 @@
     x:Name="SettingsPageName"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-  <Grid>
-    <Grid>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="60"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="60"/>
-        <RowDefinition Height="Auto"/>
-      </Grid.RowDefinitions>
+  <ScrollViewer>
+    <StackPanel Margin="100,60,100,60"
+                Spacing="24"
+                HorizontalAlignment="Left">
 
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="Auto"/>
-        <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="Auto"/>
-        <ColumnDefinition Width="*"/>
-      </Grid.ColumnDefinitions>
+      <TextBlock FontSize="36"
+                 FontWeight="Bold"
+                 Text="{x:Bind TitleString}"/>
 
-      <StackPanel Grid.Row="1"
-                  Grid.ColumnSpan="4"
-                  Grid.Column="1">
-        <TextBlock FontSize="36"
-                   Text="{x:Bind TitleString}"
-                   VerticalAlignment="Center"
-                   FontWeight="Bold">
-        </TextBlock>
-        <!-- I Did want to place a Separator here but can't seem to find them on Uno! -->
-      </StackPanel>
+      <Grid ColumnSpacing="24">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="160"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
 
-      <TextBlock Grid.Row="3"
-                 Text="{x:Bind ApplicationThemeString}"
-                 VerticalAlignment="Center"
-                 Grid.Column="1">
-      </TextBlock>
+        <TextBlock Text="{x:Bind ApplicationThemeString}"
+                   VerticalAlignment="Center"/>
 
-      <ComboBox Grid.Row="3"
-                Grid.Column="3"
-                VerticalAlignment="Center"
-                HorizontalAlignment="Left"
-                x:Name="ApplicationThemeComboBox"/>
+        <ComboBox x:Name="ApplicationThemeComboBox"
+                  Grid.Column="1"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Left"/>
+      </Grid>
 
-    </Grid>
-  </Grid>
+      <TextBlock FontSize="24"
+                 FontWeight="SemiBold"
+                 Margin="0,24,0,0"
+                 Text="{x:Bind WorkshopSectionString}"/>
+
+      <ContentControl IsEnabled="{x:Bind ViewModel.IsStoreAvailable, Mode=OneWay}"
+                      IsTabStop="False">
+      <Grid ColumnSpacing="24"
+            RowSpacing="16">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="160"/>
+          <ColumnDefinition Width="600"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="{x:Bind WorkshopUrlString}"
+                   VerticalAlignment="Center"/>
+
+        <TextBox Grid.Column="1"
+                 Text="{x:Bind ViewModel.WorkshopUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 IsSpellCheckEnabled="False"
+                 PlaceholderText="https://"/>
+
+        <TextBlock Grid.Row="1"
+                   Text="{x:Bind ApplicationKeyString}"
+                   VerticalAlignment="Center"/>
+
+        <Grid Grid.Row="1"
+              Grid.Column="1">
+          <PasswordBox Password="{x:Bind ViewModel.ApplicationKey, Mode=TwoWay}"
+                       Visibility="{x:Bind ViewModel.IsKeyEntryVisible, Mode=OneWay}"/>
+
+          <StackPanel Orientation="Horizontal"
+                      Spacing="12"
+                      Visibility="{x:Bind ViewModel.IsStoredKeyVisible, Mode=OneWay}">
+            <TextBlock Text="{x:Bind ViewModel.StoredKeyDisplay, Mode=OneWay}"
+                       VerticalAlignment="Center"/>
+            <Button Content="{x:Bind ReplaceKeyString}"
+                    Command="{x:Bind ViewModel.ReplaceApplicationKeyCommand}"/>
+          </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="2"
+                    Grid.Column="1"
+                    Orientation="Horizontal"
+                    Spacing="12">
+          <Button Content="{x:Bind SaveConnectionString}"
+                  Command="{x:Bind ViewModel.SaveWorkshopConnectionCommand}"/>
+          <Button Content="{x:Bind CancelReplaceKeyString}"
+                  Visibility="{x:Bind ViewModel.IsCancelReplaceVisible, Mode=OneWay}"
+                  Command="{x:Bind ViewModel.CancelReplaceApplicationKeyCommand}"/>
+          <Button Content="{x:Bind ClearConnectionString}"
+                  Visibility="{x:Bind ViewModel.IsClearVisible, Mode=OneWay}"
+                  Command="{x:Bind ViewModel.ClearWorkshopConnectionCommand}"/>
+        </StackPanel>
+      </Grid>
+      </ContentControl>
+
+      <InfoBar Severity="Error"
+               IsOpen="{x:Bind ViewModel.IsErrorVisible, Mode=OneWay}"
+               IsClosable="False"
+               MaxWidth="784"
+               HorizontalAlignment="Left"
+               Message="{x:Bind ViewModel.ErrorText, Mode=OneWay}"/>
+
+      <InfoBar Severity="Success"
+               IsOpen="{x:Bind ViewModel.IsStatusVisible, Mode=OneWay}"
+               IsClosable="False"
+               MaxWidth="784"
+               HorizontalAlignment="Left"
+               Message="{x:Bind ViewModel.StatusText, Mode=OneWay}"/>
+
+      <InfoBar Severity="Warning"
+               IsOpen="{x:Bind ViewModel.IsWarningVisible, Mode=OneWay}"
+               IsClosable="False"
+               MaxWidth="784"
+               HorizontalAlignment="Left"
+               Message="{x:Bind ViewModel.StatusText, Mode=OneWay}"/>
+
+    </StackPanel>
+  </ScrollViewer>
 </Page>
-

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using Celbridge.Settings;
+using Celbridge.UserInterface.ViewModels.Pages;
 
 namespace Celbridge.UserInterface.Views;
 
@@ -12,14 +13,25 @@ public sealed partial class SettingsPage : Page
     private readonly IEditorSettings _editorSettings;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly IUserInterfaceService _userInterfaceService;
-    private string TitleString => _stringLocalizer.GetString($"SettingsPage_Title");
-    private string ApplicationThemeString => _stringLocalizer.GetString($"SettingsPage_ApplicationTheme");
+
+    private string TitleString => _stringLocalizer.GetString("SettingsPage_Title");
+    private string ApplicationThemeString => _stringLocalizer.GetString("SettingsPage_ApplicationTheme");
+    private string WorkshopSectionString => _stringLocalizer.GetString("SettingsPage_WorkshopSection");
+    private string WorkshopUrlString => _stringLocalizer.GetString("SettingsPage_WorkshopUrl");
+    private string ApplicationKeyString => _stringLocalizer.GetString("SettingsPage_ApplicationKey");
+    private string SaveConnectionString => _stringLocalizer.GetString("SettingsPage_SaveConnection");
+    private string ClearConnectionString => _stringLocalizer.GetString("SettingsPage_ClearConnection");
+    private string ReplaceKeyString => _stringLocalizer.GetString("SettingsPage_ReplaceKey");
+    private string CancelReplaceKeyString => _stringLocalizer.GetString("SettingsPage_CancelReplaceKey");
+
+    public SettingsPageViewModel ViewModel { get; }
 
     public SettingsPage()
     {
         _editorSettings = ServiceLocator.AcquireService<IEditorSettings>();
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
+        ViewModel = ServiceLocator.AcquireService<SettingsPageViewModel>();
 
         // Initialise our Theme lookup Dictionary.
         var ThemeValues = Enum.GetValues(typeof(ApplicationColorTheme));
@@ -44,13 +56,20 @@ public sealed partial class SettingsPage : Page
         ApplicationThemeComboBox.Loaded += ApplicationThemeComboBox_Loaded;
         ApplicationThemeComboBox.SelectionChanged += ApplicationThemeComboBox_SelectionChanged;
 
+        Loaded += SettingsPage_Loaded;
         Unloaded += SettingsPage_Unloaded;
+    }
+
+    private async void SettingsPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.InitializeAsync();
     }
 
     private void SettingsPage_Unloaded(object sender, RoutedEventArgs e)
     {
         ApplicationThemeComboBox.Loaded -= ApplicationThemeComboBox_Loaded;
         ApplicationThemeComboBox.SelectionChanged -= ApplicationThemeComboBox_SelectionChanged;
+        Loaded -= SettingsPage_Loaded;
         Unloaded -= SettingsPage_Unloaded;
     }
 

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="OpenAI" Version="2.8.0" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.17" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
   </ItemGroup>
 </Project>

--- a/Source/Tests/Helpers/NullLogger.cs
+++ b/Source/Tests/Helpers/NullLogger.cs
@@ -1,0 +1,27 @@
+namespace Celbridge.Tests.Helpers;
+
+/// <summary>
+/// No-op logger for constructing services whose logger type parameter is an
+/// internal type, which Castle DynamicProxy cannot proxy without an
+/// InternalsVisibleTo("DynamicProxyGenAssembly2") entry on the owning assembly.
+/// </summary>
+public sealed class NullLogger<T> : ILogger<T>
+{
+    public void LogDebug(Exception? exception, string? message, params object?[] args) {}
+    public void LogDebug(string? message, params object?[] args) {}
+    public void LogTrace(Exception? exception, string? message, params object?[] args) {}
+    public void LogTrace(string? message, params object?[] args) {}
+    public void LogInformation(Exception? exception, string? message, params object?[] args) {}
+    public void LogInformation(string? message, params object?[] args) {}
+    public void LogWarning(Exception? exception, string? message, params object?[] args) {}
+    public void LogWarning(string? message, params object?[] args) {}
+    public void LogWarning(Result result, string? message, params object?[] args) {}
+    public void LogError(Exception? exception, string? message, params object?[] args) {}
+    public void LogError(string? message, params object?[] args) {}
+    public void LogError(Result result, string? message, params object?[] args) {}
+    public void LogCritical(Exception? exception, string? message, params object?[] args) {}
+    public void LogCritical(string? message, params object?[] args) {}
+    public void LogCritical(Result result, string? message, params object?[] args) {}
+    public IDisposable? BeginScope(string messageFormat, params object?[] args) => null;
+    public void Shutdown() {}
+}

--- a/Source/Tests/Settings/CredentialServiceTests.cs
+++ b/Source/Tests/Settings/CredentialServiceTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Celbridge.Credentials;
 using Celbridge.Settings.Services;
 using Celbridge.Tests.FileSystem;
+using Celbridge.Tests.Helpers;
 
 namespace Celbridge.Tests.Settings;
 
@@ -44,30 +45,6 @@ public sealed class FakeCredentialProtector : ICredentialProtector
 [TestFixture]
 public class CredentialServiceTests
 {
-    // Hand-rolled stub because Castle DynamicProxy cannot generate a proxy
-    // for ILogger of the internal CredentialService type without an
-    // InternalsVisibleTo("DynamicProxyGenAssembly2") entry on Celbridge.Settings.
-    private sealed class NullLogger<T> : ILogger<T>
-    {
-        public void LogDebug(Exception? exception, string? message, params object?[] args) {}
-        public void LogDebug(string? message, params object?[] args) {}
-        public void LogTrace(Exception? exception, string? message, params object?[] args) {}
-        public void LogTrace(string? message, params object?[] args) {}
-        public void LogInformation(Exception? exception, string? message, params object?[] args) {}
-        public void LogInformation(string? message, params object?[] args) {}
-        public void LogWarning(Exception? exception, string? message, params object?[] args) {}
-        public void LogWarning(string? message, params object?[] args) {}
-        public void LogWarning(Result result, string? message, params object?[] args) {}
-        public void LogError(Exception? exception, string? message, params object?[] args) {}
-        public void LogError(string? message, params object?[] args) {}
-        public void LogError(Result result, string? message, params object?[] args) {}
-        public void LogCritical(Exception? exception, string? message, params object?[] args) {}
-        public void LogCritical(string? message, params object?[] args) {}
-        public void LogCritical(Result result, string? message, params object?[] args) {}
-        public IDisposable? BeginScope(string messageFormat, params object?[] args) => null;
-        public void Shutdown() {}
-    }
-
     private const string CredentialsFilePath = @"C:\AppData\Celbridge\credentials.json";
     private const string WorkshopUrl = "https://workshop.celbridge.org";
     private const string ApplicationKey = "kpf_abc123_supersecretvalue";
@@ -104,13 +81,56 @@ public class CredentialServiceTests
         _protector.Available = false;
         var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
 
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
         var getResult = await _credentialService.GetWorkshopConnectionAsync();
         var setResult = await _credentialService.SetWorkshopConnectionAsync(connection);
         var clearResult = await _credentialService.ClearWorkshopConnectionAsync();
 
+        summaryResult.IsFailure.Should().BeTrue();
         getResult.IsFailure.Should().BeTrue();
         setResult.IsFailure.Should().BeTrue();
         clearResult.IsFailure.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetSummary_NothingStored_ReportsNotStored()
+    {
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
+
+        summaryResult.IsSuccess.Should().BeTrue();
+
+        var summary = summaryResult.Value;
+        summary.IsStored.Should().BeFalse();
+        summary.KeyHint.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetSummary_StoredConnection_ReportsKeyHint()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
+
+        summaryResult.IsSuccess.Should().BeTrue();
+
+        var summary = summaryResult.Value;
+        summary.IsStored.Should().BeTrue();
+        summary.KeyHint.Should().Be("kpf_abc123");
+    }
+
+    [Test]
+    public async Task GetSummary_CorruptDocument_ReportsStoredWithoutHint()
+    {
+        _fileSystem.SeedFile(CredentialsFilePath, "this is not json");
+
+        var summaryResult = await _credentialService.GetWorkshopConnectionSummaryAsync();
+
+        summaryResult.IsSuccess.Should().BeTrue();
+
+        var summary = summaryResult.Value;
+        summary.IsStored.Should().BeTrue();
+        summary.KeyHint.Should().BeEmpty();
     }
 
     [Test]

--- a/Source/Tests/Settings/CredentialServiceTests.cs
+++ b/Source/Tests/Settings/CredentialServiceTests.cs
@@ -1,0 +1,285 @@
+using System.Text.Json;
+using Celbridge.Credentials;
+using Celbridge.Settings.Services;
+using Celbridge.Tests.FileSystem;
+
+namespace Celbridge.Tests.Settings;
+
+/// <summary>
+/// In-memory protector that reverses the payload bytes, so protected data
+/// never matches the plaintext but round-trips exactly.
+/// </summary>
+public sealed class FakeCredentialProtector : ICredentialProtector
+{
+    public bool Available { get; set; } = true;
+
+    public bool FailUnprotect { get; set; }
+
+    public bool IsAvailable => Available;
+
+    public Result<byte[]> Protect(byte[] plainData)
+    {
+        var protectedData = plainData.Reverse().ToArray();
+
+        return protectedData;
+    }
+
+    public Result<byte[]> Unprotect(byte[] protectedData)
+    {
+        if (FailUnprotect)
+        {
+            return Result.Fail("Simulated unprotect failure");
+        }
+
+        var plainData = protectedData.Reverse().ToArray();
+
+        return plainData;
+    }
+}
+
+/// <summary>
+/// Unit tests for CredentialService covering the Workshop connection
+/// round-trip, clearing, missing and corrupted store files, and availability.
+/// </summary>
+[TestFixture]
+public class CredentialServiceTests
+{
+    // Hand-rolled stub because Castle DynamicProxy cannot generate a proxy
+    // for ILogger of the internal CredentialService type without an
+    // InternalsVisibleTo("DynamicProxyGenAssembly2") entry on Celbridge.Settings.
+    private sealed class NullLogger<T> : ILogger<T>
+    {
+        public void LogDebug(Exception? exception, string? message, params object?[] args) {}
+        public void LogDebug(string? message, params object?[] args) {}
+        public void LogTrace(Exception? exception, string? message, params object?[] args) {}
+        public void LogTrace(string? message, params object?[] args) {}
+        public void LogInformation(Exception? exception, string? message, params object?[] args) {}
+        public void LogInformation(string? message, params object?[] args) {}
+        public void LogWarning(Exception? exception, string? message, params object?[] args) {}
+        public void LogWarning(string? message, params object?[] args) {}
+        public void LogWarning(Result result, string? message, params object?[] args) {}
+        public void LogError(Exception? exception, string? message, params object?[] args) {}
+        public void LogError(string? message, params object?[] args) {}
+        public void LogError(Result result, string? message, params object?[] args) {}
+        public void LogCritical(Exception? exception, string? message, params object?[] args) {}
+        public void LogCritical(string? message, params object?[] args) {}
+        public void LogCritical(Result result, string? message, params object?[] args) {}
+        public IDisposable? BeginScope(string messageFormat, params object?[] args) => null;
+        public void Shutdown() {}
+    }
+
+    private const string CredentialsFilePath = @"C:\AppData\Celbridge\credentials.json";
+    private const string WorkshopUrl = "https://workshop.celbridge.org";
+    private const string ApplicationKey = "kpf_abc123_supersecretvalue";
+
+    private FakeFileSystem _fileSystem = null!;
+    private FakeCredentialProtector _protector = null!;
+    private CredentialService _credentialService = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fileSystem = new FakeFileSystem();
+        _protector = new FakeCredentialProtector();
+        _credentialService = new CredentialService(
+            new NullLogger<CredentialService>(),
+            _fileSystem,
+            _protector,
+            CredentialsFilePath);
+    }
+
+    [Test]
+    public void IsAvailable_MirrorsProtectorAvailability()
+    {
+        _protector.Available = true;
+        _credentialService.IsAvailable.Should().BeTrue();
+
+        _protector.Available = false;
+        _credentialService.IsAvailable.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AllOperations_FailWhenStoreIsUnavailable()
+    {
+        _protector.Available = false;
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        var setResult = await _credentialService.SetWorkshopConnectionAsync(connection);
+        var clearResult = await _credentialService.ClearWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        setResult.IsFailure.Should().BeTrue();
+        clearResult.IsFailure.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SetThenGet_RoundTripsConnection()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+
+        var setResult = await _credentialService.SetWorkshopConnectionAsync(connection);
+        setResult.IsSuccess.Should().BeTrue();
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        getResult.IsSuccess.Should().BeTrue();
+
+        var storedConnection = getResult.Value;
+        storedConnection.Should().Be(connection);
+    }
+
+    [Test]
+    public async Task Set_WritesNoPlaintextToDisk()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+
+        var readResult = await _fileSystem.ReadAllTextAsync(CredentialsFilePath);
+        var documentText = readResult.Value;
+        documentText.Should().NotContain(WorkshopUrl);
+        documentText.Should().NotContain(ApplicationKey);
+    }
+
+    [Test]
+    public async Task Set_StoresKeyDisplayHint()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+
+        var entry = await ReadStoredEntryAsync();
+        entry.KeyHint.Should().Be("kpf_abc123");
+    }
+
+    [Test]
+    public async Task Set_KeyWithUnexpectedShape_StoresEmptyHint()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, "not-a-kpf-shaped-key");
+
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+
+        var entry = await ReadStoredEntryAsync();
+        entry.KeyHint.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Set_EmptyValues_Fail()
+    {
+        var emptyUrl = new WorkshopConnection(string.Empty, ApplicationKey);
+        var emptyKey = new WorkshopConnection(WorkshopUrl, string.Empty);
+
+        var emptyUrlResult = await _credentialService.SetWorkshopConnectionAsync(emptyUrl);
+        var emptyKeyResult = await _credentialService.SetWorkshopConnectionAsync(emptyKey);
+
+        emptyUrlResult.IsFailure.Should().BeTrue();
+        emptyKeyResult.IsFailure.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Get_MissingFile_FailsWithActionableMessage()
+    {
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("No Workshop connection is configured");
+        getResult.FirstErrorMessage.Should().Contain("Settings page");
+    }
+
+    [Test]
+    public async Task Get_CorruptDocument_FailsCleanly()
+    {
+        _fileSystem.SeedFile(CredentialsFilePath, "this is not json");
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("could not be read");
+    }
+
+    [Test]
+    public async Task Get_CorruptProtectedBlob_FailsCleanly()
+    {
+        var documentText = """
+            {
+              "Version": 1,
+              "WorkshopConnection": {
+                "ProtectedData": "@@not-valid-base64@@",
+                "KeyHint": "kpf_abc123"
+              }
+            }
+            """;
+        _fileSystem.SeedFile(CredentialsFilePath, documentText);
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("could not be read");
+    }
+
+    [Test]
+    public async Task Get_UnprotectFailure_FailsWithoutEchoingValues()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+        _protector.FailUnprotect = true;
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.MessageChain.Should().NotContain(WorkshopUrl);
+        getResult.MessageChain.Should().NotContain(ApplicationKey);
+    }
+
+    [Test]
+    public async Task Get_TamperedPayload_FailsCleanly()
+    {
+        var garbagePayload = "garbage payload"u8.ToArray();
+        var protectResult = _protector.Protect(garbagePayload);
+        var protectedData = protectResult.Value;
+
+        var entry = new WorkshopConnectionEntry(Convert.ToBase64String(protectedData), string.Empty);
+        var document = new CredentialStoreDocument(1, entry);
+        _fileSystem.SeedFile(CredentialsFilePath, JsonSerializer.Serialize(document));
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("could not be read");
+    }
+
+    [Test]
+    public async Task Clear_RemovesStoredConnection()
+    {
+        var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);
+        await _credentialService.SetWorkshopConnectionAsync(connection);
+
+        var clearResult = await _credentialService.ClearWorkshopConnectionAsync();
+        clearResult.IsSuccess.Should().BeTrue();
+
+        _fileSystem.Files.Should().NotContainKey(CredentialsFilePath);
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("No Workshop connection is configured");
+    }
+
+    [Test]
+    public async Task Clear_WhenNothingStored_Succeeds()
+    {
+        var clearResult = await _credentialService.ClearWorkshopConnectionAsync();
+
+        clearResult.IsSuccess.Should().BeTrue();
+    }
+
+    private async Task<WorkshopConnectionEntry> ReadStoredEntryAsync()
+    {
+        var readResult = await _fileSystem.ReadAllTextAsync(CredentialsFilePath);
+        var documentText = readResult.Value;
+        var document = JsonSerializer.Deserialize<CredentialStoreDocument>(documentText);
+        document.Should().NotBeNull();
+        document!.WorkshopConnection.Should().NotBeNull();
+
+        return document.WorkshopConnection!;
+    }
+}

--- a/Source/Tests/Settings/CredentialServiceTests.cs
+++ b/Source/Tests/Settings/CredentialServiceTests.cs
@@ -218,6 +218,26 @@ public class CredentialServiceTests
     }
 
     [Test]
+    public async Task Get_NewerStoreVersion_FailsCleanly()
+    {
+        var documentText = """
+            {
+              "Version": 2,
+              "WorkshopConnection": {
+                "ProtectedData": "AAAA",
+                "KeyHint": ""
+              }
+            }
+            """;
+        _fileSystem.SeedFile(CredentialsFilePath, documentText);
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+
+        getResult.IsFailure.Should().BeTrue();
+        getResult.FirstErrorMessage.Should().Contain("newer version");
+    }
+
+    [Test]
     public async Task Get_UnprotectFailure_FailsWithoutEchoingValues()
     {
         var connection = new WorkshopConnection(WorkshopUrl, ApplicationKey);

--- a/Source/Tests/Settings/DpapiCredentialProtectorTests.cs
+++ b/Source/Tests/Settings/DpapiCredentialProtectorTests.cs
@@ -1,0 +1,57 @@
+using System.Text;
+using Celbridge.Settings.Services;
+
+namespace Celbridge.Tests.Settings;
+
+/// <summary>
+/// Unit tests for the Windows DPAPI credential protector. The DPAPI tests
+/// only run on Windows; the protector reports itself unavailable elsewhere.
+/// </summary>
+[TestFixture]
+public class DpapiCredentialProtectorTests
+{
+    private DpapiCredentialProtector _protector = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _protector = new DpapiCredentialProtector();
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void IsAvailable_OnWindows_IsTrue()
+    {
+        _protector.IsAvailable.Should().BeTrue();
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void ProtectThenUnprotect_RoundTripsData()
+    {
+        var plainData = Encoding.UTF8.GetBytes("credential payload");
+
+        var protectResult = _protector.Protect(plainData);
+        protectResult.IsSuccess.Should().BeTrue();
+
+        var protectedData = protectResult.Value;
+        protectedData.Should().NotEqual(plainData);
+
+        var unprotectResult = _protector.Unprotect(protectedData);
+        unprotectResult.IsSuccess.Should().BeTrue();
+
+        var roundTrippedData = unprotectResult.Value;
+        roundTrippedData.Should().Equal(plainData);
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void Unprotect_InvalidBlob_FailsWithoutThrowing()
+    {
+        var invalidBlob = new byte[] { 1, 2, 3, 4, 5 };
+
+        var unprotectResult = _protector.Unprotect(invalidBlob);
+
+        unprotectResult.IsFailure.Should().BeTrue();
+    }
+}

--- a/Source/Tests/UserInterface/SettingsPageViewModelTests.cs
+++ b/Source/Tests/UserInterface/SettingsPageViewModelTests.cs
@@ -1,0 +1,203 @@
+using Celbridge.Credentials;
+using Celbridge.Settings.Services;
+using Celbridge.Tests.FileSystem;
+using Celbridge.Tests.Helpers;
+using Celbridge.Tests.Settings;
+using Celbridge.UserInterface.ViewModels.Pages;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Unit tests for the Workshop connection section of the Settings page view
+/// model, driven against the real CredentialService over fakes.
+/// </summary>
+[TestFixture]
+public class SettingsPageViewModelTests
+{
+    private const string CredentialsFilePath = @"C:\AppData\Celbridge\credentials.json";
+    private const string WorkshopUrl = "https://workshop.celbridge.org";
+    private const string ApplicationKey = "kpf_abc123_supersecretvalue";
+
+    private FakeFileSystem _fileSystem = null!;
+    private FakeCredentialProtector _protector = null!;
+    private CredentialService _credentialService = null!;
+    private SettingsPageViewModel _viewModel = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fileSystem = new FakeFileSystem();
+        _protector = new FakeCredentialProtector();
+        _credentialService = new CredentialService(
+            new NullLogger<CredentialService>(),
+            _fileSystem,
+            _protector,
+            CredentialsFilePath);
+
+        var stringLocalizer = Substitute.For<IStringLocalizer>();
+        stringLocalizer[Arg.Any<string>()].Returns(
+            callInfo => new LocalizedString(callInfo.Arg<string>(), callInfo.Arg<string>()));
+
+        _viewModel = new SettingsPageViewModel(
+            Substitute.For<ILogger<SettingsPageViewModel>>(),
+            _credentialService,
+            stringLocalizer);
+    }
+
+    [Test]
+    public async Task Initialize_NothingStored_ShowsKeyEntry()
+    {
+        await _viewModel.InitializeAsync();
+
+        _viewModel.IsStoreAvailable.Should().BeTrue();
+        _viewModel.IsKeyEntryVisible.Should().BeTrue();
+        _viewModel.IsStoredKeyVisible.Should().BeFalse();
+        _viewModel.IsClearVisible.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Initialize_StoreUnavailable_ShowsErrorAndDisablesEntry()
+    {
+        _protector.Available = false;
+
+        await _viewModel.InitializeAsync();
+
+        _viewModel.IsStoreAvailable.Should().BeFalse();
+        _viewModel.IsErrorVisible.Should().BeTrue();
+        _viewModel.IsKeyEntryVisible.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Initialize_StoredConnection_ShowsUrlAndKeyPrefix()
+    {
+        await _credentialService.SetWorkshopConnectionAsync(new WorkshopConnection(WorkshopUrl, ApplicationKey));
+
+        await _viewModel.InitializeAsync();
+
+        _viewModel.WorkshopUrl.Should().Be(WorkshopUrl);
+        _viewModel.StoredKeyDisplay.Should().Be("kpf_abc123_...");
+        _viewModel.IsStoredKeyVisible.Should().BeTrue();
+        _viewModel.IsKeyEntryVisible.Should().BeFalse();
+        _viewModel.IsClearVisible.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Save_NewConnection_StoresAndShowsStoredKey()
+    {
+        await _viewModel.InitializeAsync();
+        _viewModel.WorkshopUrl = WorkshopUrl;
+        _viewModel.ApplicationKey = ApplicationKey;
+
+        await _viewModel.SaveWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.IsErrorVisible.Should().BeFalse();
+        _viewModel.IsStatusVisible.Should().BeTrue();
+        _viewModel.ApplicationKey.Should().BeEmpty("the entered key should not linger in the view model");
+        _viewModel.IsStoredKeyVisible.Should().BeTrue();
+        _viewModel.StoredKeyDisplay.Should().Be("kpf_abc123_...");
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        getResult.IsSuccess.Should().BeTrue();
+
+        var storedConnection = getResult.Value;
+        storedConnection.Should().Be(new WorkshopConnection(WorkshopUrl, ApplicationKey));
+    }
+
+    [Test]
+    public async Task Save_InvalidUrl_ShowsErrorAndStoresNothing()
+    {
+        await _viewModel.InitializeAsync();
+        _viewModel.WorkshopUrl = "http://workshop.celbridge.org";
+        _viewModel.ApplicationKey = ApplicationKey;
+
+        await _viewModel.SaveWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.IsErrorVisible.Should().BeTrue();
+        _fileSystem.Files.Should().NotContainKey(CredentialsFilePath);
+    }
+
+    [Test]
+    public async Task Save_EmptyKey_ShowsError()
+    {
+        await _viewModel.InitializeAsync();
+        _viewModel.WorkshopUrl = WorkshopUrl;
+        _viewModel.ApplicationKey = string.Empty;
+
+        await _viewModel.SaveWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.IsErrorVisible.Should().BeTrue();
+        _fileSystem.Files.Should().NotContainKey(CredentialsFilePath);
+    }
+
+    [Test]
+    public async Task Save_KeyWithoutExpectedPrefix_WarnsButStores()
+    {
+        await _viewModel.InitializeAsync();
+        _viewModel.WorkshopUrl = WorkshopUrl;
+        _viewModel.ApplicationKey = "not-a-kpf-shaped-key";
+
+        await _viewModel.SaveWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.IsErrorVisible.Should().BeFalse();
+        _viewModel.IsWarningVisible.Should().BeTrue("the prefix check is a typo guard, not a gate");
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        getResult.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Save_UrlOnlyUpdate_PreservesStoredKey()
+    {
+        await _credentialService.SetWorkshopConnectionAsync(new WorkshopConnection(WorkshopUrl, ApplicationKey));
+        await _viewModel.InitializeAsync();
+
+        var updatedUrl = "https://other.celbridge.org";
+        _viewModel.WorkshopUrl = updatedUrl;
+
+        await _viewModel.SaveWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.IsErrorVisible.Should().BeFalse();
+
+        var getResult = await _credentialService.GetWorkshopConnectionAsync();
+        getResult.IsSuccess.Should().BeTrue();
+
+        var storedConnection = getResult.Value;
+        storedConnection.Should().Be(new WorkshopConnection(updatedUrl, ApplicationKey));
+    }
+
+    [Test]
+    public async Task Clear_RemovesConnectionAndResetsForm()
+    {
+        await _credentialService.SetWorkshopConnectionAsync(new WorkshopConnection(WorkshopUrl, ApplicationKey));
+        await _viewModel.InitializeAsync();
+
+        await _viewModel.ClearWorkshopConnectionCommand.ExecuteAsync(null);
+
+        _viewModel.WorkshopUrl.Should().BeEmpty();
+        _viewModel.StoredKeyDisplay.Should().BeEmpty();
+        _viewModel.IsKeyEntryVisible.Should().BeTrue();
+        _viewModel.IsClearVisible.Should().BeFalse();
+        _fileSystem.Files.Should().NotContainKey(CredentialsFilePath);
+    }
+
+    [Test]
+    public async Task ReplaceThenCancel_RestoresStoredKeyDisplay()
+    {
+        await _credentialService.SetWorkshopConnectionAsync(new WorkshopConnection(WorkshopUrl, ApplicationKey));
+        await _viewModel.InitializeAsync();
+
+        _viewModel.ReplaceApplicationKeyCommand.Execute(null);
+
+        _viewModel.IsKeyEntryVisible.Should().BeTrue();
+        _viewModel.IsStoredKeyVisible.Should().BeFalse();
+        _viewModel.IsCancelReplaceVisible.Should().BeTrue();
+
+        _viewModel.ApplicationKey = "kpf_new123_partiallyentered";
+        _viewModel.CancelReplaceApplicationKeyCommand.Execute(null);
+
+        _viewModel.ApplicationKey.Should().BeEmpty();
+        _viewModel.IsKeyEntryVisible.Should().BeFalse();
+        _viewModel.IsStoredKeyVisible.Should().BeTrue();
+    }
+}

--- a/Source/Tests/UserInterface/WorkshopConnectionValidationTests.cs
+++ b/Source/Tests/UserInterface/WorkshopConnectionValidationTests.cs
@@ -1,0 +1,38 @@
+using Celbridge.UserInterface.Helpers;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Unit tests for the Workshop connection save-time validation rules.
+/// </summary>
+[TestFixture]
+public class WorkshopConnectionValidationTests
+{
+    [TestCase("https://workshop.celbridge.org")]
+    [TestCase("https://workshop.celbridge.org/api/v1")]
+    [TestCase("http://localhost:5000")]
+    [TestCase("http://127.0.0.1:5000")]
+    [TestCase("  https://workshop.celbridge.org  ")]
+    public void IsValidWorkshopUrl_AcceptsHttpsAndLoopbackHttp(string workshopUrl)
+    {
+        WorkshopConnectionValidation.IsValidWorkshopUrl(workshopUrl).Should().BeTrue();
+    }
+
+    [TestCase("http://workshop.celbridge.org")]
+    [TestCase("ftp://workshop.celbridge.org")]
+    [TestCase("workshop.celbridge.org")]
+    [TestCase("not a url")]
+    [TestCase("")]
+    public void IsValidWorkshopUrl_RejectsOtherUrls(string workshopUrl)
+    {
+        WorkshopConnectionValidation.IsValidWorkshopUrl(workshopUrl).Should().BeFalse();
+    }
+
+    [Test]
+    public void HasExpectedKeyPrefix_ChecksKpfPrefix()
+    {
+        WorkshopConnectionValidation.HasExpectedKeyPrefix("kpf_abc123_secret").Should().BeTrue();
+        WorkshopConnectionValidation.HasExpectedKeyPrefix("apikey-12345").Should().BeFalse();
+        WorkshopConnectionValidation.HasExpectedKeyPrefix("").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
This pull request introduces a secure credential storage system for the Workshop connection, enabling the application to safely store and manage sensitive Workshop URLs and Application Keys on supported platforms (currently, Windows via DPAPI). It provides a clear API for storing, retrieving, and clearing credentials, with robust error handling and user feedback. Additionally, it adds new localized strings and updates the service configuration to wire up the new functionality.

The most important changes are:

**Credential Storage System Implementation:**

* Added a new `ICredentialService` interface and related records (`WorkshopConnection`, `WorkshopConnectionSummary`) to define a secure, application-scoped credential store API. This API supports storing, retrieving, and clearing the Workshop connection, and provides summaries for display without exposing secrets. (`Source/Core/Celbridge.Foundation/Credentials/ICredentialService.cs`)
* Implemented `CredentialService`, which serializes encrypted credentials to a JSON file in the user's application data folder, with all file access serialized for safety. Includes detailed error handling and recovery for corrupt or unavailable stores. (`Source/Core/Celbridge.Settings/Services/CredentialService.cs`)
* Introduced `ICredentialProtector` abstraction and a Windows DPAPI implementation (`DpapiCredentialProtector`) for encrypting/decrypting credential data at rest. (`Source/Core/Celbridge.Settings/Services/ICredentialProtector.cs`, `Source/Core/Celbridge.Settings/Services/DpapiCredentialProtector.cs`) [[1]](diffhunk://#diff-6a902ca1bccea466c36a1519433dd0af8b1f2e21be7f1bb57fe177e1bbbef7adR1-R26) [[2]](diffhunk://#diff-a94764d42e9cf152c397a754319863cf2014ae35bcdff13cb21e31526bb07e4fR1-R52)

**Integration and Configuration:**

* Registered the new credential service and protector in the application's dependency injection container. (`Source/Core/Celbridge.Settings/ServiceConfiguration.cs`) [[1]](diffhunk://#diff-3123ce53035b313cb76b4ba6235a1ec63c90b6e39bb05cd4e5edb19e978e6ed9R1) [[2]](diffhunk://#diff-3123ce53035b313cb76b4ba6235a1ec63c90b6e39bb05cd4e5edb19e978e6ed9R17-R18)
* Added a package reference to `System.Security.Cryptography.ProtectedData` and made internals visible to the test project. (`Source/Core/Celbridge.Settings/Celbridge.Settings.csproj`)

**User Interface and Localization:**

* Added new localized strings for the Settings page to support Workshop credential management actions and error messages. (`Source/Celbridge/Resources/Strings/en-US/Resources.resw`)

**Constants and Minor Updates:**

* Added `CredentialConstants` to centralize the Application Key prefix logic. (`Source/Core/Celbridge.Foundation/Credentials/CredentialConstants.cs`)
* Minor documentation update to the MCP feature flag for clarity. (`Source/Core/Celbridge.Foundation/Settings/FeatureFlagConstants.cs`)
* Minor code cleanup and using directives. (`Source/Core/Celbridge.Settings/GlobalUsings.cs`)

These changes collectively provide a secure, extensible foundation for handling sensitive Workshop credentials in a cross-platform manner, with immediate support for Windows and clear extension points for other platforms.