### PR TITLE
Ensure selected document tab scrolls into view

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -85,4 +85,10 @@ public interface IPlatformInfo
     /// selection is retried on the next dispatcher cycle. True on macOS.
     /// </summary>
     bool RequiresMacOSLayoutRetry { get; }
+
+    /// <summary>
+    /// Whether the tab strip must be scrolled manually to reveal the selected tab because the platform does
+    /// not bring it into view automatically. True on macOS.
+    /// </summary>
+    bool RequiresMacOSTabScrollIntoView { get; }
 }

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -71,4 +71,6 @@ public sealed class PlatformInfo : IPlatformInfo
     public bool RequiresMacOSSelectionRepaint => OperatingSystem.IsMacOS();
 
     public bool RequiresMacOSLayoutRetry => OperatingSystem.IsMacOS();
+
+    public bool RequiresMacOSTabScrollIntoView => OperatingSystem.IsMacOS();
 }

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
@@ -274,8 +274,33 @@ public sealed partial class DocumentSection : UserControl
             DispatcherQueue.TryEnqueue(() =>
             {
                 TabView.SelectedItem = tab;
+                ScrollTabIntoView(tab);
             });
+            return;
         }
+
+        ScrollTabIntoView(tab);
+    }
+
+    /// <summary>
+    /// Scrolls the tab strip so the given tab is visible when it lies outside the visible area.
+    /// </summary>
+    private void ScrollTabIntoView(DocumentTab tab)
+    {
+        if (!_platformInfo.RequiresMacOSTabScrollIntoView)
+        {
+            // The packaged Windows TabView brings the selected tab into view on its own.
+            return;
+        }
+
+        // Defer to the next dispatcher cycle so the tab strip has completed layout. A tab that was just
+        // added, or a selection that changes the strip's extent, has no scroll geometry to act on until
+        // the layout pass runs, so scrolling synchronously here would be a no-op.
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            var tabListView = VisualTreeHelperEx.FindDescendant<ListViewBase>(TabView);
+            tabListView?.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
Update DocumentSection tab selection to actively scroll the selected tab into view. The new helper defers scrolling to the next dispatcher cycle so tab-strip layout is ready, fixing cases where newly added or newly selected tabs were off-screen and synchronous scrolling had no effect.

Fixes #731