### PR TITLE
Improve WebView initialization stability and latency

### DIFF
--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -74,6 +74,10 @@ public static class MacOSWebViewInterop
     private static TaskCompletionSource<IntPtr>? _snapshotCompletion;
     private static IntPtr _snapshotBlock;
 
+    // Web views already pinned, so the several resolution points that call RetainNativeWebView take
+    // one retain each.
+    private static readonly HashSet<IntPtr> _pinnedWebViews = new();
+
     /// <summary>
     /// Walks CoreWebView2._nativeWebView and its _webview field to recover the native WKWebView
     /// pointer. Returns false with the type name walked through in 'detail' when the shape does not
@@ -127,6 +131,31 @@ public static class MacOSWebViewInterop
     public static string GetObjectiveCClassName(IntPtr nativeObject)
     {
         return GetClassName(nativeObject);
+    }
+
+    /// <summary>
+    /// Retains the native WKWebView for the lifetime of the process. Uno's MacOSNativeElement calls
+    /// uno_native_dispose on every Unloaded event, which drops the native side's owning reference while
+    /// managed code keeps the raw handle; a later reattach or message then crashes on the freed view.
+    /// Pinning the view turns those touches into calls on a live object. The WebContent renderer is
+    /// still reclaimed by CloseNativeWebView, so what leaks is the view shell only.
+    /// </summary>
+    public static void RetainNativeWebView(IntPtr webView)
+    {
+        if (webView == IntPtr.Zero)
+        {
+            return;
+        }
+
+        lock (_pinnedWebViews)
+        {
+            if (!_pinnedWebViews.Add(webView))
+            {
+                return;
+            }
+        }
+
+        SendMessage(webView, GetSelector("retain"));
     }
 
     /// <summary>

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -57,6 +57,22 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
             }
 
             await webView.EnsureCoreWebView2Async();
+
+            // Pin the native WKWebView for the process lifetime. Uno's native element disposes the
+            // view on every Unloaded and later touches the stale handle, which is a use-after-free
+            // (see RetainNativeWebView). The handle may not be resolvable yet at this point, so the
+            // other adapter entry points that resolve it also pin (RetainNativeWebView is idempotent).
+            if (OperatingSystem.IsMacOS() && webView.CoreWebView2 is not null)
+            {
+                if (MacOSWebViewInterop.TryGetNativeWebViewHandle(webView.CoreWebView2, out var nativeWebViewHandle, out var detail))
+                {
+                    MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
+                }
+                else
+                {
+                    _logger.LogDebug("Native WKWebView handle not resolvable after init ({Detail}); pinning deferred to first resolution", detail);
+                }
+            }
         }
         finally
         {
@@ -184,6 +200,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         if (OperatingSystem.IsMacOS()
             && MacOSWebViewInterop.TryGetNativeWebViewHandle(coreWebView2, out var nativeHandle, out _))
         {
+            MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
             MacOSWebViewInterop.AddUserScriptAtDocumentStart(nativeHandle, script);
         }
 
@@ -223,6 +240,8 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
             return;
         }
 
+        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+
         _safariVersion ??= ResolveSafariVersion();
 
         var userAgent = $"{MacOSUserAgentPrefix} Version/{_safariVersion} Safari/605.1.15 {applicationToken}";
@@ -251,6 +270,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
                 $"Could not reach the native WKWebView handle to load HTML: {detail}");
         }
 
+        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
         MacOSWebViewInterop.LoadHtmlString(nativeHandle, html, baseUrl);
     }
 

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -23,13 +23,6 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         _logger = logger;
     }
 
-    // In-place creation is a consequence of the macOS Skia WebView2 being a native WKWebView: re-parenting
-    // resets its context. This coincides with "not Windows" on the Skia heads (the desktop Windows head
-    // re-parents harmlessly).
-    public bool CreatesWebViewInPlace => !OperatingSystem.IsWindows();
-
-    public bool UsesPrewarmedPool => false;
-
     // Windows-under-Skia hosts a real WebView2 that implements virtual-host mapping; macOS WKWebView and the
     // Linux Skia head do not, and use loadHTMLString instead.
     public bool SupportsVirtualHostMapping => OperatingSystem.IsWindows();
@@ -39,7 +32,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         // EnsureCoreWebView2Async never completes for a control that is not parented to a window. Parent the
         // control in the hidden, window-rooted host for the duration of initialization, then detach it so the
         // consumer can place it in its own container with the CoreWebView2 already live.
-        var host = EnsureInitHost();
+        var host = await EnsureInitHostAsync();
         host.Children.Add(webView);
         try
         {
@@ -274,19 +267,37 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         MacOSWebViewInterop.LoadHtmlString(nativeHandle, html, baseUrl);
     }
 
-    private Panel EnsureInitHost()
+    private async Task<Panel> EnsureInitHostAsync()
     {
         if (_initHost is not null)
         {
             return _initHost;
         }
 
+        // The factory pre-warms its pool from application startup, before the window content exists, so
+        // wait for the root grid rather than failing the early pool instances.
         var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
-        if (userInterfaceService.MainWindow is not Window mainWindow ||
-            mainWindow.Content is not Grid rootGrid)
+        var pollInterval = TimeSpan.FromMilliseconds(100);
+        var rootGridWait = TimeSpan.Zero;
+
+        Grid? rootGrid = null;
+        while (rootGrid is null)
         {
-            throw new InvalidOperationException(
-                "Cannot initialize WebView2: the application root grid is not available yet");
+            if (userInterfaceService.MainWindow is Window mainWindow &&
+                mainWindow.Content is Grid windowRootGrid)
+            {
+                rootGrid = windowRootGrid;
+                break;
+            }
+
+            if (rootGridWait > TimeSpan.FromSeconds(30))
+            {
+                throw new InvalidOperationException(
+                    "Cannot initialize WebView2: the application root grid did not become available");
+            }
+
+            await Task.Delay(pollInterval);
+            rootGridWait += pollInterval;
         }
 
         var host = new Grid

--- a/Source/Core/Celbridge.WebHost/Platform/WindowsWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/WindowsWebViewAdapter.cs
@@ -12,10 +12,6 @@ public sealed class WindowsWebViewAdapter : IWebViewAdapter
     // otherwise leave the CDP call hanging.
     private static readonly TimeSpan ScreenshotCaptureTimeout = TimeSpan.FromSeconds(5);
 
-    public bool CreatesWebViewInPlace => false;
-
-    public bool UsesPrewarmedPool => true;
-
     public bool SupportsVirtualHostMapping => true;
 
     public async Task EnsureCoreWebView2Async(WebView2 webView)

--- a/Source/Core/Celbridge.WebHost/Services/IWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Services/IWebViewAdapter.cs
@@ -11,18 +11,6 @@ namespace Celbridge.WebHost;
 public interface IWebViewAdapter
 {
     /// <summary>
-    /// True when the WebView2 is a native WKWebView that loses its context if re-parented, so a view must
-    /// create its control in place rather than reuse a pre-warmed, re-parentable pool.
-    /// </summary>
-    bool CreatesWebViewInPlace { get; }
-
-    /// <summary>
-    /// True when the platform benefits from a background-warmed pool of WebView2 controls. Only the packaged
-    /// Windows head initializes controls while detached, which the pre-warm relies on.
-    /// </summary>
-    bool UsesPrewarmedPool { get; }
-
-    /// <summary>
     /// True when the platform can map a virtual host name to a local folder and serve it under a faked origin.
     /// True on the packaged Windows head and the Windows Skia head (both back a real WebView2); false on the
     /// macOS and Linux Skia heads, which fake the origin via LoadHtmlString instead.

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFactory.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFactory.cs
@@ -30,12 +30,9 @@ public class WebViewFactory : IWebViewFactory, IDisposable
         _maxPoolSize = poolSize;
         _pool = new Queue<WebView2>();
 
-        if (_webViewAdapter.UsesPrewarmedPool)
-        {
-            // Start initialization but don't await it.
-            // This allows the WebView pool to be populated in the background.
-            _initializationTask = InitializePoolAsync();
-        }
+        // Start initialization but don't await it.
+        // This allows the WebView pool to be populated in the background.
+        _initializationTask = InitializePoolAsync();
     }
 
     private async Task InitializePoolAsync()

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -246,25 +246,8 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
 
         var editorLoader = ResolveContributionEditorLoader(Contribution.Package);
 
-        // In-place vs. pooled is a platform decision, not a loader one: re-parenting a pooled control resets
-        // the WebKit context on the Skia heads, so those create the WebView in place. Windows reuses the
-        // pre-warmed pool, where re-parenting is harmless.
-        if (!_webViewAdapter.CreatesWebViewInPlace)
-        {
-            await InitPooledWebViewAsync(editorLoader);
-        }
-        else
-        {
-            await InitInPlaceWebViewAsync(editorLoader);
-        }
-    }
-
-    // Windows: the pre-warmed pool hands back a control with CoreWebView2 already live, so the host is
-    // configured immediately and init is signalled only once the editor's navigation has started.
-    private async Task InitPooledWebViewAsync(IContributionEditorLoader editorLoader)
-    {
-        Guard.IsNotNull(Contribution);
-
+        // The factory hands back a control with CoreWebView2 already live (pre-warmed where possible), so
+        // the host is configured immediately and init is signalled once the editor's navigation has started.
         try
         {
             WebView = await _webViewFactory.AcquireAsync();
@@ -282,54 +265,6 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
                 .WithException(ex);
             _initTcs!.TrySetResult(failure);
         }
-    }
-
-    // Skia heads: create the control in place and never re-parent it, so its WebKit context stays intact.
-    // EnsureCoreWebView2Async completes only once the control is window-rooted (Loaded), which is after
-    // LoadContent returns -- so init is signalled up front and the host is configured once the control loads.
-    // A failure past that point is logged and torn down rather than surfaced, since init has already completed.
-    private async Task InitInPlaceWebViewAsync(IContributionEditorLoader editorLoader)
-    {
-        Guard.IsNotNull(Contribution);
-
-        WebView = new WebView2
-        {
-            DefaultBackgroundColor = Microsoft.UI.Colors.Transparent
-        };
-        ContributionWebViewContainer.Children.Add(WebView);
-        _initTcs!.TrySetResult(Result.Ok());
-
-        try
-        {
-            await WaitForLoadedAsync(WebView);
-            await WebView.EnsureCoreWebView2Async();
-            await ConfigureWebViewHostAsync(editorLoader);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, $"Failed to initialize in-place contribution view: {Contribution.Package.Name}");
-            TeardownWebViewState();
-        }
-    }
-
-    // Completes once the element is loaded into the visual tree, or immediately if it already is.
-    private static Task WaitForLoadedAsync(FrameworkElement element)
-    {
-        if (element.IsLoaded)
-        {
-            return Task.CompletedTask;
-        }
-
-        var loadedCompletionSource = new TaskCompletionSource();
-        RoutedEventHandler? onLoaded = null;
-        onLoaded = (sender, args) =>
-        {
-            element.Loaded -= onLoaded;
-            loadedCompletionSource.TrySetResult();
-        };
-        element.Loaded += onLoaded;
-
-        return loadedCompletionSource.Task;
     }
 
     // Configures a live WebView (CoreWebView2 ready): host channel, RPC targets, tool bridge, navigation gate,


### PR DESCRIPTION
This pull request refactors WebView initialization across platforms to simplify the codebase and improve stability, especially on macOS. The main changes are the removal of platform-specific logic for in-place creation and prewarmed pools, and the introduction of a robust pinning mechanism for native WKWebView handles on macOS to prevent use-after-free crashes. Initialization logic is now more resilient, with asynchronous waiting for the application root grid to become available.

**Platform abstraction and initialization simplification:**

* Removed the `CreatesWebViewInPlace` and `UsesPrewarmedPool` properties from `IWebViewAdapter` and all related platform-specific implementations, consolidating initialization logic and removing the need for platform-dependent branching in consumers. [[1]](diffhunk://#diff-6a81e30ede7c978712fe0743ed47b87742ba5387bb024ef33f0bde2e6d73a529L13-L24) [[2]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0L26-L32) [[3]](diffhunk://#diff-408450f968c0a4e477b5ed0c0a5563fc710904c0e7aa9ae1f8b73a45df1fbccfL15-L18) [[4]](diffhunk://#diff-9bbfacf6fc2784c5a8776dcbf0b9984ef78982ed3ec772a8d6ed76d96d4dba35L33-L39) [[5]](diffhunk://#diff-3a01697b6e860385f0d905a44cb1d92b31b74f7803a5c9965f52f4f5acd965d9L249-R250) [[6]](diffhunk://#diff-3a01697b6e860385f0d905a44cb1d92b31b74f7803a5c9965f52f4f5acd965d9L287-L334)
* Refactored `WebViewFactory` and `ContributionDocumentView` to always acquire WebViews from the factory, with platform-specific details handled internally, eliminating duplicated code paths for pooled and in-place creation. [[1]](diffhunk://#diff-9bbfacf6fc2784c5a8776dcbf0b9984ef78982ed3ec772a8d6ed76d96d4dba35L33-L39) [[2]](diffhunk://#diff-3a01697b6e860385f0d905a44cb1d92b31b74f7803a5c9965f52f4f5acd965d9L249-R250) [[3]](diffhunk://#diff-3a01697b6e860385f0d905a44cb1d92b31b74f7803a5c9965f52f4f5acd965d9L287-L334)

**macOS stability improvements:**

* Introduced a process-lifetime pinning mechanism for native WKWebView handles using `RetainNativeWebView`, preventing use-after-free errors caused by premature disposal of native views. This is now called in all relevant entry points (`EnsureCoreWebView2Async`, `InstallDocumentStartScriptAsync`, `SetApplicationUserAgent`, `LoadHtmlString`). [[1]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dR77-R80) [[2]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dR136-R160) [[3]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R53-R68) [[4]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R196) [[5]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R236-R237) [[6]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R266-R300)

**Initialization robustness:**

* Changed initialization host logic to asynchronously wait for the application's root grid to become available, improving resilience during early startup and preventing failures when the UI is not yet ready. [[1]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0L42-R35) [[2]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R266-R300)

These changes streamline the platform abstraction, reduce complexity, and address critical lifecycle issues on macOS.