### PR TITLE
Use IReloadProjectCommand for project reload

### DIFF
--- a/Source/Core/Celbridge.Foundation/Projects/IReloadProjectCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Projects/IReloadProjectCommand.cs
@@ -1,0 +1,9 @@
+using Celbridge.Commands;
+
+namespace Celbridge.Projects;
+
+/// <summary>
+/// Reload the currently loaded project from disk.
+/// </summary>
+public interface IReloadProjectCommand : IExecutableCommand
+{}

--- a/Source/Core/Celbridge.Foundation/Projects/ProjectMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Projects/ProjectMessages.cs
@@ -1,6 +1,0 @@
-namespace Celbridge.Projects;
-
-/// <summary>
-/// Message sent to request reloading the current project.
-/// </summary>
-public record RequestReloadProjectMessage();

--- a/Source/Core/Celbridge.Projects/Commands/ReloadProjectCommand.cs
+++ b/Source/Core/Celbridge.Projects/Commands/ReloadProjectCommand.cs
@@ -1,0 +1,50 @@
+using Celbridge.Commands;
+
+namespace Celbridge.Projects.Commands;
+
+public class ReloadProjectCommand : CommandBase, IReloadProjectCommand
+{
+    private readonly IProjectService _projectService;
+    private readonly ICommandService _commandService;
+
+    public ReloadProjectCommand(
+        ICommandService commandService,
+        IProjectService projectService)
+    {
+        _commandService = commandService;
+        _projectService = projectService;
+    }
+
+    public override async Task<Result> ExecuteAsync()
+    {
+        var currentProject = _projectService.CurrentProject;
+        if (currentProject is null)
+        {
+            // No project is open, so there is nothing to reload.
+            return Result.Ok();
+        }
+
+        string projectFilePath = currentProject.ProjectFilePath;
+
+        // Unload immediately so the subsequent load does not early out on the already-loaded project.
+        await _commandService.ExecuteImmediate<IUnloadProjectCommand>();
+
+        _commandService.Execute<ILoadProjectCommand>(command =>
+        {
+            command.ProjectFilePath = projectFilePath;
+        });
+
+        return Result.Ok();
+    }
+
+    //
+    // Static methods for scripting support.
+    //
+
+    public static void ReloadProject()
+    {
+        var commandService = ServiceLocator.AcquireService<ICommandService>();
+
+        commandService.Execute<IReloadProjectCommand>();
+    }
+}

--- a/Source/Core/Celbridge.Projects/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.Projects/ServiceConfiguration.cs
@@ -28,6 +28,7 @@ public static class ServiceConfiguration
         services.AddTransient<ICreateProjectCommand, CreateProjectCommand>();
         services.AddTransient<ILoadProjectCommand, LoadProjectCommand>();
         services.AddTransient<IUnloadProjectCommand, UnloadProjectCommand>();
+        services.AddTransient<IReloadProjectCommand, ReloadProjectCommand>();
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
@@ -249,7 +249,7 @@ internal static class MacOSMainMenu
                 break;
 
             case TagReloadProject:
-                _ = viewModel.ReloadProjectAsync();
+                viewModel.ReloadProject();
                 break;
 
             case TagCloseProject:

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/MainMenuViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/MainMenuViewModel.cs
@@ -48,7 +48,6 @@ public partial class MainMenuViewModel : ObservableObject
     {
         _messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoaded);
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
-        _messengerService.Register<RequestReloadProjectMessage>(this, OnRequestReloadProject);
 
         IsWorkspaceLoaded = _workspaceWrapper.IsWorkspacePageLoaded;
     }
@@ -68,11 +67,6 @@ public partial class MainMenuViewModel : ObservableObject
         IsWorkspaceLoaded = false;
     }
 
-    private void OnRequestReloadProject(object recipient, RequestReloadProjectMessage message)
-    {
-        _ = ReloadProjectAsync();
-    }
-
     public void NewProject()
     {
         _ = _mainMenuUtils.ShowNewProjectDialogAsync();
@@ -83,20 +77,9 @@ public partial class MainMenuViewModel : ObservableObject
         _ = _mainMenuUtils.ShowOpenProjectDialogAsync();
     }
 
-    public async Task ReloadProjectAsync()
+    public void ReloadProject()
     {
-        var projectService = ServiceLocator.AcquireService<IProjectService>();
-        if (projectService.CurrentProject is not null)
-        {
-            string projectPath = projectService.CurrentProject.ProjectFilePath;
-
-            await _commandService.ExecuteImmediate<IUnloadProjectCommand>();
-
-            _commandService.Execute<ILoadProjectCommand>((command) =>
-            {
-                command.ProjectFilePath = projectPath;
-            });
-        }
+        _commandService.Execute<IReloadProjectCommand>();
     }
 
     public async Task CloseProjectAsync()

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
@@ -392,7 +392,7 @@ public class MainMenu
                 break;
 
             case ReloadProjectTag:
-                _ = ViewModel.ReloadProjectAsync();
+                ViewModel.ReloadProject();
                 MenuItemInvoked?.Invoke(this, EventArgs.Empty);
                 break;
 

--- a/Source/Workspace/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
+++ b/Source/Workspace/Celbridge.Console/ViewModels/ConsolePanelViewModel.cs
@@ -233,8 +233,7 @@ public partial class ConsolePanelViewModel : ObservableObject
 
     public void OnReloadProjectClicked()
     {
-        // Send message to request project reload
-        _messengerService.Send<RequestReloadProjectMessage>();
+        _commandService.Execute<IReloadProjectCommand>();
     }
 
     private void ShowConsolePanel()


### PR DESCRIPTION
Replace the message-based project reload flow with a command. Added IReloadProjectCommand and ReloadProjectCommand (with a static scripting entry), registered the command in ServiceConfiguration, and removed the RequestReloadProjectMessage type. Updated MainMenuViewModel, MainMenu view, MacOSMainMenu and ConsolePanelViewModel to invoke the new command instead of sending messages or running an async reload helper. Centralizes reload logic through ICommandService and cleans up the messenger-based pathway.