### PR TITLE
Redact sensitive log payloads

### DIFF
--- a/Source/Core/Celbridge.Foundation/Logging/RedactedInLogsAttribute.cs
+++ b/Source/Core/Celbridge.Foundation/Logging/RedactedInLogsAttribute.cs
@@ -1,0 +1,10 @@
+namespace Celbridge.Logging;
+
+/// <summary>
+/// Marks a command property whose value must not appear in logs. The command logger replaces the
+/// value with a size summary, so user file content and clipboard text never leave the payload.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class RedactedInLogsAttribute : Attribute
+{
+}

--- a/Source/Core/Celbridge.Logging/Services/ExecuteCommandStartedMessageJsonConverter.cs
+++ b/Source/Core/Celbridge.Logging/Services/ExecuteCommandStartedMessageJsonConverter.cs
@@ -1,4 +1,6 @@
 using Celbridge.Commands;
+using System.Collections;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -39,11 +41,20 @@ public class ExecuteCommandStartedMessageJsonConverter : JsonConverter<ExecuteCo
             foreach (var prop in properties)
             {
                 var value = prop.GetValue(command);
-                if (value is not null || options.DefaultIgnoreCondition != JsonIgnoreCondition.WhenWritingNull)
+                if (value is null && options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingNull)
                 {
-                    writer.WritePropertyName(prop.Name);
-                    JsonSerializer.Serialize(writer, value, prop.PropertyType, options);
+                    continue;
                 }
+
+                writer.WritePropertyName(prop.Name);
+
+                if (prop.GetCustomAttribute<RedactedInLogsAttribute>() is not null)
+                {
+                    writer.WriteStringValue(DescribeRedactedValue(value));
+                    continue;
+                }
+
+                JsonSerializer.Serialize(writer, value, prop.PropertyType, options);
             }
         }
 
@@ -58,6 +69,26 @@ public class ExecuteCommandStartedMessageJsonConverter : JsonConverter<ExecuteCo
         JsonSerializer.Serialize(writer, command.ExecutionSource, options);
 
         writer.WriteEndObject();
+    }
+
+    private static string DescribeRedactedValue(object? value)
+    {
+        if (value is null)
+        {
+            return "(redacted)";
+        }
+
+        if (value is string text)
+        {
+            return $"(redacted, {text.Length} chars)";
+        }
+
+        if (value is ICollection collection)
+        {
+            return $"(redacted, {collection.Count} items)";
+        }
+
+        return "(redacted)";
     }
 
     public override ExecuteCommandStartedMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Source/Core/Celbridge.Logging/Services/LogSerializer.cs
+++ b/Source/Core/Celbridge.Logging/Services/LogSerializer.cs
@@ -5,6 +5,10 @@ namespace Celbridge.Logging.Services;
 
 public class LogSerializer : ILogSerializer
 {
+    // Command arguments longer than this are truncated in the log. Large enough to keep a useful
+    // snippet of an edit's match text, small enough that a whole-file write does not flood the log.
+    private const int MaxLoggedStringLength = 256;
+
     private readonly JsonSerializerOptions _jsonSettingsWithProperties;
     private readonly JsonSerializerOptions _jsonSettingsNoProperties;
 
@@ -31,6 +35,7 @@ public class LogSerializer : ILogSerializer
         };
 
         options.Converters.Add(new ExecuteCommandStartedMessageJsonConverter(ignoreCommandProperties));
+        options.Converters.Add(new TruncatingStringJsonConverter(MaxLoggedStringLength));
         options.Converters.Add(new JsonStringEnumConverter());
         options.Converters.Add(new EntityIdConverter());
         options.Converters.Add(new ResourceKeyConverter());

--- a/Source/Core/Celbridge.Logging/Services/TruncatingStringJsonConverter.cs
+++ b/Source/Core/Celbridge.Logging/Services/TruncatingStringJsonConverter.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Celbridge.Logging.Services;
+
+/// <summary>
+/// Serializes strings for logging, truncating any value longer than the limit to its head plus a
+/// character count. Keeps file-editing commands (whose Content/OldString/NewString carry whole
+/// documents) from dumping their entire payload into the log.
+/// </summary>
+public class TruncatingStringJsonConverter : JsonConverter<string>
+{
+    private readonly int _maxLength;
+
+    public TruncatingStringJsonConverter(int maxLength)
+    {
+        _maxLength = maxLength;
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        if (value.Length <= _maxLength)
+        {
+            writer.WriteStringValue(value);
+            return;
+        }
+
+        var truncated = $"{value.Substring(0, _maxLength)}... ({value.Length} chars)";
+        writer.WriteStringValue(truncated);
+    }
+
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetString() ?? string.Empty;
+    }
+}

--- a/Source/Workspace/Celbridge.Resources/Commands/ApplyRangeEditsCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/ApplyRangeEditsCommand.cs
@@ -13,6 +13,7 @@ public class ApplyRangeEditsCommand : CommandBase, IApplyRangeEditsCommand
     private readonly IDialogService _dialogService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
+    [RedactedInLogs]
     public List<FileRangeEdit> Edits { get; set; } = new();
 
     public ApplyRangeEditsCommand(

--- a/Source/Workspace/Celbridge.Resources/Commands/EditFileCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/EditFileCommand.cs
@@ -11,8 +11,13 @@ public class EditFileCommand : CommandBase, IEditFileCommand
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey FileResource { get; set; }
+
+    [RedactedInLogs]
     public string OldString { get; set; } = string.Empty;
+
+    [RedactedInLogs]
     public string NewString { get; set; } = string.Empty;
+
     public bool ReplaceAll { get; set; }
 
     public EditFileResult ResultValue { get; private set; } = new(0, Array.Empty<FileEditAffectedRange>(), false);

--- a/Source/Workspace/Celbridge.Resources/Commands/MultiEditFileCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/MultiEditFileCommand.cs
@@ -11,6 +11,8 @@ public class MultiEditFileCommand : CommandBase, IMultiEditFileCommand
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey FileResource { get; set; }
+
+    [RedactedInLogs]
     public List<FileEditOperation> Edits { get; set; } = new();
 
     public MultiEditFileResult ResultValue { get; private set; } = new(

--- a/Source/Workspace/Celbridge.Resources/Commands/ReplaceFileCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/ReplaceFileCommand.cs
@@ -13,8 +13,13 @@ public class ReplaceFileCommand : CommandBase, IReplaceFileCommand
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey FileResource { get; set; }
+
+    [RedactedInLogs]
     public string SearchText { get; set; } = string.Empty;
+
+    [RedactedInLogs]
     public string ReplaceText { get; set; } = string.Empty;
+
     public bool MatchCase { get; set; }
     public bool MatchWord { get; set; }
     public bool UseRegex { get; set; }

--- a/Source/Workspace/Celbridge.Resources/Commands/WriteBinaryFileCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/WriteBinaryFileCommand.cs
@@ -13,6 +13,8 @@ public class WriteBinaryFileCommand : CommandBase, IWriteBinaryFileCommand
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey FileResource { get; set; }
+
+    [RedactedInLogs]
     public string Base64Content { get; set; } = string.Empty;
 
     public WriteBinaryFileCommand(

--- a/Source/Workspace/Celbridge.Resources/Commands/WriteFileCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/WriteFileCommand.cs
@@ -14,6 +14,8 @@ public class WriteFileCommand : CommandBase, IWriteFileCommand
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey FileResource { get; set; }
+
+    [RedactedInLogs]
     public string Content { get; set; } = string.Empty;
 
     public WriteFileCommand(

--- a/Source/Workspace/Celbridge.WorkspaceUI/Commands/CopyTextToClipboardCommand.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Commands/CopyTextToClipboardCommand.cs
@@ -1,11 +1,13 @@
 using Celbridge.Commands;
 using Celbridge.DataTransfer;
+using Celbridge.Logging;
 using Windows.ApplicationModel.DataTransfer;
 
 namespace Celbridge.WorkspaceUI.Commands;
 
 public class CopyTextToClipboardCommand : CommandBase, ICopyTextToClipboardCommand
 {
+    [RedactedInLogs]
     public string Text { get; set; } = string.Empty;
     public DataTransferMode TransferMode { get; set; }
 


### PR DESCRIPTION
Add a log-redaction attribute and truncate long string values during command serialization so file contents, edit payloads, and clipboard text do not leak into logs. Apply the redaction to write, replace, edit, range-edit, and clipboard commands.