### PR TITLE
macOS installer build support

### DIFF
--- a/.run/Publish macOS app bundle.run.xml
+++ b/.run/Publish macOS app bundle.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Publish macOS app bundle" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="dotnet publish Source/Celbridge/Celbridge.Application.csproj -f net9.0-desktop -p:PublishProfile=macOS-AppBundle" />
+    <option name="SCRIPT_TEXT" value="dotnet publish Source/Celbridge/Celbridge.Application.csproj -f net10.0-desktop -p:PublishProfile=macOS-AppBundle" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />

--- a/Source/Celbridge/Celbridge.Application.csproj
+++ b/Source/Celbridge/Celbridge.Application.csproj
@@ -52,7 +52,7 @@
     <!-- Enable the hardened runtime (required for notarization) and grant the CoreCLR JIT its
          writable-then-executable memory via the entitlements plist. The two travel together: under the
          hardened runtime the JIT faults without allow-jit. Only consumed by the app-bundle publish
-         (PackageFormat=app/pkg/dmg); a plain net9.0-desktop build ignores them. -->
+         (PackageFormat=app/pkg/dmg); a plain net10.0-desktop build ignores them. -->
     <UnoMacOSHardenedRuntime>true</UnoMacOSHardenedRuntime>
     <UnoMacOSEntitlements>$(MSBuildProjectDirectory)/Platforms/Desktop/Entitlements.plist</UnoMacOSEntitlements>
   </PropertyGroup>

--- a/Source/Celbridge/Celbridge.Application.csproj
+++ b/Source/Celbridge/Celbridge.Application.csproj
@@ -49,6 +49,12 @@
   <!-- Custom Info.plist for the macOS desktop bundle (see that file for details). -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-desktop'">
     <UnoMacOSCustomInfoPlist>$(MSBuildProjectDirectory)/Platforms/Desktop/Info.plist</UnoMacOSCustomInfoPlist>
+    <!-- Enable the hardened runtime (required for notarization) and grant the CoreCLR JIT its
+         writable-then-executable memory via the entitlements plist. The two travel together: under the
+         hardened runtime the JIT faults without allow-jit. Only consumed by the app-bundle publish
+         (PackageFormat=app/pkg/dmg); a plain net9.0-desktop build ignores them. -->
+    <UnoMacOSHardenedRuntime>true</UnoMacOSHardenedRuntime>
+    <UnoMacOSEntitlements>$(MSBuildProjectDirectory)/Platforms/Desktop/Entitlements.plist</UnoMacOSEntitlements>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Source/Celbridge/Platforms/Desktop/Entitlements.plist
+++ b/Source/Celbridge/Platforms/Desktop/Entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<!-- The CoreCLR JIT needs writable-then-executable memory, which the hardened runtime blocks by
+		     default. These two entitlements grant exactly that and nothing more: library validation,
+		     network, and keychain access are all either unneeded (uv and Python are subprocesses, the
+		     credential store targets the entitlement-free login keychain) or granted by Developer ID
+		     being unsandboxed. Hardened runtime (UnoMacOSHardenedRuntime) is required for notarization
+		     and must be enabled for these entitlements to matter. -->
+		<key>com.apple.security.cs.allow-jit</key>
+		<true/>
+		<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+		<true/>
+	</dict>
+</plist>

--- a/Source/Celbridge/Properties/PublishProfiles/macOS-AppBundle.pubxml
+++ b/Source/Celbridge/Properties/PublishProfiles/macOS-AppBundle.pubxml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Publish profile holding the canonical settings for the macOS desktop app bundle: Release, net9.0-desktop,
+  Publish profile holding the canonical settings for the macOS desktop app bundle: Release, net10.0-desktop,
   osx-arm64, self-contained, Uno PackageFormat=app. Produces a self-contained Celbridge.app.
 
   Build it with:
-    dotnet publish Source/Celbridge/Celbridge.Application.csproj -f net9.0-desktop -p:PublishProfile=macOS-AppBundle
+    dotnet publish Source/Celbridge/Celbridge.Application.csproj -f net10.0-desktop -p:PublishProfile=macOS-AppBundle
   (-f is required: a multi-targeted project cannot infer the framework from the profile alone.)
 
   In Rider, use the bundled "Publish macOS app bundle" run configuration (.run/), which runs that command.
@@ -19,7 +19,7 @@
     <Platform>Any CPU</Platform>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net9.0-desktop</TargetFramework>
+    <TargetFramework>net10.0-desktop</TargetFramework>
     <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PackageFormat>app</PackageFormat>

--- a/Source/Celbridge/appsettings.json
+++ b/Source/Celbridge/appsettings.json
@@ -12,6 +12,7 @@
     "webview-dev-tools": true,
     "note-editor":false,
     "mcp-tools": true,
-    "web-access-tools": false
+    "web-access-tools": false,
+    "answer-dialog": false
   }
 }

--- a/Source/Core/Celbridge.Foundation/Settings/FeatureFlagConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Settings/FeatureFlagConstants.cs
@@ -32,8 +32,8 @@ public static class FeatureFlagConstants
 
     /// <summary>
     /// Enables the app_answer_dialog MCP tool that lets a script answer a
-    /// modal dialog without a human present. The tool only ships in debug
-    /// builds, so the flag has no effect in release even when set.
+    /// modal dialog without a human present. A test-automation capability,
+    /// off by default in shipping builds.
     /// </summary>
     public const string AnswerDialog = "answer-dialog";
 

--- a/Source/Core/Celbridge.Tools/Celbridge.Tools.csproj
+++ b/Source/Core/Celbridge.Tools/Celbridge.Tools.csproj
@@ -29,8 +29,6 @@
     <EmbeddedResource Include="Guides\**\*.md" />
     <!-- README.md documents the guide-authoring conventions for human contributors and must not be embedded into the agent guide library. -->
     <EmbeddedResource Remove="Guides\README.md" />
-    <!-- app_answer_dialog is debug-only (its tool carries #if DEBUG), so exclude its guide from Release builds to match the tool's gating and keep the loader's tool-coverage validator happy. -->
-    <EmbeddedResource Remove="Guides\Tools\app_answer_dialog.md" Condition="'$(Configuration)' != 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Core/Celbridge.Tools/Tools/App/AppTools.AnswerDialog.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppTools.AnswerDialog.cs
@@ -1,4 +1,3 @@
-#if DEBUG
 using Celbridge.Dialog;
 using Celbridge.Settings;
 using ModelContextProtocol.Protocol;
@@ -8,7 +7,7 @@ namespace Celbridge.Tools;
 
 public partial class AppTools
 {
-    /// <summary>Schedule an automated answer for the next modal dialog (debug-only test automation).</summary>
+    /// <summary>Schedule an automated answer for the next modal dialog (test automation, gated by the answer-dialog flag).</summary>
     [McpServerTool(Name = "app_answer_dialog", ReadOnly = false, Idempotent = false)]
     [ToolAlias("app.answer_dialog")]
     [RelatedGuides]
@@ -32,4 +31,3 @@ public partial class AppTools
         return ToolResponse.Success("ok");
     }
 }
-#endif

--- a/Source/Directory.Build.targets
+++ b/Source/Directory.Build.targets
@@ -1,6 +1,32 @@
 <Project>
 
   <!--
+    Drop the Windows target framework from every project when not building on Windows.
+    The .NET 10 SDK no longer restores -windows target frameworks on non-Windows hosts,
+    so building one there fails with NETSDK1005. Uno's own UnoRemoveUnsupportedTargetFrameworks
+    filter runs as a build-time target, which Rider does not honor. Doing the same filtering
+    here as an evaluation-time property means Rider (and every other tool) sees only the
+    buildable frameworks. The condition guards non-Windows, so Windows builds are untouched.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworks)' != '' and !$([MSBuild]::IsOSPlatform('windows'))">
+    <TargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace($(TargetFrameworks), '(^|;)[^;]*-windows[^;]*', ''))</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks.Trim(';'))</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+    Put the desktop target framework first so every project shares the same active (first)
+    target framework. Rider builds a referenced project only for its active target framework,
+    so if the app's active head is net*-desktop while a library's is plain net*, the library's
+    desktop reference assemblies are never built and the app's desktop head fails with CS0006.
+    Fronting desktop everywhere keeps Rider's per-project active head aligned on macOS.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworks)' != '' and !$([MSBuild]::IsOSPlatform('windows')) and $(TargetFrameworks.Contains('-desktop'))">
+    <_UnoDesktopTargetFramework>$([System.Text.RegularExpressions.Regex]::Match($(TargetFrameworks), '[^;]*-desktop[^;]*').Value)</_UnoDesktopTargetFramework>
+    <TargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace($(TargetFrameworks), '(^|;)[^;]*-desktop[^;]*', ''))</TargetFrameworks>
+    <TargetFrameworks>$(_UnoDesktopTargetFramework);$(TargetFrameworks.Trim(';'))</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
     Distribute the Celbridge.FileSystem.Analyzers gateway analyzer (CEL_FS_001)
     to every product project. OutputItemType="Analyzer" with
     ReferenceOutputAssembly="false" adds it as an analyzer only, not a compile

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="JsonPatch.Net" Version="5.0.3" />
     <PackageVersion Include="JsonPointer.Net" Version="7.0.1" />
     <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />

--- a/Source/Workspace/Celbridge.Python/Services/PythonService.cs
+++ b/Source/Workspace/Celbridge.Python/Services/PythonService.cs
@@ -19,6 +19,9 @@ public class PythonService : IPythonService, IDisposable
 {
     private const int PythonLogMaxFiles = 10;
 
+    // Bounds the wait for the login-shell PATH query so a slow shell profile cannot stall project load.
+    private const int LoginShellPathTimeoutMs = 5000;
+
     // Folder and file names
     private const string UVCacheFolderName = "uv_cache";
     private const string UVExecutableName = "uv";
@@ -44,6 +47,10 @@ public class PythonService : IPythonService, IDisposable
     private string _pendingProjectPythonFolder = string.Empty;
     private bool _fingerprintSaved;
     private volatile bool _hadConnection;
+
+    // The login-shell PATH is app-global and costs a subprocess to resolve, so cache it for the app run.
+    private static string? _resolvedLoginShellPath;
+    private static readonly object _loginShellPathLock = new();
 
     public PythonService(
         IProjectService projectService,
@@ -167,7 +174,7 @@ public class PythonService : IPythonService, IDisposable
             // Build the per-process environment for the terminal
             var uvToolsFolder = Path.Combine(projectPythonFolder, UVToolsFolderName);
             var uvBinFolder = Path.Combine(projectPythonFolder, UVBinFolderName);
-            var currentPath = Environment.GetEnvironmentVariable("PATH") ?? "";
+            var currentPath = ResolveChildProcessBasePath();
             var terminalPath = currentPath.Contains(uvBinFolder, StringComparison.OrdinalIgnoreCase)
                 ? currentPath
                 : uvBinFolder + Path.PathSeparator + currentPath;
@@ -668,6 +675,98 @@ public class PythonService : IPythonService, IDisposable
         }
 
         return Result<string>.Ok(wheelFiles[0]);
+    }
+
+    // The base PATH for the Python subsystem and terminal child processes. A macOS app launched from
+    // Finder inherits only the minimal launchd PATH, not the user's login-shell PATH, so user-installed
+    // CLI tools (claude in ~/.local/bin, Homebrew binaries) are invisible. Resolve the login shell's PATH
+    // once and use it. On other platforms, and if resolution fails, fall back to the process PATH.
+    private string ResolveChildProcessBasePath()
+    {
+        var processPath = Environment.GetEnvironmentVariable("PATH") ?? "";
+        if (!OperatingSystem.IsMacOS())
+        {
+            return processPath;
+        }
+
+        lock (_loginShellPathLock)
+        {
+            if (_resolvedLoginShellPath is not null)
+            {
+                return _resolvedLoginShellPath;
+            }
+
+            var loginShellPath = TryResolveLoginShellPath();
+            _resolvedLoginShellPath = string.IsNullOrEmpty(loginShellPath) ? processPath : loginShellPath;
+            return _resolvedLoginShellPath;
+        }
+    }
+
+    // Runs the user's login shell interactively to capture the PATH they see in Terminal. The interactive
+    // (-i) flag is required, not just login (-l): tools like claude add ~/.local/bin from .zshrc, which
+    // only interactive shells source. Returns an empty string on any failure so the caller falls back.
+    private string TryResolveLoginShellPath()
+    {
+        try
+        {
+            var shell = Environment.GetEnvironmentVariable("SHELL");
+            if (string.IsNullOrEmpty(shell))
+            {
+                shell = "/bin/zsh";
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = shell,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("-i");
+            startInfo.ArgumentList.Add("-l");
+            startInfo.ArgumentList.Add("-c");
+            // Wrap the value in sentinels so it survives any banner or profile output the shell prints.
+            startInfo.ArgumentList.Add("printf '__CEL_PATH_BEGIN__%s__CEL_PATH_END__' \"$PATH\"");
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return string.Empty;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(LoginShellPathTimeoutMs))
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // The process may have exited between the wait timing out and the kill.
+                }
+                _logger.LogWarning("Timed out resolving the login shell PATH; using the process PATH instead.");
+                return string.Empty;
+            }
+
+            const string beginMarker = "__CEL_PATH_BEGIN__";
+            const string endMarker = "__CEL_PATH_END__";
+            var startIndex = output.IndexOf(beginMarker, StringComparison.Ordinal);
+            var endIndex = output.IndexOf(endMarker, StringComparison.Ordinal);
+            if (startIndex < 0 || endIndex <= startIndex)
+            {
+                return string.Empty;
+            }
+
+            startIndex += beginMarker.Length;
+            return output.Substring(startIndex, endIndex - startIndex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve the login shell PATH; using the process PATH instead.");
+            return string.Empty;
+        }
     }
 
     private bool _disposed;

--- a/Source/Workspace/Celbridge.Python/Services/PythonService.cs
+++ b/Source/Workspace/Celbridge.Python/Services/PythonService.cs
@@ -287,7 +287,7 @@ public class PythonService : IPythonService, IDisposable
             // single quotes uvCommand already uses to quote its own arguments).
             var commandLine = OperatingSystem.IsWindows()
                 ? $"cmd.exe /k \"{uvCommand}\""
-                : $"{uvCommand}; exec bash";
+                : $"{uvCommand}; exec $SHELL";
 
             // Cancel any previous RPC listening loop in case InitializePython
             // is called again after a project reload.

--- a/Source/Workspace/Celbridge.Python/packages/celbridge/src/celbridge/integration_tests/conftest.py
+++ b/Source/Workspace/Celbridge.Python/packages/celbridge/src/celbridge/integration_tests/conftest.py
@@ -56,16 +56,16 @@ def data():
 def answer_dialog_available(app):
     """Skip the suite (or a single test) when the dialog-answer surface is unavailable.
 
-    The tool only ships in debug builds and requires the `answer-dialog` flag
-    to be on. When the flag is off (or the build is release, which carries no
-    flag at all), `app_get_state.featureFlags` will not report it as enabled
-    and we skip. Otherwise the fixture returns True and tests proceed.
+    The tool ships in every build configuration and is gated by the `answer-dialog`
+    flag, which defaults off in shipping builds. When the flag is off,
+    `app_get_state.featureFlags` reports it disabled and we skip. Enable it with
+    `answer-dialog = true` under `[features]` in the project .celbridge.
     """
     state = app.get_state()
     feature_flags = state.get("featureFlags", {})
     if not feature_flags.get("answer-dialog", False):
         pytest.skip(
-            "Dialog answer feature not enabled — requires a debug build with "
-            "answer-dialog = true in user .celbridge"
+            "Dialog answer feature not enabled — set answer-dialog = true "
+            "under [features] in the project .celbridge"
         )
     return True

--- a/Source/Workspace/Celbridge.Python/packages/celbridge/src/celbridge/integration_tests/test_answer_dialog.py
+++ b/Source/Workspace/Celbridge.Python/packages/celbridge/src/celbridge/integration_tests/test_answer_dialog.py
@@ -1,7 +1,7 @@
-"""End-to-end coverage for app_answer_dialog (debug-only test automation).
+"""End-to-end coverage for app_answer_dialog (test automation).
 
-Skipped (whole class) when the build is release or the user has not set
-`answer-dialog = true` in their .celbridge.
+Skipped (whole class) when the `answer-dialog` flag is off — it defaults off in
+shipping builds; set `answer-dialog = true` under `[features]` in the .celbridge.
 
 Coverage boundary: Confirmation and InputText are exercised here because
 `explorer.delete(showDialog=True)` and `explorer.rename` reliably surface


### PR DESCRIPTION
This pull request makes several important updates to improve macOS compatibility, enhance test automation, and fix issues with environment variable propagation on macOS. The main themes are: upgrading to .NET 10, improving the "answer-dialog" test automation tool, and ensuring macOS child processes inherit the correct PATH. Additionally, there are dependency and build system updates for better cross-platform support.

**.NET 10 Upgrade and macOS Hardened Runtime:**
- Upgraded all relevant build configurations, publish profiles, and run scripts from `net9.0-desktop` to `net10.0-desktop` to support the latest .NET features and requirements. [[1]](diffhunk://#diff-bfb9e6f2c5a5af71fad1036555a059cffbf1084986705901018ece17e7449b80L3-R3) [[2]](diffhunk://#diff-47dc47c5863604879b65c24fd388f53fc9d48d5c5457e4d119b097942169780cL3-R7) [[3]](diffhunk://#diff-47dc47c5863604879b65c24fd388f53fc9d48d5c5457e4d119b097942169780cL22-R22)
- Enabled the macOS hardened runtime and specified an entitlements file (`Entitlements.plist`) to allow JIT execution, which is required for notarization and correct operation under the hardened runtime. [[1]](diffhunk://#diff-745de803615d037468a2996cb83796d5347f8720bd53ac9f5b69c82d519900c4R52-R57) [[2]](diffhunk://#diff-7586ceda257549b26d2e1324a5498ab76cef37a5abc73365f5e72bd65b62e15cR1-R16)

**Test Automation ("answer-dialog" tool):**
- Changed the `answer-dialog` feature flag and tool so it is now available in all builds (not just debug), but remains gated by the feature flag, which defaults off in shipping builds. Updated related comments, documentation, and integration tests to reflect this. [[1]](diffhunk://#diff-b3eb17bd50808bd3cd86abe690dcc0db56bf47112a97110eb0befea6b563f6f3L35-R36) [[2]](diffhunk://#diff-f078c68f7c73dbdec51997ff2f079b09e6d5375502c6627499a415f90b8bc6f5L15-R16) [[3]](diffhunk://#diff-9358eeb22ac9ed522dee2ec4156e38823a98410209c48c8d817ef089ffadfc5eL59-R69) [[4]](diffhunk://#diff-c04582b37bc01b8e4a4120850801976285a8976e9a2f09b8d0dceb72f9b6e275L1-R4) [[5]](diffhunk://#diff-e45c3ba327fbae115dfe8e80d69026e41cfc4184e336a03e9f87195801021c71L1) [[6]](diffhunk://#diff-e45c3ba327fbae115dfe8e80d69026e41cfc4184e336a03e9f87195801021c71L11-R10) [[7]](diffhunk://#diff-e45c3ba327fbae115dfe8e80d69026e41cfc4184e336a03e9f87195801021c71L35)
- Removed the conditional compilation for the tool, so its code and guide are always present, but it is only enabled by the feature flag. [[1]](diffhunk://#diff-e45c3ba327fbae115dfe8e80d69026e41cfc4184e336a03e9f87195801021c71L1) [[2]](diffhunk://#diff-c1680fbb2f3f6d89aea7cb80b0893a3ea53bc40f2ca2b056a6096bee772cf9b2L32-L33)

**macOS PATH Propagation Fix:**
- Implemented logic in `PythonService` to resolve and cache the user's login-shell PATH on macOS, ensuring that child processes (like Python and CLI tools) can find user-installed binaries even when the app is launched from Finder. Falls back gracefully if the resolution fails or on other platforms. [[1]](diffhunk://#diff-bcb944e47d294a2271f350877cb6268e52d9bed2304dce7c84fa5119de164063R22-R24) [[2]](diffhunk://#diff-bcb944e47d294a2271f350877cb6268e52d9bed2304dce7c84fa5119de164063R51-R54) [[3]](diffhunk://#diff-bcb944e47d294a2271f350877cb6268e52d9bed2304dce7c84fa5119de164063L170-R177) [[4]](diffhunk://#diff-bcb944e47d294a2271f350877cb6268e52d9bed2304dce7c84fa5119de164063R680-R771) [[5]](diffhunk://#diff-bcb944e47d294a2271f350877cb6268e52d9bed2304dce7c84fa5119de164063L290-R297)

**Build System and Dependency Updates:**
- Updated the build system to remove unsupported Windows target frameworks on non-Windows hosts and to ensure the desktop target framework is prioritized, improving cross-platform builds and IDE compatibility.
- Downgraded `Microsoft.CodeAnalysis.CSharp` NuGet package to version 5.0.0 for compatibility.

These changes collectively improve macOS support, streamline test automation, and ensure a more robust development and build experience across platforms.