### PR TITLE
Fix ServiceLocator state leakage between tests

### DIFF
--- a/Source/Core/Celbridge.Foundation/Core/ServiceLocator.cs
+++ b/Source/Core/Celbridge.Foundation/Core/ServiceLocator.cs
@@ -23,6 +23,15 @@ public static class ServiceLocator
     }
 
     /// <summary>
+    /// Clears the service provider, returning the locator to its uninitialized state.
+    /// Intended for test teardown where a fixture must restore an uninitialized locator so that later fixtures inherit a clean slate.
+    /// </summary>
+    public static void Reset()
+    {
+        _serviceProvider = null;
+    }
+
+    /// <summary>
     /// Extension method to acquire a service from the service provider.
     /// This can be used in contexts where Microsoft.Extensions.DependencyInjection should be avoided, e.g. Modules.
     /// </summary>

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSModalOcclusionMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSModalOcclusionMonitor.cs
@@ -26,7 +26,14 @@ internal static class MacOSModalOcclusionMonitor
             return NoOpScope.Instance;
         }
 
-        var scope = new DialogScope(dialogName);
+        // No DI logger means no UI host to monitor (e.g. unit tests).
+        var logger = ServiceLocator.ServiceProvider?.GetService(typeof(ILogger<DialogScope>)) as ILogger<DialogScope>;
+        if (logger is null)
+        {
+            return NoOpScope.Instance;
+        }
+
+        var scope = new DialogScope(dialogName, logger);
         scope.Start();
         return scope;
     }
@@ -51,9 +58,9 @@ internal static class MacOSModalOcclusionMonitor
         private readonly string _dialogName;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-        public DialogScope(string dialogName)
+        public DialogScope(string dialogName, ILogger logger)
         {
-            _logger = ServiceLocator.AcquireService<ILogger<DialogScope>>();
+            _logger = logger;
             _dialogName = dialogName;
         }
 

--- a/Source/Tests/Documents/DocumentViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentViewModelTests.cs
@@ -22,6 +22,7 @@ public class DocumentViewModelTests
     private TestDocumentViewModel _vm = null!;
     private string _tempFolder = null!;
     private string _tempFilePath = null!;
+    private IServiceProvider? _previousServiceProvider;
 
     [SetUp]
     public void Setup()
@@ -58,6 +59,10 @@ public class DocumentViewModelTests
         services.AddSingleton(_messengerService);
         services.AddSingleton(workspaceWrapper);
         services.AddSingleton<ILocalFileSystem>(TestFileSystem.CreateLocal());
+
+        // Capture and restore the global ServiceLocator around each test so this fixture
+        // leaves it as it found it and later fixtures inherit a clean slate.
+        _previousServiceProvider = ServiceLocator.ServiceProvider;
         ServiceLocator.Initialize(services.BuildServiceProvider());
 
         _vm = new TestDocumentViewModel(_resourceFileSystem);
@@ -70,6 +75,15 @@ public class DocumentViewModelTests
     {
         _vm.Cleanup();
         _messengerService.UnregisterAll(this);
+
+        if (_previousServiceProvider is not null)
+        {
+            ServiceLocator.Initialize(_previousServiceProvider);
+        }
+        else
+        {
+            ServiceLocator.Reset();
+        }
 
         if (Directory.Exists(_tempFolder))
         {

--- a/Source/Tests/Host/CelbridgeHostTests.cs
+++ b/Source/Tests/Host/CelbridgeHostTests.cs
@@ -41,6 +41,10 @@ public class CelbridgeHostTests
         {
             ServiceLocator.Initialize(_previousServiceProvider);
         }
+        else
+        {
+            ServiceLocator.Reset();
+        }
     }
 
     [Test]


### PR DESCRIPTION
Tests were polluting each other's global ServiceLocator state, causing intermittent failures when test order varied.

Added ServiceLocator.Reset() to clear the service provider for test teardown. Updated test fixtures (DocumentViewModelTests and CelbridgeHostTests) to capture and restore the ServiceLocator state, ensuring each test inherits a clean slate. Also updated MacOSModalOcclusionMonitor to gracefully handle missing DI context (e.g., in unit tests) by checking for logger availability before attempting to log.