### PR TITLE
Fix MacOS - cannot open a project by double clicking “.celbridge” file 

### DIFF
--- a/Source/Celbridge/App.xaml.cs
+++ b/Source/Celbridge/App.xaml.cs
@@ -1,6 +1,7 @@
 using Celbridge.Commands.Services;
 using Celbridge.Commands;
 using Celbridge.Platform;
+using Celbridge.Projects;
 using Celbridge.Modules.Services;
 using Celbridge.Modules;
 using Celbridge.UserInterface.Services;
@@ -11,9 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 
 #if WINDOWS
-using Celbridge.FileSystem;
 using Celbridge.Resources;
-using Celbridge.Settings;
 using Windows.ApplicationModel.Activation;
 #endif
 
@@ -152,7 +151,11 @@ public partial class App : Application
         var environmentInfo = environmentService.GetEnvironmentInfo();
         logger.LogDebug(environmentInfo.ToString());
 
-        // Check if the application was opened with a project file argument 
+        // Resolve the activation service before the main page loads so it is subscribed for the
+        // MainPageLoadedMessage that triggers the startup project open.
+        var appActivationService = Host.Services.GetRequiredService<IAppActivationService>();
+
+        // Check if the application was opened with a project file argument
 #if WINDOWS
         var activatedEventArgs = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
         if (activatedEventArgs.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.File)
@@ -165,24 +168,18 @@ public partial class App : Application
                 {
                     var projectFile = storageFile.Path;
                     logger.LogDebug($"Launched with project file: {projectFile}");
-                    var fileSystem = Host.Services.GetRequiredService<ILocalFileSystem>();
-                    var projectFileInfo = await fileSystem.GetInfoAsync(projectFile);
-                    if (projectFileInfo.IsSuccess
-                        && projectFileInfo.Value.Kind == StorageItemKind.File)
-                    {
-                        var settingsService = Host.Services.GetRequiredService<ISettingsService>();
-                        settingsService.Set(SettingCatalog.Project.PreviousProject, projectFile);
-                    }
+                    appActivationService.OnFilesActivated(new List<string> { projectFile });
                 }
             }
         }
 #else
-        // The macOS counterpart to the Windows file activation above is not implemented yet: a double-clicked
-        // .celbridge launches the app (the bundle declares the association), but macOS delivers the opened
-        // path via an Apple Event that Uno does not surface on this head. The app auto-opens the previous project.
-        // No async file-activation work on this head; the await keeps OnLaunched awaiting on non-Windows heads.
-        await Task.CompletedTask;
+        // The macOS open-document handler is installed onto the app delegate class in Program.Main (before the
+        // run loop, since macOS delivers the launch open event before this runs). Now that DI exists, wire the
+        // routing callback and flush any file path that arrived during launch. Does nothing on the non-macOS
+        // Skia heads.
+        Celbridge.UserInterface.Platform.MacOSFileActivation.SetCallback(appActivationService.OnFilesActivated);
 #endif
+        await Task.CompletedTask;
 
         // Initialize the Core Services
         InitializeCoreServices();

--- a/Source/Celbridge/Platforms/Desktop/Program.cs
+++ b/Source/Celbridge/Platforms/Desktop/Program.cs
@@ -14,6 +14,11 @@ public class Program
             .UseWin32()
             .Build();
 
+        // Add the macOS open-document handler to Uno's application delegate before the run loop starts. macOS
+        // delivers a double-clicked file's open event before applicationDidFinishLaunching:, so installing it
+        // from App.OnLaunched would be too late and AppKit would reject the file. No-op off macOS.
+        Celbridge.UserInterface.Platform.MacOSFileActivation.InstallOnDelegateClass();
+
         host.Run();
     }
 }

--- a/Source/Core/Celbridge.Foundation/Platform/IAppEnvironment.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IAppEnvironment.cs
@@ -27,6 +27,11 @@ public interface IAppEnvironment
     string TemporaryFolderPath { get; }
 
     /// <summary>
+    /// The process working folder captured at application startup, before any loaded project changes it.
+    /// </summary>
+    string LaunchWorkingFolderPath { get; }
+
+    /// <summary>
     /// Returns the on-disk path to a bundled asset (file or folder) shipped by the given library module,
     /// at the forward-slashed relative path within that module's bundled files.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Projects/IAppActivationService.cs
+++ b/Source/Core/Celbridge.Foundation/Projects/IAppActivationService.cs
@@ -1,0 +1,15 @@
+namespace Celbridge.Projects;
+
+/// <summary>
+/// Decides which project to open when the app is activated: the project file the operating system asked the
+/// app to open (such as a double-clicked .celbridge file), or the previously open project at startup. Opens
+/// the startup project when the main page has loaded.
+/// </summary>
+public interface IAppActivationService
+{
+    /// <summary>
+    /// Handles the file paths the operating system asked the app to open. Before startup completes the
+    /// project file is deferred to the startup flow; afterwards it opens immediately.
+    /// </summary>
+    void OnFilesActivated(IReadOnlyList<string> filePaths);
+}

--- a/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
@@ -16,6 +16,11 @@ public record MainWindowDeactivatedMessage();
 public record ActivePageChangedMessage(ApplicationPage ActivePage);
 
 /// <summary>
+/// Sent when the main page has finished loading at startup.
+/// </summary>
+public record MainPageLoadedMessage();
+
+/// <summary>
 /// Message sent when the layout mode (chrome level) changes.
 /// </summary>
 public record LayoutModeChangedMessage(LayoutMode LayoutMode);

--- a/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
+++ b/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
@@ -41,6 +41,10 @@
     <ProjectReference Include="..\..\Templates\Celbridge.Templates.csproj" ReferenceOutputAssembly="false" UndefineProperties="TargetFramework" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Celbridge.Tests" />
+  </ItemGroup>
+
   <!-- Runs after the referenced Celbridge.Templates project has generated the zips and before MSBuild
        assigns content target paths, so the freshly built zips flow through the normal Uno content
        pipeline (library layout on the Skia heads, package root on the packaged Windows head). -->

--- a/Source/Core/Celbridge.Projects/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.Projects/ServiceConfiguration.cs
@@ -12,6 +12,7 @@ public static class ServiceConfiguration
         //
 
         services.AddSingleton<IProjectService, ProjectService>();
+        services.AddSingleton<IAppActivationService, AppActivationService>();
         services.AddSingleton<IProjectMigrationService, ProjectMigrationService>();
         services.AddSingleton<IProjectTemplateService, ProjectTemplateService>();
         services.AddSingleton<IMigrationStepRegistry, MigrationStepRegistry>();

--- a/Source/Core/Celbridge.Projects/Services/AppActivationService.cs
+++ b/Source/Core/Celbridge.Projects/Services/AppActivationService.cs
@@ -1,0 +1,140 @@
+using Celbridge.Commands;
+using Celbridge.FileSystem;
+using Celbridge.Logging;
+using Celbridge.Messaging;
+using Celbridge.Navigation;
+using Celbridge.Settings;
+using Celbridge.UserInterface;
+
+namespace Celbridge.Projects.Services;
+
+public class AppActivationService : IAppActivationService
+{
+    private readonly ILogger<AppActivationService> _logger;
+    private readonly ICommandService _commandService;
+    private readonly ISettingsService _settingsService;
+    private readonly ILocalFileSystem _fileSystem;
+    private readonly INavigationService _navigationService;
+
+    // All access is on the UI thread: the macOS open-document callback, the Windows activation call, and the
+    // MainPageLoadedMessage handler all run there.
+    private bool _startupCompleted;
+    private string? _pendingProjectFilePath;
+
+    public AppActivationService(
+        ILogger<AppActivationService> logger,
+        IMessengerService messengerService,
+        ICommandService commandService,
+        ISettingsService settingsService,
+        ILocalFileSystem fileSystem,
+        INavigationService navigationService)
+    {
+        _logger = logger;
+        _commandService = commandService;
+        _settingsService = settingsService;
+        _fileSystem = fileSystem;
+        _navigationService = navigationService;
+
+        messengerService.Register<MainPageLoadedMessage>(this, OnMainPageLoaded);
+    }
+
+    public void OnFilesActivated(IReadOnlyList<string> filePaths)
+    {
+        var projectFilePath = filePaths.FirstOrDefault(IsProjectFile);
+        if (string.IsNullOrEmpty(projectFilePath))
+        {
+            return;
+        }
+
+        if (_startupCompleted)
+        {
+            LoadProject(projectFilePath);
+        }
+        else
+        {
+            // The startup flow has not run yet, so defer the project to it rather than racing a second load
+            // against the previous-project open.
+            _pendingProjectFilePath = projectFilePath;
+        }
+    }
+
+    private async void OnMainPageLoaded(object recipient, MainPageLoadedMessage message)
+    {
+        if (_startupCompleted)
+        {
+            return;
+        }
+
+        try
+        {
+            var projectFilePath = await ChooseStartupProjectAsync();
+            _startupCompleted = true;
+
+            // A file activation that arrived while choosing wins over the startup choice.
+            if (_pendingProjectFilePath != null)
+            {
+                projectFilePath = _pendingProjectFilePath;
+                _pendingProjectFilePath = null;
+            }
+
+            if (!string.IsNullOrEmpty(projectFilePath))
+            {
+                LoadProject(projectFilePath);
+            }
+            else
+            {
+                // No project to open, so show the home page.
+                _navigationService.NavigateToPage(NavigationConstants.HomeTag);
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to open a project at startup");
+        }
+    }
+
+    // Prefer a project file the OS asked the app to open at launch, falling back to the project that was open
+    // last time the app ran.
+    private async Task<string?> ChooseStartupProjectAsync()
+    {
+        var activationProjectFile = _pendingProjectFilePath;
+        _pendingProjectFilePath = null;
+        if (!string.IsNullOrEmpty(activationProjectFile) &&
+            await ProjectFileExistsAsync(activationProjectFile))
+        {
+            return activationProjectFile;
+        }
+
+        var previousProjectFile = _settingsService.Get(SettingCatalog.Project.PreviousProject);
+        if (!string.IsNullOrEmpty(previousProjectFile) &&
+            await ProjectFileExistsAsync(previousProjectFile))
+        {
+            return previousProjectFile;
+        }
+
+        return null;
+    }
+
+    private async Task<bool> ProjectFileExistsAsync(string filePath)
+    {
+        var infoResult = await _fileSystem.GetInfoAsync(filePath);
+        return infoResult.IsSuccess
+            && infoResult.Value.Kind == StorageItemKind.File;
+    }
+
+    private void LoadProject(string projectFilePath)
+    {
+        _logger.LogDebug($"Opening project file: {projectFilePath}");
+
+        _commandService.Execute<ILoadProjectCommand>(command =>
+        {
+            command.ProjectFilePath = projectFilePath;
+        });
+    }
+
+    private static bool IsProjectFile(string filePath)
+    {
+        var extension = System.IO.Path.GetExtension(filePath);
+        return string.Equals(extension, ProjectConstants.ProjectFileExtension, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectUnloader.cs
@@ -13,6 +13,11 @@ public class ProjectUnloader
 {
     private const string EmptyPageTag = "Empty";
 
+    private const int PollIntervalMs = 50;
+
+    // Settable so tests can exercise the timeout without waiting the full bound.
+    internal int UnloadTimeoutMs { get; set; } = 30000;
+
     private readonly ILogger<ProjectUnloader> _logger;
     private readonly IProjectService _projectService;
     private readonly INavigationService _navigationService;
@@ -107,10 +112,19 @@ public class ProjectUnloader
                 .WithErrors(navResult);
         }
 
-        // Wait until the workspace is fully unloaded
+        // Wait until the workspace is fully unloaded. The wait is bounded so a teardown failure fails
+        // this command instead of blocking the command queue forever. The healthy path can take tens of
+        // seconds when many open editors each hit their state-save timeout.
+        var elapsedMs = 0;
         while (_workspaceWrapper.IsWorkspacePageLoaded)
         {
-            await Task.Delay(50);
+            if (elapsedMs >= UnloadTimeoutMs)
+            {
+                return Result.Fail($"The workspace page did not unload within {UnloadTimeoutMs}ms");
+            }
+
+            await Task.Delay(PollIntervalMs);
+            elapsedMs += PollIntervalMs;
         }
 
         return Result.Ok();

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSFileActivation.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSFileActivation.cs
@@ -1,0 +1,148 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Adds an application:openURLs: method to Uno's macOS application delegate, which Uno does not implement.
+/// Without it AppKit rejects the Finder open-document event for a double-clicked .celbridge file and shows a
+/// "cannot open files" error instead of opening the project. macOS delivers the launch open event before
+/// applicationDidFinishLaunching:, so the method must be added to the delegate CLASS before the run loop
+/// starts (InstallOnDelegateClass, called from Program.Main), while the routing callback is wired up later
+/// once dependency injection exists (SetCallback). Paths that arrive before the callback is set are buffered
+/// and flushed to it. macOS-only.
+/// </summary>
+public static class MacOSFileActivation
+{
+    private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+
+    // Uno's application delegate class, whose only launch methods are applicationDidFinishLaunching: and the
+    // terminate handlers, so it does not respond to the open-document event on its own.
+    private const string DelegateClassName = "UNOApplicationDelegate";
+
+    // Objective-C type encoding for -(void)application:(id)app openURLs:(id)urls: void return, then self,
+    // _cmd, and the two object arguments.
+    private const string OpenURLsTypeEncoding = "v@:@@";
+
+    [DllImport(LibObjC, EntryPoint = "class_addMethod")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static extern bool class_addMethod(IntPtr classHandle, IntPtr selector, IntPtr implementation, string types);
+
+    private static readonly object _gate = new();
+    private static readonly List<string> _bufferedFilePaths = new();
+    private static Action<IReadOnlyList<string>>? _filesOpenedCallback;
+
+    /// <summary>
+    /// Adds application:openURLs: to Uno's application delegate class. Call before the app's run loop starts,
+    /// because macOS delivers the launch open event before applicationDidFinishLaunching:. Returns false off
+    /// macOS or when the delegate class is not yet registered.
+    /// </summary>
+    public static bool InstallOnDelegateClass()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return false;
+        }
+
+        var delegateClass = GetClass(DelegateClassName);
+        if (delegateClass == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var selector = GetSelector("application:openURLs:");
+
+        unsafe
+        {
+            var implementation = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, void>)&HandleOpenURLs;
+            return class_addMethod(delegateClass, selector, implementation, OpenURLsTypeEncoding);
+        }
+    }
+
+    /// <summary>
+    /// Registers the routing callback and flushes any file paths that arrived before it was set. A cold-launch
+    /// open event fires before dependency injection is ready, so its path is buffered until this is called.
+    /// The callback runs on the main (UI) thread.
+    /// </summary>
+    public static void SetCallback(Action<IReadOnlyList<string>> filesOpenedCallback)
+    {
+        List<string> pendingFilePaths;
+        lock (_gate)
+        {
+            _filesOpenedCallback = filesOpenedCallback;
+            pendingFilePaths = new List<string>(_bufferedFilePaths);
+            _bufferedFilePaths.Clear();
+        }
+
+        if (pendingFilePaths.Count > 0)
+        {
+            filesOpenedCallback(pendingFilePaths);
+        }
+    }
+
+    // AppKit invokes this on the main thread with the NSApplication and an NSArray<NSURL*> of opened files.
+    // A managed exception must never unwind back into AppKit.
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static void HandleOpenURLs(IntPtr self, IntPtr selector, IntPtr application, IntPtr urls)
+    {
+        try
+        {
+            if (urls == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var filePaths = ReadFilePaths(urls);
+            if (filePaths.Count == 0)
+            {
+                return;
+            }
+
+            Action<IReadOnlyList<string>>? callback;
+            lock (_gate)
+            {
+                callback = _filesOpenedCallback;
+                if (callback is null)
+                {
+                    // The callback is not wired up yet (cold launch, before DI). Buffer for SetCallback.
+                    _bufferedFilePaths.AddRange(filePaths);
+                    return;
+                }
+            }
+
+            callback(filePaths);
+        }
+        catch
+        {
+            // The routing callback logs its own failures. This boundary guard only exists so a throw from the
+            // Objective-C marshaling cannot cross back into AppKit, so there is nothing useful to log here.
+        }
+    }
+
+    private static List<string> ReadFilePaths(IntPtr urls)
+    {
+        var count = SendMessageReturnNuint(urls, GetSelector("count"));
+        var objectAtIndexSelector = GetSelector("objectAtIndex:");
+        var pathSelector = GetSelector("path");
+
+        var filePaths = new List<string>();
+        for (nuint index = 0; index < count; index++)
+        {
+            var url = SendMessage(urls, objectAtIndexSelector, index);
+            if (url == IntPtr.Zero)
+            {
+                continue;
+            }
+
+            var pathString = SendMessage(url, pathSelector);
+            var path = ReadNSString(pathString);
+            if (!string.IsNullOrEmpty(path))
+            {
+                filePaths.Add(path);
+            }
+        }
+
+        return filePaths;
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Pages/MainPageViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Pages/MainPageViewModel.cs
@@ -1,66 +1,29 @@
-using Celbridge.Commands;
-using Celbridge.Navigation;
-using Celbridge.Projects;
-using Celbridge.Settings;
-
 namespace Celbridge.UserInterface.ViewModels.Pages;
 
 public partial class MainPageViewModel : ObservableObject
 {
     private readonly IMessengerService _messengerService;
     private readonly Logging.ILogger<MainPageViewModel> _logger;
-    private readonly INavigationService _navigationService;
-    private readonly ICommandService _commandService;
-    private readonly ISettingsService _settingsService;
     private readonly IUndoService _undoService;
-    private readonly ILocalFileSystem _fileSystem;
 
     public MainPageViewModel(
         Logging.ILogger<MainPageViewModel> logger,
         IMessengerService messengerService,
-        INavigationService navigationService,
-        ICommandService commandService,
-        ISettingsService settingsService,
-        IUndoService undoService,
-        ILocalFileSystem fileSystem)
+        IUndoService undoService)
     {
         _logger = logger;
         _messengerService = messengerService;
-        _navigationService = navigationService;
-        _commandService = commandService;
-        _settingsService = settingsService;
         _undoService = undoService;
-        _fileSystem = fileSystem;
 
         // Register for undo/redo messages
         _messengerService.Register<UndoRequestedMessage>(this, OnUndoRequested);
         _messengerService.Register<RedoRequestedMessage>(this, OnRedoRequested);
     }
 
-    public async Task OnMainPage_LoadedAsync()
+    public void OnMainPage_Loaded()
     {
-        // Open the previous project if one was loaded last time we ran the application.
-        var previousProjectFile = _settingsService.Get(SettingCatalog.Project.PreviousProject);
-        bool previousProjectExists = false;
-        if (!string.IsNullOrEmpty(previousProjectFile))
-        {
-            var infoResult = await _fileSystem.GetInfoAsync(previousProjectFile);
-            previousProjectExists = infoResult.IsSuccess
-                && infoResult.Value.Kind == StorageItemKind.File;
-        }
-
-        if (previousProjectExists)
-        {
-            _commandService.Execute<ILoadProjectCommand>((command) =>
-            {
-                command.ProjectFilePath = previousProjectFile;
-            });
-        }
-        else
-        {
-            // No previous project to load, so navigate to the home page
-            _navigationService.NavigateToPage(NavigationConstants.HomeTag);
-        }
+        // The app activation service opens the startup project in response to this message.
+        _messengerService.Send(new MainPageLoadedMessage());
     }
 
     public void OnMainPage_Unloaded()
@@ -88,4 +51,3 @@ public partial class MainPageViewModel : ObservableObject
         _undoService.Redo();
     }
 }
-

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
@@ -89,7 +89,7 @@ public partial class MainPage : Page
         Guard.IsNotNull(navigationService);
         navigationService.SetNavigateHandler(NavigateToPage);
 
-        await ViewModel.OnMainPage_LoadedAsync();
+        ViewModel.OnMainPage_Loaded();
 
         // Listen for keyboard input events (required for undo / redo and other app shortcuts).
         // Window.CoreWindow is a legacy UWP API that is null on the Skia desktop head, so the root

--- a/Source/Core/Celbridge.Utilities/Platform/AppEnvironment.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/AppEnvironment.cs
@@ -14,6 +14,20 @@ public sealed class AppEnvironment : IAppEnvironment
 {
     private const string ApplicationDataFolderName = "Celbridge";
 
+    // The process working folder captured at startup, before any loaded project changes it.
+    private static readonly string LaunchWorkingFolder;
+
+    // Capture the launch working folder when this type is first touched during startup (the pre-DI instance
+    // created for the log folder), not lazily on first read of LaunchWorkingFolderPath. By then a loaded
+    // project may have changed the working folder, or deleted it, which would make Environment.CurrentDirectory
+    // throw. The explicit static constructor forces this precise timing (a field initializer alone is
+    // beforefieldinit, so the CLR could defer it to first field access). Environment.CurrentDirectory (not the
+    // analyzer-gated Directory facade) keeps this dependency-free utility from needing a filesystem carve-out.
+    static AppEnvironment()
+    {
+        LaunchWorkingFolder = Environment.CurrentDirectory;
+    }
+
     public EnvironmentInfo GetEnvironmentInfo()
     {
         var appVersion = ResolveAppVersion();
@@ -55,6 +69,8 @@ public sealed class AppEnvironment : IAppEnvironment
 #endif
         }
     }
+
+    public string LaunchWorkingFolderPath => LaunchWorkingFolder;
 
     public string GetBundledAssetPath(string moduleFolderName, string relativePath)
     {

--- a/Source/Tests/Projects/ProjectUnloaderTests.cs
+++ b/Source/Tests/Projects/ProjectUnloaderTests.cs
@@ -1,0 +1,80 @@
+using Celbridge.Navigation;
+using Celbridge.Projects;
+using Celbridge.Projects.Services;
+using Celbridge.Server;
+using Celbridge.Tests.Helpers;
+using Celbridge.Workspace;
+
+namespace Celbridge.Tests.Projects;
+
+/// <summary>
+/// Covers ProjectUnloader's workspace page cleanup wait: the successful unload, the early-out when no
+/// project is loaded, and the bounded timeout that fails the unload instead of blocking the command queue
+/// when the workspace page never unloads.
+/// </summary>
+[TestFixture]
+public class ProjectUnloaderTests
+{
+    private IProjectService _projectService = null!;
+    private INavigationService _navigationService = null!;
+    private IWorkspaceWrapper _workspaceWrapper = null!;
+    private IServerService _serverService = null!;
+    private ProjectUnloader _projectUnloader = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _projectService = Substitute.For<IProjectService>();
+        _navigationService = Substitute.For<INavigationService>();
+        _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+        _serverService = Substitute.For<IServerService>();
+
+        var project = Substitute.For<IProject>();
+        project.ProjectName.Returns("TestProject");
+        _projectService.CurrentProject.Returns(project);
+
+        _navigationService.NavigateToPage(Arg.Any<string>()).Returns(Result.Ok());
+
+        _projectUnloader = new ProjectUnloader(
+            new NullLogger<ProjectUnloader>(),
+            _projectService,
+            _navigationService,
+            _workspaceWrapper,
+            _serverService);
+    }
+
+    [Test]
+    public async Task UnloadProject_WithNoProjectLoaded_Succeeds()
+    {
+        _projectService.CurrentProject.Returns((IProject?)null);
+
+        var result = await _projectUnloader.UnloadProjectAsync();
+
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    [Test]
+    public async Task UnloadProject_WhenWorkspacePageUnloads_Succeeds()
+    {
+        // The workspace page reports loaded until the second poll, then unloads.
+        _workspaceWrapper.IsWorkspacePageLoaded.Returns(true, true, false);
+
+        var result = await _projectUnloader.UnloadProjectAsync();
+
+        Assert.That(result.IsSuccess, Is.True);
+        _projectService.Received(1).ClearCurrentProject();
+        await _serverService.Received(1).StopAsync();
+    }
+
+    [Test]
+    public async Task UnloadProject_WhenWorkspacePageNeverUnloads_FailsAfterTimeout()
+    {
+        _workspaceWrapper.IsWorkspacePageLoaded.Returns(true);
+        _projectUnloader.UnloadTimeoutMs = 200;
+
+        var result = await _projectUnloader.UnloadProjectAsync();
+
+        Assert.That(result.IsFailure, Is.True);
+        _projectService.DidNotReceive().ClearCurrentProject();
+    }
+}

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Celbridge.Console;
 using Celbridge.Logging;
+using Celbridge.Platform;
 using Celbridge.Projects;
 using Celbridge.Server;
 using Celbridge.Settings;
@@ -18,6 +19,7 @@ public class WorkspaceLoader
     private readonly IServerService _serverService;
     private readonly ProjectCheckReporter _projectCheckReporter;
     private readonly IProjectLoadReporter _loadReporter;
+    private readonly IAppEnvironment _appEnvironment;
 
     public WorkspaceLoader(
         ILogger<WorkspaceLoader> logger,
@@ -27,7 +29,8 @@ public class WorkspaceLoader
         IProjectService projectService,
         IServerService serverService,
         ProjectCheckReporter projectCheckReporter,
-        IProjectLoadReporter loadReporter)
+        IProjectLoadReporter loadReporter,
+        IAppEnvironment appEnvironment)
     {
         _logger = logger;
         _workspaceWrapper = workspaceWrapper;
@@ -37,6 +40,7 @@ public class WorkspaceLoader
         _serverService = serverService;
         _projectCheckReporter = projectCheckReporter;
         _loadReporter = loadReporter;
+        _appEnvironment = appEnvironment;
     }
 
     public async Task<Result> LoadWorkspaceAsync()
@@ -222,6 +226,19 @@ public class WorkspaceLoader
         if (Path.Exists(folderPath))
         {
             Directory.SetCurrentDirectory(folderPath);
+        }
+    }
+
+    // Reverts the process working folder to the one captured at startup. Called when a project unloads so the
+    // working folder stays valid while no project is loaded. A deleted project folder would otherwise leave
+    // the working folder dangling, which breaks the next project's server start (getcwd fails).
+    [AllowDirectFileSystemAccess]
+    public void ResetProcessWorkingFolder()
+    {
+        var launchWorkingFolderPath = _appEnvironment.LaunchWorkingFolderPath;
+        if (Path.Exists(launchWorkingFolderPath))
+        {
+            Directory.SetCurrentDirectory(launchWorkingFolderPath);
         }
     }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
@@ -110,27 +110,58 @@ public partial class WorkspacePageViewModel : ObservableObject
         OnPropertyChanged(nameof(IsConsoleMaximized));
     }
 
-    public void OnWorkspacePageUnloaded()
+    public async Task OnWorkspacePageUnloadedAsync()
     {
-        _workspaceService.BindableWorkspaceSettings.PropertyChanged -= OnWorkspaceSettings_PropertyChanged;
+        // Best-effort: persist editor state while the editors are still alive, then close the panels. A
+        // failure here (e.g. the project folder was deleted while the project was open) must not prevent the
+        // dispose and unload notification below, which is a separate step so it still runs.
+        try
+        {
+            // Save editor states before closing documents, while editors are still alive.
+            await _workspaceService.DocumentsService.StoreDocumentEditorStates();
 
-        // Unregister message handlers
-        _messengerService.Unregister<RegionVisibilityChangedMessage>(this);
-        _messengerService.Unregister<ConsoleMaximizedChangedMessage>(this);
+            // Close all open documents and clean up their WebView2 resources.
+            _workspaceService.DocumentsPanel.Shutdown();
 
-        // Clear project-level feature flag overrides before disposing the workspace
-        _featureFlags.ClearProjectOverrides();
+            _workspaceService.ConsolePanel?.Shutdown();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to save workspace state during page unload");
+        }
 
-        // Clear shortcut buttons from the title bar before disposing the workspace
-        _workspaceLoader.ClearTitleBarShortcuts();
+        // Tear down and dispose the workspace. Guarded so the unload notification is still sent on failure.
+        try
+        {
+            _workspaceService.BindableWorkspaceSettings.PropertyChanged -= OnWorkspaceSettings_PropertyChanged;
 
-        // Dispose the workspace service
-        // This disposes all the sub-services and releases all resources held by the workspace.
-        var disposableWorkspace = _workspaceService as IDisposable;
-        Guard.IsNotNull(disposableWorkspace);
-        disposableWorkspace.Dispose();
+            // Unregister message handlers
+            _messengerService.Unregister<RegionVisibilityChangedMessage>(this);
+            _messengerService.Unregister<ConsoleMaximizedChangedMessage>(this);
 
-        // Notify listeners that the workspace has been unloaded.
+            // Clear project-level feature flag overrides before disposing the workspace
+            _featureFlags.ClearProjectOverrides();
+
+            // Clear shortcut buttons from the title bar before disposing the workspace
+            _workspaceLoader.ClearTitleBarShortcuts();
+
+            // Revert the process working folder set on load, so it stays valid while no project is loaded
+            _workspaceLoader.ResetProcessWorkingFolder();
+
+            // Dispose the workspace service
+            // This disposes all the sub-services and releases all resources held by the workspace.
+            var disposableWorkspace = _workspaceService as IDisposable;
+            Guard.IsNotNull(disposableWorkspace);
+            disposableWorkspace.Dispose();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Workspace teardown failed during page unload");
+        }
+
+        // Notify listeners that the workspace has been unloaded. This must always be sent, even after a
+        // failure above, because the ProjectUnloader wait completes only when this message clears the
+        // workspace loaded state.
         var message = new WorkspaceUnloadedMessage();
         _messengerService.Send(message);
     }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspacePage.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspacePage.xaml.cs
@@ -199,25 +199,14 @@ public sealed partial class WorkspacePage : Page
 
     private async Task PerformCleanupAsync()
     {
-        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
-        var workspaceService = workspaceWrapper.WorkspaceService;
-        Guard.IsNotNull(workspaceService);
-
+        // Cleanup owned by this page: its own view-model and message subscriptions. The workspace teardown
+        // (save editor state, shut down panels, dispose the workspace) is orchestrated by the view-model.
         ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
-        // Unregister message handlers
         var messengerService = ServiceLocator.AcquireService<IMessengerService>();
         messengerService.UnregisterAll(this);
 
-        // Save editor states before closing documents, while editors are still alive
-        await workspaceService.DocumentsService.StoreDocumentEditorStates();
-
-        // Close all open documents and clean up their WebView2 resources
-        workspaceService.DocumentsPanel.Shutdown();
-
-        workspaceService.ConsolePanel?.Shutdown();
-
-        ViewModel.OnWorkspacePageUnloaded();
+        await ViewModel.OnWorkspacePageUnloadedAsync();
 
         _initialized = false;
     }


### PR DESCRIPTION
Fixes #745 

This pull request introduces a cross-platform application activation service that centralizes and improves how project files are opened at startup, especially handling OS-level file activation events (like double-clicking a project file) on both Windows and macOS. It also cleans up related startup logic and adds robustness to project unloading. The most important changes are grouped below.

**Cross-Platform Project File Activation**

* Introduced the `IAppActivationService` interface and its implementation `AppActivationService`, which decides which project to open at startup based on OS file activation events or the previously opened project. This service is now registered in dependency injection and handles both Windows and macOS activation flows. [[1]](diffhunk://#diff-6fd55a97ff78b9a810c2d714803cfef0eb34de6eb865389ca5f13172dd8684b8R1-R15) [[2]](diffhunk://#diff-da5f5ab427e01c992bca9965f52bb226f547e98655817bb162f661bbfe4b1d7eR1-R140) [[3]](diffhunk://#diff-6960f96586b6941fd4672355925c229a10098e1bd610dcd68c8a4d7788cd6a76R15)
* On macOS, added `MacOSFileActivation` to hook into Uno's application delegate and handle open-document events, buffering file paths until the DI system is ready. This ensures double-clicking a `.celbridge` file opens the project as expected. [[1]](diffhunk://#diff-a6672a7f8865c2060c08d8e2adecc217f884a05f3fe046284ba571ded09ac2e5R1-R148) [[2]](diffhunk://#diff-0b18123a1e8fc8326e0597c6a44dc7c8e016068dfc26ca07fa25bba7156a21e1R17-R21)

**Startup Flow Refactoring**

* Refactored `App.xaml.cs` to delegate all project file activation logic to `AppActivationService`, removing direct file system and settings checks from the startup path. Also, set up the macOS open-document handler at the correct lifecycle point. [[1]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dR4) [[2]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dL14-L16) [[3]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dR154-R157) [[4]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dL168-R182)
* Simplified `MainPageViewModel` by removing all project opening logic; it now just sends a `MainPageLoadedMessage` to trigger project activation via the new service. [[1]](diffhunk://#diff-8c092e95af05c5c5286aae2b64cd7bb44f4ca20f282564192b14288d844e97ffL1-R26) [[2]](diffhunk://#diff-8c092e95af05c5c5286aae2b64cd7bb44f4ca20f282564192b14288d844e97ffL91)
* Added `MainPageLoadedMessage` to signal when the main page is ready, used by `AppActivationService` to begin project loading.

**Project Unloading Robustness**

* Improved `ProjectUnloader` to bound the wait time for workspace page unloading, making teardown failures explicit and testable. [[1]](diffhunk://#diff-eb68887e54376b0a4a4585dd2d4e0a1d8c2a67fe3173c673dfdc7a4f6f4c17f5R16-R20) [[2]](diffhunk://#diff-eb68887e54376b0a4a4585dd2d4e0a1d8c2a67fe3173c673dfdc7a4f6f4c17f5L110-R127)

**Platform and Environment Enhancements**

* Added `LaunchWorkingFolderPath` to `IAppEnvironment` for capturing the process working folder at startup.

**Testing Support**

* Made `Celbridge.Projects` internals visible to the test project for improved testability.