### PR TITLE
Fix invalid ChoiceDialog return value

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/ChoiceDialog.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/ChoiceDialog.xaml.cs
@@ -49,6 +49,13 @@ public sealed partial class ChoiceDialog : ContentDialog, IChoiceDialog
 
     private void OptionsRadioButtons_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        // RadioButtons resets SelectedIndex to -1 when it unloads as the dialog closes.
+        // Ignore that deselection so the user's last choice is preserved in the result.
+        if (OptionsRadioButtons.SelectedIndex < 0)
+        {
+            return;
+        }
+
         ViewModel.SelectedIndex = OptionsRadioButtons.SelectedIndex;
     }
 


### PR DESCRIPTION
This pull request makes a small but important improvement to the `ChoiceDialog` user interface component. The change ensures that when the dialog is closed and the `RadioButtons` control resets its selection, this event is ignored so that the user's last choice is preserved in the dialog result.

- Prevents the `OptionsRadioButtons_SelectionChanged` handler from updating the selection when the control is unloaded and `SelectedIndex` becomes `-1`, thereby preserving the user's last choice.