### PR TITLE
Keep Tab inside focused editors on macOS

### DIFF
--- a/Source/Core/Celbridge.Foundation/Workspace/Editing.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/Editing.cs
@@ -33,6 +33,13 @@ public interface IEditTarget
     /// Performs the intent on the surface's current selection. May be fire-and-forget.
     /// </summary>
     void PerformEdit(EditIntent intent);
+
+    /// <summary>
+    /// Handles a Tab (or Shift+Tab) keypress that the platform's focus navigation would otherwise consume,
+    /// keeping it inside the surface (e.g. a code editor indents or outdents). Returns false to let normal
+    /// focus navigation proceed. May be fire-and-forget.
+    /// </summary>
+    bool TryHandleTabKey(bool shift);
 }
 
 /// <summary>
@@ -45,12 +52,13 @@ public record EditAvailability(
     bool CanPaste,
     bool CanSelectAll,
     bool CanUndo,
-    bool CanRedo)
+    bool CanRedo,
+    bool CanIndent)
 {
     /// <summary>
     /// The default for an editor that has reported nothing yet: nothing is allowed.
     /// </summary>
-    public static EditAvailability None { get; } = new(false, false, false, false, false, false);
+    public static EditAvailability None { get; } = new(false, false, false, false, false, false, false);
 
     /// <summary>
     /// Whether the given intent is one of the currently allowed verbs.

--- a/Source/Core/Celbridge.Host/Services/IHostInput.cs
+++ b/Source/Core/Celbridge.Host/Services/IHostInput.cs
@@ -17,6 +17,10 @@ public static class InputRpcMethods
     // Host to client. Asks the editor to run one of its own edit commands (selectAll, undo, redo).
     public const string PerformEdit = "input/performEdit";
 
+    // Host to client. Tells the editor a Tab (or Shift+Tab) was pressed, for editors that handle Tab their
+    // own way (e.g. the spreadsheet moves the active cell). The code editor uses PerformEdit for indenting.
+    public const string TabKey = "input/tabKey";
+
     // Client to host. Reports which edit verbs the editor can currently perform.
     public const string EditAvailabilityChanged = "input/editAvailabilityChanged";
 
@@ -79,7 +83,8 @@ public interface IHostInput
         bool canPaste,
         bool canSelectAll,
         bool canUndo,
-        bool canRedo)
+        bool canRedo,
+        bool canIndent = false)
     { }
 
     /// <summary>
@@ -103,8 +108,15 @@ public static class HostInputExtensions
 
     /// <summary>
     /// Asks the editor to run one of its own edit commands. The command is the editor command name
-    /// (selectAll, undo, redo). Copy, cut, and paste are host-mediated and not sent here.
+    /// (selectAll, undo, redo, indent, outdent). Copy, cut, and paste are host-mediated and not sent here.
     /// </summary>
     public static Task NotifyPerformEditAsync(this CelbridgeHost host, string command)
         => host.Rpc.NotifyWithParameterObjectAsync(InputRpcMethods.PerformEdit, new { command });
+
+    /// <summary>
+    /// Tells the editor that Tab (or Shift+Tab) was pressed while it was focused, so an editor that navigates
+    /// on Tab (such as the spreadsheet moving the active cell) can act on it.
+    /// </summary>
+    public static Task NotifyTabKeyAsync(this CelbridgeHost host, bool shift)
+        => host.Rpc.NotifyWithParameterObjectAsync(InputRpcMethods.TabKey, new { shift });
 }

--- a/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
+++ b/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
@@ -8,6 +8,7 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <UnoFeatures>
       CSharpMarkup;

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSTabKeyMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSTabKeyMonitor.cs
@@ -1,0 +1,163 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Celbridge.Logging;
+using Celbridge.Workspace;
+using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Installs an AppKit local key-down monitor that keeps Tab inside a focused document instead of letting it
+/// move focus out to the surrounding panels. On the Skia head a Tab press routes either natively (the WKWebView
+/// is first responder) or through Uno's focus manager, and in both cases the AppKit key-view loop advances out
+/// of the WebView regardless of what the web content does with the key. A local monitor sees the event before
+/// it is dispatched to any responder, so while a document holds focus it hands Tab to the focused editor (which
+/// indents, moves a cell, and so on) and swallows the key so focus cannot leave the document. macOS-only.
+/// </summary>
+internal static class MacOSTabKeyMonitor
+{
+    private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+    private const string LibSystem = "/usr/lib/libSystem.dylib";
+
+    // BLOCK_IS_GLOBAL marks a block literal as a global (never copied or freed) block.
+    private const int BlockIsGlobal = 1 << 28;
+
+    // NSEventMaskKeyDown == 1 << 10.
+    private const ulong EventMaskKeyDown = 1UL << 10;
+
+    // kVK_Tab hardware key code.
+    private const ulong TabKeyCode = 48;
+
+    // NSEventModifierFlagShift == 1 << 17.
+    private const ulong ModifierFlagShift = 1UL << 17;
+
+    // objc_msgSend for +addLocalMonitorForEventsMatchingMask:handler: (an NSUInteger mask then a block).
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendMessageAddMonitor(IntPtr receiver, IntPtr selector, nuint mask, IntPtr block);
+
+    [DllImport(LibSystem)]
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+    private static readonly IntPtr RtldDefault = new(-2);
+
+    private static bool _started;
+    private static IntPtr _monitor;
+    private static IntPtr _monitorBlock;
+    private static IFocusService? _focusService;
+    private static ILogger? _logger;
+
+    public static void Start(IFocusService focusService, ILogger logger)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+        _focusService = focusService;
+        _logger = logger;
+
+        var nsEventClass = GetClass("NSEvent");
+        var selector = GetSelector("addLocalMonitorForEventsMatchingMask:handler:");
+        var block = EnsureMonitorBlock();
+
+        var monitor = SendMessageAddMonitor(nsEventClass, selector, (nuint)EventMaskKeyDown, block);
+
+        // Retain the monitor object for the process lifetime so the subscription survives.
+        _monitor = SendMessage(monitor, GetSelector("retain"));
+    }
+
+    // The handler is an Objective-C block of shape NSEvent* (^)(NSEvent*). Built once as a no-capture global
+    // block whose invoke pointer is a managed method: returning the event passes it on, returning nil swallows
+    // it.
+    private static unsafe IntPtr EnsureMonitorBlock()
+    {
+        if (_monitorBlock != IntPtr.Zero)
+        {
+            return _monitorBlock;
+        }
+
+        var descriptor = new BlockDescriptor
+        {
+            Reserved = 0,
+            Size = (nuint)Marshal.SizeOf<BlockLiteral>(),
+        };
+        var descriptorPointer = Marshal.AllocHGlobal(Marshal.SizeOf<BlockDescriptor>());
+        Marshal.StructureToPtr(descriptor, descriptorPointer, false);
+
+        var blockIsa = dlsym(RtldDefault, "_NSConcreteGlobalBlock");
+        var invoke = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)&MonitorCallback;
+
+        var block = new BlockLiteral
+        {
+            Isa = blockIsa,
+            Flags = BlockIsGlobal,
+            Reserved = 0,
+            Invoke = invoke,
+            Descriptor = descriptorPointer,
+        };
+        var blockPointer = Marshal.AllocHGlobal(Marshal.SizeOf<BlockLiteral>());
+        Marshal.StructureToPtr(block, blockPointer, false);
+
+        _monitorBlock = blockPointer;
+        return blockPointer;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static IntPtr MonitorCallback(IntPtr block, IntPtr nsEvent)
+    {
+        // Runs on the main thread during event dispatch. Never let an exception cross back into AppKit.
+        try
+        {
+            var keyCode = SendMessageReturnNuint(nsEvent, GetSelector("keyCode")) & 0xFFFF;
+            if (keyCode != TabKeyCode)
+            {
+                return nsEvent;
+            }
+
+            // Only intercept Tab while a document is focused. Tab still navigates the managed panels
+            // (Explorer, Inspector, and so on) everywhere else.
+            if (_focusService?.FocusedPanel != WorkspacePanel.Documents)
+            {
+                return nsEvent;
+            }
+
+            var modifierFlags = SendMessageReturnNuint(nsEvent, GetSelector("modifierFlags"));
+            var shift = (modifierFlags & ModifierFlagShift) != 0;
+
+            // Let the focused editor act on Tab (a code editor indents or outdents). Whether or not it does,
+            // the key is swallowed below so focus can never leave the document for the surrounding app UI.
+            _focusService.EditTarget?.TryHandleTabKey(shift);
+
+            return IntPtr.Zero;
+        }
+        catch (Exception exception)
+        {
+            // A throw must never unwind back into AppKit, so pass the event through on failure.
+            _logger?.LogError(exception, "The Tab key monitor callback failed");
+            return nsEvent;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BlockLiteral
+    {
+        public IntPtr Isa;
+        public int Flags;
+        public int Reserved;
+        public IntPtr Invoke;
+        public IntPtr Descriptor;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BlockDescriptor
+    {
+        public nuint Reserved;
+        public nuint Size;
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using Celbridge.Navigation;
 using Celbridge.UserInterface.Services;
 using Celbridge.UserInterface.ViewModels.Pages;
 using Celbridge.UserInterface.Views.Controls;
+using Celbridge.Workspace;
 using Windows.System;
 
 namespace Celbridge.UserInterface.Views;
@@ -74,6 +75,11 @@ public partial class MainPage : Page
         // Keep the AppKit first responder aligned with managed-panel focus so the native Edit-menu
         // shortcuts fall through to Uno's keyboard handling. macOS-only. A no-op elsewhere.
         Celbridge.UserInterface.Platform.MacOSManagedPanelResponder.Start(_messengerService);
+
+        // Deliver Tab to a focused code editor (indent / outdent) instead of letting the platform focus loop
+        // move focus out of it. macOS-only. A no-op elsewhere.
+        var focusServiceForTab = ServiceLocator.AcquireService<IFocusService>();
+        Celbridge.UserInterface.Platform.MacOSTabKeyMonitor.Start(focusServiceForTab, _logger);
 
         // Register for layout mode changes
         _messengerService.Register<LayoutModeChangedMessage>(this, OnLayoutModeChanged);

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/input-api.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/input-api.js
@@ -77,6 +77,8 @@ export class InputAPI {
      * @param {boolean} [availability.canSelectAll]
      * @param {boolean} [availability.canUndo]
      * @param {boolean} [availability.canRedo]
+     * @param {boolean} [availability.canIndent] - Whether the editor indents on Tab, so the host keeps Tab
+     *   inside the editor instead of letting it move focus.
      */
     notifyEditAvailability(availability = {}) {
         this.#transport.notify('input/editAvailabilityChanged', {
@@ -85,7 +87,8 @@ export class InputAPI {
             canPaste: availability.canPaste === true,
             canSelectAll: availability.canSelectAll === true,
             canUndo: availability.canUndo === true,
-            canRedo: availability.canRedo === true
+            canRedo: availability.canRedo === true,
+            canIndent: availability.canIndent === true
         });
     }
 }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -138,7 +138,9 @@ export class EditorController {
             cut: 'editor.action.clipboardCutAction',
             paste: 'editor.action.clipboardPasteAction',
             undo: 'undo',
-            redo: 'redo'
+            redo: 'redo',
+            indent: 'tab',
+            outdent: 'outdent'
         }[intent];
 
         if (actionId) {
@@ -554,6 +556,7 @@ export class EditorController {
         // Paste/select-all/undo/redo are always offered and no-op when there is nothing to do.
         this.#editor.onDidChangeCursorSelection(() => this.#notifyEditAvailability());
         this.#editor.onDidFocusEditorText(() => this.#notifyEditAvailability());
+        this.#editor.onDidBlurEditorText(() => this.#notifyEditAvailability());
     }
 
     #notifyEditAvailability() {
@@ -570,7 +573,10 @@ export class EditorController {
             canPaste: true,
             canSelectAll: true,
             canUndo: true,
-            canRedo: true
+            canRedo: true,
+            // Only claim Tab while the editor text has focus, so Tab still moves between the fields of the
+            // find widget or any other control hosted in the same WebView.
+            canIndent: this.#editor.hasTextFocus()
         });
     }
 

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/editor-controller.test.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/tests/editor-controller.test.js
@@ -33,6 +33,8 @@ function createMockEditor(model) {
         onDidScrollChange: vi.fn(),
         onDidChangeCursorSelection: vi.fn(),
         onDidFocusEditorText: vi.fn(),
+        onDidBlurEditorText: vi.fn(),
+        hasTextFocus: vi.fn(() => true),
         getSelection: vi.fn(() => ({ isEmpty: () => true })),
         setSelection: vi.fn(),
         trigger: vi.fn(),

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -278,6 +278,43 @@ function initializeSpreadsheet() {
     }
 }
 
+// Moves the active cell one column on Tab (or back on Shift+Tab). The host swallows the native Tab so focus
+// stays in the document, then forwards it here, matching the cell navigation the packaged Windows head gets
+// from the WebView natively.
+function handleTabKey(shift) {
+    if (!designer) {
+        return;
+    }
+
+    let spread;
+    try {
+        spread = designer.getWorkbook();
+    } catch (err) {
+        return;
+    }
+
+    const sheet = spread?.getActiveSheet();
+    if (!sheet) {
+        return;
+    }
+
+    const row = sheet.getActiveRowIndex();
+    const column = sheet.getActiveColumnIndex();
+    if (row < 0
+        || column < 0) {
+        return;
+    }
+
+    const columnCount = sheet.getColumnCount();
+    const targetColumn = Math.max(0, Math.min(shift ? column - 1 : column + 1, columnCount - 1));
+    if (targetColumn === column) {
+        return;
+    }
+
+    sheet.setActiveCell(row, targetColumn);
+    sheet.showColumn(targetColumn, GC.Spread.Sheets.HorizontalPosition.nearest);
+}
+
 async function initializeEditor() {
     try {
         // Resolve the host capability context before initializeSpreadsheet reads the
@@ -308,6 +345,11 @@ async function initializeEditor() {
             });
             return;
         }
+
+        // The host forwards Tab here (it swallows the native key so focus cannot leave the document).
+        client.onNotification('input/tabKey', (params) => {
+            handleTabKey(params?.shift === true);
+        });
 
         client.viewState.onChanged((viewState) => {
             if (viewState.writable) {

--- a/Source/Workspace/Celbridge.Console/Views/ConsolePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Console/Views/ConsolePanel.xaml.cs
@@ -113,6 +113,12 @@ public sealed partial class ConsolePanel : UserControl, IConsolePanel, IConsoleN
         }
     }
 
+    public bool TryHandleTabKey(bool shift)
+    {
+        // The console does not act on Tab, so normal focus navigation proceeds.
+        return false;
+    }
+
     private async Task CopyConsoleSelectionAsync()
     {
         var consoleHost = _consoleHost;
@@ -168,7 +174,8 @@ public sealed partial class ConsolePanel : UserControl, IConsolePanel, IConsoleN
         bool canPaste,
         bool canSelectAll,
         bool canUndo,
-        bool canRedo)
+        bool canRedo,
+        bool canIndent = false)
     {
         _editAvailability = new EditAvailability(
             canCopy,
@@ -176,7 +183,8 @@ public sealed partial class ConsolePanel : UserControl, IConsolePanel, IConsoleN
             canPaste,
             canSelectAll,
             canUndo,
-            canRedo);
+            canRedo,
+            canIndent);
     }
 
     private void OnRequestConsoleFocus(object recipient, RequestConsoleFocusMessage message)

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -907,6 +907,25 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
         }
     }
 
+    public bool TryHandleTabKey(bool shift)
+    {
+        // A code editor with text focus indents or outdents. It reports that over the bridge, so a read-only
+        // or unfocused editor falls through to the generic Tab notification below.
+        if (_editAvailability.CanIndent)
+        {
+            var command = shift ? "outdent" : "indent";
+            _ = Host?.NotifyPerformEditAsync(command);
+
+            return true;
+        }
+
+        // Other editors handle Tab their own way (the spreadsheet moves the active cell). Editors that do
+        // not act on it ignore the notification, and the key is still swallowed so focus stays in the document.
+        _ = Host?.NotifyTabKeyAsync(shift);
+
+        return true;
+    }
+
     private async Task CopyEditorSelectionAsync(bool deleteSelection)
     {
         var host = Host;
@@ -967,7 +986,8 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
         bool canPaste,
         bool canSelectAll,
         bool canUndo,
-        bool canRedo)
+        bool canRedo,
+        bool canIndent = false)
     {
         _editAvailability = new EditAvailability(
             canCopy,
@@ -975,7 +995,8 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
             canPaste,
             canSelectAll,
             canUndo,
-            canRedo);
+            canRedo,
+            canIndent);
     }
 
     private async void ViewModel_ReloadRequested(object? sender, EventArgs e)

--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.Keyboard.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.Keyboard.cs
@@ -96,6 +96,12 @@ public sealed partial class ResourceTree : IEditTarget
         }
     }
 
+    public bool TryHandleTabKey(bool shift)
+    {
+        // The resource tree does not act on Tab, so normal focus navigation proceeds.
+        return false;
+    }
+
     private static EditIntent? ResolveEditIntent(VirtualKey key)
     {
         if (!EditKeyboard.IsCommandModifierDown())


### PR DESCRIPTION
Route Tab so focused editors can handle it (indent/outdent or cell navigation) instead of losing focus. Adds IEditTarget.TryHandleTabKey and EditAvailability.canIndent, a new host RPC (input/tabKey) and NotifyTabKeyAsync, and a MacOSTabKeyMonitor (ObjC interop) that swallows Tab on macOS and forwards it to the focused document. Code editor maps indent/outdent and reports canIndent when text-focused; spreadsheet handles Tab to move active cell and listens for input/tabKey. Updated views to implement TryHandleTabKey and propagate canIndent. AllowUnsafeBlocks enabled for ObjC interop. Tests adjusted.

Fixes #747