### PR TITLE
Upgrade to .NET 10 and update nuget dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore Source/Tests/Celbridge.Tests.csproj

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Each release includes an example project that demonstrates the core features of 
 3. Follow the Visual Studio setup instructions for [Uno Platform](https://platform.uno/docs/articles/get-started-vs-2022.html?tabs=ubuntu1804) development.
 4. Open `Celbridge.slnx` in Visual Studio.
 5. In `Solution Explorer`, right click on the `Celbridge.Application` project and select `Set as Startup Project`.
-6. Select the `Celbridge.Application (WinAppSDK Packaged)` and `net9.0-windows10.0.22621` targets in the Visual Studio configuration toolbar.
+6. Select the `Celbridge.Application (WinAppSDK Packaged)` and `net10.0-windows10.0.22621` targets in the Visual Studio configuration toolbar.
 7. Build and run the application.
 
 If you encounter build errors, try restarting Visual Studio. If this fails, do a clean build.

--- a/Source/Celbridge/Celbridge.Application.csproj
+++ b/Source/Celbridge/Celbridge.Application.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-windows10.0.22621;net9.0-desktop;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-windows10.0.22621;net10.0-desktop;net10.0</TargetFrameworks>
     <UnoDisableVSWarnWindowsIsFirst>true</UnoDisableVSWarnWindowsIsFirst>
     
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
     <ApplicationTitle>Celbridge</ApplicationTitle>
     <ApplicationId>org.celbridge.Celbridge</ApplicationId>
     <!-- ApplicationDisplayVersion is the single source of the version; Version derives from it so every
-         TFM agrees. The Uno.Sdk maps it to $(Version) on the platform heads but not the plain net9.0 TFM,
+         TFM agrees. The Uno.Sdk maps it to $(Version) on the platform heads but not the plain net10.0 TFM,
          which would otherwise default to 1.0.0 and fail project load in Visual Studio. The packaged
          Windows Identity Version in Package.appxmanifest is separate, keep it in sync. -->
     <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
@@ -47,7 +47,7 @@
   </PropertyGroup>
 
   <!-- Custom Info.plist for the macOS desktop bundle (see that file for details). -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-desktop'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-desktop'">
     <UnoMacOSCustomInfoPlist>$(MSBuildProjectDirectory)/Platforms/Desktop/Info.plist</UnoMacOSCustomInfoPlist>
   </PropertyGroup>
 

--- a/Source/Celbridge/Properties/launchSettings.json
+++ b/Source/Celbridge/Properties/launchSettings.json
@@ -15,7 +15,7 @@
     },
     "Celbridge (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net9.0-desktop/Celbridge.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/Celbridge.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/Source/Core/Celbridge.Commands/Celbridge.Commands.csproj
+++ b/Source/Core/Celbridge.Commands/Celbridge.Commands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.FileSystem/Celbridge.FileSystem.csproj
+++ b/Source/Core/Celbridge.FileSystem/Celbridge.FileSystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Foundation/Celbridge.Foundation.csproj
+++ b/Source/Core/Celbridge.Foundation/Celbridge.Foundation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Host/Celbridge.Host.csproj
+++ b/Source/Core/Celbridge.Host/Celbridge.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Logging/Celbridge.Logging.csproj
+++ b/Source/Core/Celbridge.Logging/Celbridge.Logging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Messaging/Celbridge.Messaging.csproj
+++ b/Source/Core/Celbridge.Messaging/Celbridge.Messaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Modules/Celbridge.Modules.csproj
+++ b/Source/Core/Celbridge.Modules/Celbridge.Modules.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
+++ b/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
@@ -36,8 +36,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Celbridge.Foundation\Celbridge.Foundation.csproj" />
     <ProjectReference Include="..\..\Core\Celbridge.Utilities\Celbridge.Utilities.csproj" />
-    <!-- UndefineProperties stops a global TargetFramework (e.g. dotnet build -f net9.0-desktop)
-         from forcing net9.0-desktop onto this net9.0 NoTargets project (NETSDK1139). -->
+    <!-- UndefineProperties stops a global TargetFramework (e.g. dotnet build -f net10.0-desktop)
+         from forcing net10.0-desktop onto this net10.0 NoTargets project (NETSDK1139). -->
     <ProjectReference Include="..\..\Templates\Celbridge.Templates.csproj" ReferenceOutputAssembly="false" UndefineProperties="TargetFramework" />
   </ItemGroup>
 

--- a/Source/Core/Celbridge.Projects/Services/ProjectConfigParser.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectConfigParser.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Parsing;
 
 namespace Celbridge.Projects.Services;
 
@@ -49,14 +50,14 @@ public static class ProjectConfigParser
             // a project config written with non-standard line endings still
             // parses cleanly.
             var text = LineEndingHelper.ConvertLineEndings(readResult.Value, "\n");
-            var parse = Toml.Parse(text);
+            var parse = SyntaxParser.Parse(text);
             if (parse.HasErrors)
             {
                 var errors = string.Join("; ", parse.Diagnostics.Select(d => d.ToString()));
                 return Result<ProjectConfig>.Fail($"TOML parse error(s): {errors}");
             }
 
-            var root = (TomlTable)parse.ToModel();
+            var root = TomlSerializer.Deserialize<TomlTable>(text);
             var config = MapRootToModel(root);
 
             return Result<ProjectConfig>.Ok(config);

--- a/Source/Core/Celbridge.Projects/Services/ProjectConfigReader.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectConfigReader.cs
@@ -1,6 +1,7 @@
 using Celbridge.Logging;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Parsing;
 
 namespace Celbridge.Projects.Services;
 
@@ -71,7 +72,7 @@ public class ProjectConfigReader
             }
 
             var text = readResult.Value;
-            var parse = Toml.Parse(text);
+            var parse = SyntaxParser.Parse(text);
 
             if (parse.HasErrors)
             {
@@ -87,7 +88,7 @@ public class ProjectConfigReader
                     IsConfigValid: false));
             }
 
-            var root = (TomlTable)parse.ToModel();
+            var root = TomlSerializer.Deserialize<TomlTable>(text);
             isConfigValid = true;
 
             // Try to extract version from [celbridge] section

--- a/Source/Core/Celbridge.Projects/Services/ProjectMigrationService.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectMigrationService.cs
@@ -3,6 +3,7 @@ using Celbridge.Platform;
 using Celbridge.Logging;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Parsing;
 
 namespace Celbridge.Projects.Services;
 
@@ -119,7 +120,7 @@ public class ProjectMigrationService : IProjectMigrationService
             // anything that produced CR-only line endings somewhere upstream)
             // still parse cleanly.
             var text = LineEndingHelper.ConvertLineEndings(readResult.Value, "\n");
-            var parse = Toml.Parse(text);
+            var parse = SyntaxParser.Parse(text);
 
             if (parse.HasErrors)
             {
@@ -128,7 +129,7 @@ public class ProjectMigrationService : IProjectMigrationService
                     Result.Fail($"Failed to parse project TOML file: {string.Join("; ", parse.Diagnostics)}"));
             }
 
-            var root = parse.ToModel();
+            var root = TomlSerializer.Deserialize<TomlTable>(text);
 
             // Get project version from [celbridge].celbridge-version property
             var projectVersion = string.Empty;
@@ -529,14 +530,14 @@ public class ProjectMigrationService : IProjectMigrationService
         // Match ParseProjectVersionInfoAsync: collapse any bare-\r line
         // endings to \n before handing the bytes to Tomlyn.
         var text = LineEndingHelper.ConvertLineEndings(readResult.Value, "\n");
-        var parse = Toml.Parse(text);
+        var parse = SyntaxParser.Parse(text);
 
         if (parse.HasErrors)
         {
             return Result<TomlTable>.Fail($"Failed to parse project TOML file: {string.Join("; ", parse.Diagnostics)}");
         }
 
-        var root = parse.ToModel();
+        var root = TomlSerializer.Deserialize<TomlTable>(text);
         return Result<TomlTable>.Ok(root);
     }
 }

--- a/Source/Core/Celbridge.Server/Celbridge.Server.csproj
+++ b/Source/Core/Celbridge.Server/Celbridge.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Settings/Celbridge.Settings.csproj
+++ b/Source/Core/Celbridge.Settings/Celbridge.Settings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Tools/Celbridge.Tools.csproj
+++ b/Source/Core/Celbridge.Tools/Celbridge.Tools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Publish.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Publish.cs
@@ -341,7 +341,7 @@ public partial class PackageTools
         TomlTable tomlTable;
         try
         {
-            tomlTable = Toml.ToModel(tomlContent);
+            tomlTable = TomlSerializer.Deserialize<TomlTable>(tomlContent);
         }
         catch (TomlException exception)
         {

--- a/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
@@ -207,7 +207,7 @@ public partial class PageTools
         TomlTable tomlTable;
         try
         {
-            tomlTable = Toml.ToModel(tomlContent);
+            tomlTable = TomlSerializer.Deserialize<TomlTable>(tomlContent);
         }
         catch (TomlException exception)
         {

--- a/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
+++ b/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.Utilities/Celbridge.Utilities.csproj
+++ b/Source/Core/Celbridge.Utilities/Celbridge.Utilities.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Core/Celbridge.WebHost/Celbridge.WebHost.csproj
+++ b/Source/Core/Celbridge.WebHost/Celbridge.WebHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Directory.Build.targets
+++ b/Source/Directory.Build.targets
@@ -12,7 +12,7 @@
 
     UndefineProperties="TargetFramework" stops a consuming project's TargetFramework
     from flowing into the netstandard2.0 analyzer. Without it, a CLI build that sets a
-    global TargetFramework (e.g. dotnet build -f net9.0-desktop) forces net9.0-desktop
+    global TargetFramework (e.g. dotnet build -f net10.0-desktop) forces net10.0-desktop
     onto the analyzer and fails with NETSDK1139 (unrecognized platform "desktop").
   -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Celbridge.FileSystem.Analyzers' and '$(IsTestProject)' != 'true'">

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="OpenAI" Version="2.8.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.17" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
   </ItemGroup>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -1,25 +1,25 @@
 <Project ToolsVersion="15.0">
   <ItemGroup>
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
-    <PackageVersion Include="Humanizer" Version="3.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="Ignore" Version="0.2.1" />
-    <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
-    <PackageVersion Include="JsonPointer.Net" Version="5.3.1" />
-    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
-    <PackageVersion Include="NLog" Version="6.0.7" />
-    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.0" />
+    <PackageVersion Include="JsonPatch.Net" Version="5.0.3" />
+    <PackageVersion Include="JsonPointer.Net" Version="7.0.1" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit" Version="4.4.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="OpenAI" Version="2.8.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.17" />
-    <PackageVersion Include="Tomlyn" Version="0.19.0" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
+    <PackageVersion Include="Tomlyn" Version="2.9.0" />
   </ItemGroup>
 </Project>

--- a/Source/Modules/Celbridge.Core/Celbridge.Core.csproj
+++ b/Source/Modules/Celbridge.Core/Celbridge.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Modules/Celbridge.DocumentEditors/Celbridge.DocumentEditors.csproj
+++ b/Source/Modules/Celbridge.DocumentEditors/Celbridge.DocumentEditors.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
+++ b/Source/Modules/Celbridge.Screenplay/Celbridge.Screenplay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Modules/Celbridge.Spreadsheet/Celbridge.Spreadsheet.csproj
+++ b/Source/Modules/Celbridge.Spreadsheet/Celbridge.Spreadsheet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Modules/Celbridge.WebView/Celbridge.WebView.csproj
+++ b/Source/Modules/Celbridge.WebView/Celbridge.WebView.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Templates/Celbridge.Templates.csproj
+++ b/Source/Templates/Celbridge.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.7.56">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <!-- Zips are copied here so Celbridge.Projects can load them as ms-appx assets -->
     <TemplateOutputFolder>$(MSBuildThisFileDirectory)..\Core\Celbridge.Projects\Assets\Templates</TemplateOutputFolder>
     <!-- Staging area outside this folder to avoid polluting the project tree in VS -->

--- a/Source/Tests/Celbridge.Tests.csproj
+++ b/Source/Tests/Celbridge.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Source/Tests/Celbridge.Tests.csproj
+++ b/Source/Tests/Celbridge.Tests.csproj
@@ -8,7 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/Source/Tests/Migration/Steps/MigrationStepTestBase.cs
+++ b/Source/Tests/Migration/Steps/MigrationStepTestBase.cs
@@ -2,6 +2,7 @@ using Celbridge.FileSystem.Services;
 using Celbridge.Projects.Services;
 using Celbridge.Tests.Migration.TestHelpers;
 using Tomlyn;
+using Tomlyn.Model;
 
 namespace Celbridge.Tests.Migration.Steps;
 
@@ -49,8 +50,7 @@ public abstract class MigrationStepTestBase<T>
         var projectDataFolderPath = Path.Combine(projectFolderPath, "celbridge");
 
         var text = await File.ReadAllTextAsync(projectFilePath);
-        var parse = Toml.Parse(text);
-        var config = parse.ToModel();
+        var config = TomlSerializer.Deserialize<TomlTable>(text);
 
         // If originalVersion not provided, try to extract from the file
         if (originalVersion == null)

--- a/Source/Workspace/Celbridge.Activities/Celbridge.Activities.csproj
+++ b/Source/Workspace/Celbridge.Activities/Celbridge.Activities.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Console/Celbridge.Console.csproj
+++ b/Source/Workspace/Celbridge.Console/Celbridge.Console.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Documents/Celbridge.Documents.csproj
+++ b/Source/Workspace/Celbridge.Documents/Celbridge.Documents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Entities/Celbridge.Entities.csproj
+++ b/Source/Workspace/Celbridge.Entities/Celbridge.Entities.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Entities/Services/ComponentConfigRegistry.cs
+++ b/Source/Workspace/Celbridge.Entities/Services/ComponentConfigRegistry.cs
@@ -282,9 +282,17 @@ public class ComponentConfigRegistry
 
             var prototype = JsonSerializer.Deserialize<JsonElement>(prototypeNode.ToJsonString());
 
-            // Create the JsonSchema object
+            // Create the JsonSchema object.
+            // attributes, prototype and form are Celbridge metadata read from the raw JSON, not JSON
+            // Schema keywords. JsonSchema.Net rejects unknown keywords when parsing, so strip the
+            // metadata keys before building the validation schema.
 
-            var jsonSchema = JsonSchema.FromText(schemaJson);
+            var schemaNode = root.AsNode()!.AsObject();
+            schemaNode.Remove(ComponentConfig.AttributesKey);
+            schemaNode.Remove(ComponentConfig.PrototypeKey);
+            schemaNode.Remove(ComponentConfig.FormKey);
+
+            var jsonSchema = JsonSchema.FromText(schemaNode.ToJsonString());
             if (jsonSchema is null)
             {
                 return Result<ComponentConfig>.Fail($"Failed to parse JSON schema for component type: '{componentType}'");

--- a/Source/Workspace/Celbridge.Explorer/Celbridge.Explorer.csproj
+++ b/Source/Workspace/Celbridge.Explorer/Celbridge.Explorer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Inspector/Celbridge.Inspector.csproj
+++ b/Source/Workspace/Celbridge.Inspector/Celbridge.Inspector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Packages/Celbridge.Packages.csproj
+++ b/Source/Workspace/Celbridge.Packages/Celbridge.Packages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Celbridge.Documents;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Parsing;
 
 namespace Celbridge.Packages;
 
@@ -74,7 +75,7 @@ public static class PackageManifestLoader
                     .WithErrors(readResult);
             }
             var toml = readResult.Value;
-            var parsed = Toml.Parse(toml);
+            var parsed = SyntaxParser.Parse(toml);
 
             if (parsed.HasErrors)
             {
@@ -82,7 +83,7 @@ public static class PackageManifestLoader
                 return Result.Fail($"TOML parse error in {packageTomlPath}: {errors}");
             }
 
-            var root = (TomlTable)parsed.ToModel();
+            var root = TomlSerializer.Deserialize<TomlTable>(toml);
 
             if (!root.TryGetValue(PackageSection, out var packageObject) ||
                 packageObject is not TomlTable packageTable)
@@ -193,7 +194,7 @@ public static class PackageManifestLoader
                     .WithErrors(readResult);
             }
             var toml = readResult.Value;
-            var parsed = Toml.Parse(toml);
+            var parsed = SyntaxParser.Parse(toml);
 
             if (parsed.HasErrors)
             {
@@ -201,7 +202,7 @@ public static class PackageManifestLoader
                 return Result.Fail($"TOML parse error in {documentTomlPath}: {errors}");
             }
 
-            var root = (TomlTable)parsed.ToModel();
+            var root = TomlSerializer.Deserialize<TomlTable>(toml);
 
             if (!root.TryGetValue(DocumentSection, out var documentObject) ||
                 documentObject is not TomlTable documentTable)

--- a/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
+++ b/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
@@ -67,7 +67,7 @@
        system Python on PATH at build time. -->
   <Target Name="BuildPythonWheel" BeforeTargets="Build"
           Inputs="@(PythonSourceFiles)" Outputs="$(PythonWheelPath)"
-          Condition="'$(TargetFramework)' == 'net9.0-windows10.0.22621'">
+          Condition="'$(TargetFramework)' == 'net10.0-windows10.0.22621'">
     <Message Text="Building celbridge Python wheel via build.py..." Importance="high" />
     <Exec Command="python &quot;$(MSBuildThisFileDirectory)build.py&quot;" />
   </Target>

--- a/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
+++ b/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
@@ -24,6 +24,11 @@
     <!-- being incorrectly parsed as Windows resource qualifiers by the PRI indexer. -->
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);PRI249</MSBuildWarningsAsMessages>
 
+    <!-- The wheel is generated during the build and re-included by IncludeGeneratedPythonWheel.
+         Excluding it from the default Assets glob avoids a duplicate MSIX payload (APPX1101) on the
+         packaged Windows head. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);Assets\Python\*.whl</DefaultItemExcludes>
+
   </PropertyGroup>
 
   <!-- Download uv binary from GitHub releases if not already present -->
@@ -47,9 +52,7 @@
     <DownloadFile SourceUrl="$(UvDownloadUrl)" DestinationFolder="$(UvAssetFolder)" DestinationFileName="$(UvZipFileName)" />
   </Target>
 
-  <!-- Build the celbridge Python wheel from source when Python files change.
-       Uses the uv binary (extracted from the downloaded zip) to build the wheel
-       without needing a pre-installed Python or virtual environment. -->
+  <!-- Build the celbridge Python wheel from source when Python files change. -->
   <PropertyGroup>
     <PythonPackageFolder>$(MSBuildThisFileDirectory)packages\celbridge</PythonPackageFolder>
     <PythonAssetsFolder>$(MSBuildThisFileDirectory)Assets\Python</PythonAssetsFolder>
@@ -61,21 +64,23 @@
     <PythonSourceFiles Include="$(PythonPackageFolder)\pyproject.toml" />
   </ItemGroup>
 
-  <!-- Build the wheel for one TFM only. Other TFMs pick it up via IncludePythonAssets.
-       Delegates to build.py so wheel-building logic lives in one place; build.py is
-       also the script developers run manually outside Visual Studio. Requires a
-       system Python on PATH at build time. -->
-  <Target Name="BuildPythonWheel" BeforeTargets="Build"
+  <!-- Rebuild the wheel via build.py (requires a system Python on PATH) before content target paths
+       are assigned. Runs on the Windows head only; other heads use the committed wheel. Skipped during
+       design-time builds so editing Python source in Visual Studio does not invoke pip. -->
+  <Target Name="BuildPythonWheel" BeforeTargets="AssignTargetPaths"
           Inputs="@(PythonSourceFiles)" Outputs="$(PythonWheelPath)"
-          Condition="'$(TargetFramework)' == 'net10.0-windows10.0.22621'">
+          Condition="'$(TargetFramework)' == 'net10.0-windows10.0.22621' AND '$(DesignTimeBuild)' != 'true'">
     <Message Text="Building celbridge Python wheel via build.py..." Importance="high" />
     <Exec Command="python &quot;$(MSBuildThisFileDirectory)build.py&quot;" />
   </Target>
 
-  <!-- Note: the wheel is NOT cleaned during 'Clean' because MSBuild evaluates Content items
-       at project load time. If the file is missing, it won't be included in the AppX package
-       even after BuildPythonWheel recreates it. The target uses Inputs/Outputs to regenerate
-       it when needed. -->
+  <!-- Include the generated wheel as Content before target paths are assigned, so it enters the Uno
+       content pipeline exactly once. -->
+  <Target Name="IncludeGeneratedPythonWheel" BeforeTargets="AssignTargetPaths" DependsOnTargets="BuildPythonWheel">
+    <ItemGroup>
+      <Content Include="Assets\Python\*.whl" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Celbridge.Foundation\Celbridge.Foundation.csproj" />

--- a/Source/Workspace/Celbridge.Resources/Celbridge.Resources.csproj
+++ b/Source/Workspace/Celbridge.Resources/Celbridge.Resources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
@@ -1,6 +1,7 @@
 using Celbridge.Logging;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Parsing;
 
 namespace Celbridge.Resources.Helpers;
 
@@ -199,14 +200,14 @@ public static class SidecarHelper
                     new Dictionary<string, object>());
             }
 
-            var parseResult = Toml.Parse(tomlText);
+            var parseResult = SyntaxParser.Parse(tomlText);
             if (parseResult.HasErrors)
             {
                 var diagnostics = string.Join("; ", parseResult.Diagnostics.Select(d => d.ToString()));
                 return Result<IReadOnlyDictionary<string, object>>.Fail($"TOML parse error(s): {diagnostics}");
             }
 
-            var table = (TomlTable)parseResult.ToModel();
+            var table = TomlSerializer.Deserialize<TomlTable>(tomlText);
             var dictionary = new Dictionary<string, object>();
             foreach (var (key, value) in table)
             {

--- a/Source/Workspace/Celbridge.Search/Celbridge.Search.csproj
+++ b/Source/Workspace/Celbridge.Search/Celbridge.Search.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.Workspace/Celbridge.Workspace.csproj
+++ b/Source/Workspace/Celbridge.Workspace/Celbridge.Workspace.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/Source/Workspace/Celbridge.WorkspaceUI/Celbridge.WorkspaceUI.csproj
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Celbridge.WorkspaceUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.22621;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-windows10.0.22621;net10.0-desktop</TargetFrameworks>
     <UnoDisableVSWarnNetIsFirst>true</UnoDisableVSWarnNetIsFirst>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.36"
   },
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This pull request updates the solution to target .NET 10.0 across all projects and modernizes TOML parsing to use the latest Tomlyn APIs. This ensures compatibility with the newest .NET runtime and improves TOML file handling throughout the codebase.

**.NET 10.0 migration:**
* Updated all `TargetFrameworks` in project files from `net9.0` variants to `net10.0` variants, including desktop and Windows targets. This affects all main projects and core libraries. [[1]](diffhunk://#diff-745de803615d037468a2996cb83796d5347f8720bd53ac9f5b69c82d519900c4L3-R3) [[2]](diffhunk://#diff-d5d901d8eb8e64bbd617a4d23bdc213730fa67b672c5b4bf7fc35a77080a8067L4-R4) [[3]](diffhunk://#diff-8c8c4b08afd0e66925466d023368b4d6670b15eaaba18521de78d98de298fcb4L4-R4) [[4]](diffhunk://#diff-cc609a7fa291ad80adcc024f3593b81c152e637c346c84377605ecfd78049cfaL3-R3) [[5]](diffhunk://#diff-cb990c6da7038d67b465e06b494fe0b59670ea9581905ca902f5f2444803e306L4-R4) [[6]](diffhunk://#diff-f1d7bb752c96ae517a236a941ced9eb975c22c5f404b6557012b41f729cfae2cL4-R4) [[7]](diffhunk://#diff-c744a187ec2c77dfe0fae57fe1c521ba06798ced5d74c8b28658615ecc8262dfL4-R4) [[8]](diffhunk://#diff-8c8c4b08afd0e66925466d023368b4d6670b15eaaba18521de78d98de298fcb4L4-R4) [[9]](diffhunk://#diff-290e27932da08e64139cb22a3fe89ef4027e80c4c301b2d42fd4b06e657aad67L4-R4) [[10]](diffhunk://#diff-ba78873a037d6e2e089e16b0819be2bd4bd27580d888d6e4c488073550e0cde5L4-R4) [[11]](diffhunk://#diff-12c0af38d4b5b107518db692ba6148be23163bd140a6f542349f160a58ae397aL4-R4) [[12]](diffhunk://#diff-c1680fbb2f3f6d89aea7cb80b0893a3ea53bc40f2ca2b056a6096bee772cf9b2L4-R4)
* Updated the CI workflow in `.github/workflows/ci.yml` to use .NET 10.0 (`actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'`).
* Updated `README.md` and other documentation/config files to reference `net10.0` targets and paths instead of `net9.0`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R134) [[2]](diffhunk://#diff-745de803615d037468a2996cb83796d5347f8720bd53ac9f5b69c82d519900c4L13-R13) [[3]](diffhunk://#diff-745de803615d037468a2996cb83796d5347f8720bd53ac9f5b69c82d519900c4L50-R50) [[4]](diffhunk://#diff-03b75116801ca9d1c9a2f2b237334cd00490b00571d782d89a6b69a333f4fc14L18-R18) [[5]](diffhunk://#diff-290e27932da08e64139cb22a3fe89ef4027e80c4c301b2d42fd4b06e657aad67L39-R40)

**TOML parsing modernization:**
* Replaced deprecated Tomlyn parsing APIs (`Toml.Parse` and `.ToModel()`) with the new `SyntaxParser.Parse` and `TomlSerializer.Deserialize<TomlTable>` methods throughout all services and tools that read or parse TOML files. This includes `ProjectConfigParser`, `ProjectConfigReader`, `ProjectMigrationService`, `PackageTools.Publish`, and `PageTools.Publish`. [[1]](diffhunk://#diff-93a34842046b86f6ca97ab601e214d946f9277aecfa5cd38fd8a1aaa417b59d9R4) [[2]](diffhunk://#diff-93a34842046b86f6ca97ab601e214d946f9277aecfa5cd38fd8a1aaa417b59d9L52-R60) [[3]](diffhunk://#diff-87be5c74de58920d397b7096d73689223f407c55bd200df1e6108e9a0abf8a07R4) [[4]](diffhunk://#diff-87be5c74de58920d397b7096d73689223f407c55bd200df1e6108e9a0abf8a07L74-R75) [[5]](diffhunk://#diff-87be5c74de58920d397b7096d73689223f407c55bd200df1e6108e9a0abf8a07L90-R91) [[6]](diffhunk://#diff-9c7071ee0b0655efaf8dc4c5d95ac7d04efd58b7684dc95b267909e375740eceR6) [[7]](diffhunk://#diff-9c7071ee0b0655efaf8dc4c5d95ac7d04efd58b7684dc95b267909e375740eceL122-R123) [[8]](diffhunk://#diff-9c7071ee0b0655efaf8dc4c5d95ac7d04efd58b7684dc95b267909e375740eceL131-R132) [[9]](diffhunk://#diff-9c7071ee0b0655efaf8dc4c5d95ac7d04efd58b7684dc95b267909e375740eceL532-R540) [[10]](diffhunk://#diff-04ddd8c06a4a7fe1194db7635b4abd275e0ae93c2142ad1bbd64c3cdd484c0c6L344-R344) [[11]](diffhunk://#diff-d148bfa71cff357afc9520f9ad1c591b3ed494b70e2f090967ad4d3b315797c1L210-R210)