### PR TITLE
Enhance document panel state management and add macOS focus monitor

### DIFF
--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewFocusMonitor.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewFocusMonitor.cs
@@ -1,0 +1,258 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Celbridge.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.Web.WebView2.Core;
+using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
+
+namespace Celbridge.WebHost.Platform;
+
+/// <summary>
+/// macOS IWebViewFocusMonitor. Installs an AppKit local mouse-down monitor and hit-tests each click
+/// against the registered WKWebViews' native view hierarchies. Hit-testing is the discriminator
+/// because Uno keeps its Skia canvas (UNOMetalFlippedView) as the window's first responder even for
+/// clicks that land inside a hosted WKWebView, so responder state cannot tell the two apart. The
+/// whole click is handled on the native side, so this signal needs neither the managed GotFocus
+/// event nor any script injected into the page. macOS-only.
+/// </summary>
+public class MacOSWebViewFocusMonitor : IWebViewFocusMonitor
+{
+    private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+    private const string LibSystem = "/usr/lib/libSystem.dylib";
+
+    // BLOCK_IS_GLOBAL marks a block literal as a global (never copied or freed) block.
+    private const int BlockIsGlobal = 1 << 28;
+
+    // NSEventMaskLeftMouseDown == 1 << 1, NSEventMaskRightMouseDown == 1 << 3.
+    private const ulong EventMaskMouseDown = (1UL << 1) | (1UL << 3);
+
+    // objc_msgSend for +addLocalMonitorForEventsMatchingMask:handler: (an NSUInteger mask then a block).
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendMessageAddMonitor(IntPtr receiver, IntPtr selector, nuint mask, IntPtr block);
+
+    // An NSPoint is two doubles, a homogeneous float aggregate the ARM64 ABI passes and returns in the
+    // floating-point registers, so the struct marshals by value through plain objc_msgSend. The
+    // struct-shaped signatures keep these declarations local rather than in the shared runtime.
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern NSPoint SendMessageReturnNSPoint(IntPtr receiver, IntPtr selector);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendMessageHitTest(IntPtr receiver, IntPtr selector, NSPoint point);
+
+    [DllImport(LibSystem)]
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+    private static readonly IntPtr RtldDefault = new(-2);
+
+    // The AppKit monitor and its UnmanagedCallersOnly callback are process-global, so the state is
+    // static; DI creates a single instance. All access happens on the main thread: Register and
+    // Unregister run from view lifecycle handlers and the monitor callback runs during AppKit event
+    // dispatch.
+    private static readonly Dictionary<IntPtr, Action> _callbacksByHandle = new();
+    private static readonly Dictionary<CoreWebView2, IntPtr> _handlesByWebView = new();
+
+    private static bool _monitorInstalled;
+    private static IntPtr _monitor;
+    private static IntPtr _monitorBlock;
+    private static IntPtr _lastMatchedHandle;
+    private static DispatcherQueue? _dispatcherQueue;
+    private static ILogger? _logger;
+
+    public MacOSWebViewFocusMonitor(ILogger<MacOSWebViewFocusMonitor> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Register(CoreWebView2 coreWebView, Action onFocusSignal)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        if (!MacOSWebViewInterop.TryGetNativeWebViewHandle(coreWebView, out var handle, out var detail))
+        {
+            _logger?.LogDebug($"Could not resolve the native web view for focus monitoring: {detail}");
+            return;
+        }
+
+        // Re-registration replaces the previous entry, including a stale handle entry if the web
+        // view's native view was recreated since the last registration.
+        if (_handlesByWebView.TryGetValue(coreWebView, out var previousHandle)
+            && previousHandle != handle)
+        {
+            _callbacksByHandle.Remove(previousHandle);
+        }
+
+        _handlesByWebView[coreWebView] = handle;
+        _callbacksByHandle[handle] = onFocusSignal;
+
+        _dispatcherQueue ??= DispatcherQueue.GetForCurrentThread();
+        EnsureMonitorInstalled();
+    }
+
+    public void Unregister(CoreWebView2 coreWebView)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        if (!_handlesByWebView.Remove(coreWebView, out var handle))
+        {
+            return;
+        }
+
+        _callbacksByHandle.Remove(handle);
+
+        // Forget the dedup state for the removed view so a pooled web view that is reacquired for a
+        // new document reports its first click.
+        if (_lastMatchedHandle == handle)
+        {
+            _lastMatchedHandle = IntPtr.Zero;
+        }
+    }
+
+    private static void EnsureMonitorInstalled()
+    {
+        if (_monitorInstalled)
+        {
+            return;
+        }
+
+        _monitorInstalled = true;
+
+        var nsEventClass = GetClass("NSEvent");
+        var selector = GetSelector("addLocalMonitorForEventsMatchingMask:handler:");
+        var block = EnsureMonitorBlock();
+
+        var monitor = SendMessageAddMonitor(nsEventClass, selector, (nuint)EventMaskMouseDown, block);
+
+        // Retain the monitor object for the process lifetime so the subscription survives.
+        _monitor = SendMessage(monitor, GetSelector("retain"));
+    }
+
+    // The handler is an Objective-C block of shape NSEvent* (^)(NSEvent*). Built once as a no-capture
+    // global block whose invoke pointer is a managed method.
+    private static unsafe IntPtr EnsureMonitorBlock()
+    {
+        if (_monitorBlock != IntPtr.Zero)
+        {
+            return _monitorBlock;
+        }
+
+        var descriptor = new BlockDescriptor
+        {
+            Reserved = 0,
+            Size = (nuint)Marshal.SizeOf<BlockLiteral>(),
+        };
+        var descriptorPointer = Marshal.AllocHGlobal(Marshal.SizeOf<BlockDescriptor>());
+        Marshal.StructureToPtr(descriptor, descriptorPointer, false);
+
+        var blockIsa = dlsym(RtldDefault, "_NSConcreteGlobalBlock");
+        var invoke = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)&MonitorCallback;
+
+        var block = new BlockLiteral
+        {
+            Isa = blockIsa,
+            Flags = BlockIsGlobal,
+            Reserved = 0,
+            Invoke = invoke,
+            Descriptor = descriptorPointer,
+        };
+        var blockPointer = Marshal.AllocHGlobal(Marshal.SizeOf<BlockLiteral>());
+        Marshal.StructureToPtr(block, blockPointer, false);
+
+        _monitorBlock = blockPointer;
+        return blockPointer;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static IntPtr MonitorCallback(IntPtr block, IntPtr nsEvent)
+    {
+        // Runs on the main thread during event dispatch. Never let an exception cross back into AppKit.
+        try
+        {
+            var matchedHandle = FindClickedRegisteredWebView(nsEvent);
+
+            // Report transitions only: repeated clicks inside the same web view stay quiet, and a click
+            // that lands anywhere else resets the state so returning to the view reports again.
+            if (matchedHandle != _lastMatchedHandle)
+            {
+                _lastMatchedHandle = matchedHandle;
+
+                if (matchedHandle != IntPtr.Zero
+                    && _callbacksByHandle.TryGetValue(matchedHandle, out var callback))
+                {
+                    // Defer so the callback's UI work runs after AppKit finishes dispatching the click.
+                    _dispatcherQueue?.TryEnqueue(() => callback());
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger?.LogError(exception, "The web view focus monitor callback failed");
+        }
+
+        // Pure observer: always pass the event through unchanged.
+        return nsEvent;
+    }
+
+    private static IntPtr FindClickedRegisteredWebView(IntPtr nsEvent)
+    {
+        var window = SendMessage(nsEvent, GetSelector("window"));
+        if (window == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        var contentView = SendMessage(window, GetSelector("contentView"));
+        if (contentView == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        // locationInWindow is in window coordinates, which match the content view's superview (the
+        // frame view) for the content area, so the standard contentView hitTest works directly.
+        var location = SendMessageReturnNSPoint(nsEvent, GetSelector("locationInWindow"));
+        var hitView = SendMessageHitTest(contentView, GetSelector("hitTest:"), location);
+
+        // A click inside a WKWebView hits one of its descendant views, so walk up from the hit view
+        // comparing against the registered web view handles.
+        var view = hitView;
+        while (view != IntPtr.Zero)
+        {
+            if (_callbacksByHandle.ContainsKey(view))
+            {
+                return view;
+            }
+            view = SendMessage(view, GetSelector("superview"));
+        }
+
+        return IntPtr.Zero;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NSPoint
+    {
+        public double X;
+        public double Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BlockLiteral
+    {
+        public IntPtr Isa;
+        public int Flags;
+        public int Reserved;
+        public IntPtr Invoke;
+        public IntPtr Descriptor;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BlockDescriptor
+    {
+        public nuint Reserved;
+        public nuint Size;
+    }
+}

--- a/Source/Core/Celbridge.WebHost/Platform/NullWebViewFocusMonitor.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/NullWebViewFocusMonitor.cs
@@ -1,0 +1,18 @@
+using Microsoft.Web.WebView2.Core;
+
+namespace Celbridge.WebHost.Platform;
+
+/// <summary>
+/// No-op IWebViewFocusMonitor for platforms where the managed GotFocus event fires for clicks inside
+/// web view content, so no native focus signal is needed.
+/// </summary>
+public class NullWebViewFocusMonitor : IWebViewFocusMonitor
+{
+    public void Register(CoreWebView2 coreWebView, Action onFocusSignal)
+    {
+    }
+
+    public void Unregister(CoreWebView2 coreWebView)
+    {
+    }
+}

--- a/Source/Core/Celbridge.WebHost/Platform/PlatformServiceConfiguration.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/PlatformServiceConfiguration.cs
@@ -18,5 +18,17 @@ public static class PlatformServiceConfiguration
 #else
         services.AddSingleton<IWebViewAdapter, SkiaWebViewAdapter>();
 #endif
+
+        // The focus monitor is a genuine runtime OS selection: the AppKit first-responder signal
+        // exists only on macOS, which is also the only OS where WKWebView consumes clicks without
+        // raising the managed GotFocus event.
+        if (OperatingSystem.IsMacOS())
+        {
+            services.AddSingleton<IWebViewFocusMonitor, MacOSWebViewFocusMonitor>();
+        }
+        else
+        {
+            services.AddSingleton<IWebViewFocusMonitor, NullWebViewFocusMonitor>();
+        }
     }
 }

--- a/Source/Core/Celbridge.WebHost/Services/IWebViewFocusMonitor.cs
+++ b/Source/Core/Celbridge.WebHost/Services/IWebViewFocusMonitor.cs
@@ -1,0 +1,26 @@
+using Microsoft.Web.WebView2.Core;
+
+namespace Celbridge.WebHost;
+
+/// <summary>
+/// Native macOS click-focus signal for hosted web views, supplementing (not replacing) the primary
+/// path where editors and the console report focus over their JS host channel
+/// (IHostInput.OnFocusReceived). That path is the general signal but cannot see two cases this
+/// monitor covers: external-URL .webview documents with no injected script, and clicks on
+/// non-focusable content (e.g. rendered markdown) that raise no DOM focus event. Non-macOS heads,
+/// which rely on the JS path, use a no-op implementation.
+/// </summary>
+public interface IWebViewFocusMonitor
+{
+    /// <summary>
+    /// Registers a web view so onFocusSignal runs on the UI thread when a click gives its native
+    /// surface focus. Registering the same web view again replaces the previous callback.
+    /// </summary>
+    void Register(CoreWebView2 coreWebView, Action onFocusSignal);
+
+    /// <summary>
+    /// Removes a previously registered web view. Safe to call for a web view that was never
+    /// registered.
+    /// </summary>
+    void Unregister(CoreWebView2 coreWebView);
+}

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
     private readonly IWebViewService _webViewService;
     private readonly IFocusService _focusService;
     private readonly IWebViewAdapter _webViewAdapter;
+    private readonly IWebViewFocusMonitor _webViewFocusMonitor;
 
     private WebView2? _webView;
     // Host RPC channel. Only created for the HtmlViewer role; external-URL documents run without one.
@@ -81,6 +82,7 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         _webViewService = webViewService;
         _focusService = ServiceLocator.AcquireService<IFocusService>();
         _webViewAdapter = ServiceLocator.AcquireService<IWebViewAdapter>();
+        _webViewFocusMonitor = ServiceLocator.AcquireService<IWebViewFocusMonitor>();
 
         ViewModel = serviceProvider.GetRequiredService<WebViewDocumentViewModel>();
 
@@ -229,6 +231,11 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
             _webView.GotFocus -= WebView_GotFocus;
             _webView.GotFocus += WebView_GotFocus;
+
+            // On macOS the WKWebView consumes clicks without raising GotFocus, and the external-URL
+            // role deliberately injects no script that could report focus over the bridge, so the
+            // native monitor supplies the click-focus signal. No-op on other platforms.
+            _webViewFocusMonitor.Register(_webView.CoreWebView2, OnNativeFocusSignal);
 
             _webView.CoreWebView2.Settings.AreDevToolsEnabled = _webViewService.IsDevToolsFeatureEnabled();
 
@@ -383,6 +390,8 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
         if (_webView?.CoreWebView2 is not null)
         {
+            _webViewFocusMonitor.Unregister(_webView.CoreWebView2);
+
             _webView.CoreWebView2.DownloadStarting -= CoreWebView2_DownloadStarting;
             _webView.CoreWebView2.NewWindowRequested -= WebView_NewWindowRequested;
             _webView.CoreWebView2.HistoryChanged -= CoreWebView2_HistoryChanged;
@@ -776,6 +785,16 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
             _focusService.OnFocusReceived(WorkspacePanel.Documents, onReleaseFocus: ReleaseFocus);
         });
+    }
+
+    private void OnNativeFocusSignal()
+    {
+        // Arrives from the platform focus monitor on the UI thread when a click lands inside this
+        // view's native web surface. Same handling as the managed GotFocus path.
+        var message = new DocumentViewFocusedMessage(FileResource);
+        _messengerService.Send(message);
+
+        _focusService.OnFocusReceived(WorkspacePanel.Documents, onReleaseFocus: ReleaseFocus);
     }
 
     private void ReleaseFocus()

--- a/Source/Tests/Documents/DocumentLayoutStoreTests.cs
+++ b/Source/Tests/Documents/DocumentLayoutStoreTests.cs
@@ -288,6 +288,26 @@ public class DocumentLayoutStoreTests
     }
 
     [Test]
+    public async Task RestorePanelStateAsync_NoStoredActiveDocument_StillSetsActiveDocument()
+    {
+        // Restored tabs with no persisted active document must still delegate to the panel so it
+        // can enforce the one-active-document invariant. The store used to return early here, which
+        // left the panel showing a selected tab with no active document.
+        var stored = new List<DocumentLayoutStore.StoredDocumentAddress>
+        {
+            new("notes/readme.md", 0, 0, 0),
+        };
+        _propertyBag.GetPropertyAsync<List<DocumentLayoutStore.StoredDocumentAddress>>("DocumentLayout")
+            .Returns(Task.FromResult<List<DocumentLayoutStore.StoredDocumentAddress>?>(stored));
+        _propertyBag.GetPropertyAsync<string>("ActiveDocument")
+            .Returns(Task.FromResult<string?>(null));
+
+        await _store.RestorePanelStateAsync();
+
+        _documentsPanel.Received().ActiveDocument = ResourceKey.Empty;
+    }
+
+    [Test]
     public async Task RestorePanelStateAsync_AppliesSectionRatiosWhenValid()
     {
         var ratios = new List<double> { 0.3, 0.7 };
@@ -303,11 +323,15 @@ public class DocumentLayoutStoreTests
     }
 
     [Test]
-    public async Task StoreActiveDocumentAsync_WritesResourceKeyString()
+    public async Task StoreActiveDocumentAsync_WritesPanelActiveDocumentString()
     {
+        // The store reads the panel's active document directly (not the gated
+        // IDocumentsService.ActiveDocument), so the real value is persisted even while the
+        // workspace page is still loading.
         var resource = new ResourceKey("notes/readme.md");
+        _documentsPanel.ActiveDocument.Returns(resource);
 
-        await _store.StoreActiveDocumentAsync(resource);
+        await _store.StoreActiveDocumentAsync();
 
         // ResourceKey.ToString prefixes the default root, so the persisted
         // value is "project:notes/readme.md" rather than the bare path.

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
@@ -61,13 +61,18 @@ public class DocumentLayoutStore
         await propertyBag.SetPropertyAsync(DocumentLayoutKey, storedAddresses);
     }
 
-    public async Task StoreActiveDocumentAsync(ResourceKey activeDocument)
+    public async Task StoreActiveDocumentAsync()
     {
         var propertyBag = _workspaceWrapper.WorkspaceService.WorkspaceSettings.PropertyBag;
         Guard.IsNotNull(propertyBag);
 
-        var fileResource = activeDocument.ToString();
-        await propertyBag.SetPropertyAsync(ActiveDocumentKey, fileResource);
+        // Read the panel's active document directly rather than the gated
+        // IDocumentsService.ActiveDocument, which reports Empty until the workspace page finishes
+        // loading. WorkspaceLoader persists right after restore, before that milestone, so the
+        // gated value would clobber the setting to empty and the active document would never be
+        // remembered across loads.
+        var activeDocument = DocumentsPanel.ActiveDocument;
+        await propertyBag.SetPropertyAsync(ActiveDocumentKey, activeDocument.ToString());
     }
 
     public async Task StoreSectionRatiosAsync(List<double> ratios)
@@ -290,22 +295,22 @@ public class DocumentLayoutStore
         var propertyBag = _workspaceWrapper.WorkspaceService.WorkspaceSettings.PropertyBag;
         Guard.IsNotNull(propertyBag);
 
-        var selectedDocument = await propertyBag.GetPropertyAsync<string>(ActiveDocumentKey);
-        if (string.IsNullOrEmpty(selectedDocument))
+        var storedActiveDocument = await propertyBag.GetPropertyAsync<string>(ActiveDocumentKey);
+
+        var activeDocument = ResourceKey.Empty;
+        if (!string.IsNullOrEmpty(storedActiveDocument))
         {
-            return;
+            if (!ResourceKey.TryCreate(storedActiveDocument, out activeDocument))
+            {
+                _logger.LogWarning($"Invalid resource key '{storedActiveDocument}' found for previously selected document");
+                activeDocument = ResourceKey.Empty;
+            }
         }
 
-        if (!ResourceKey.TryCreate(selectedDocument, out var selectedDocumentKey))
-        {
-            _logger.LogWarning($"Invalid resource key '{selectedDocument}' found for previously selected document");
-            return;
-        }
-
-        // Set the active document. SectionContainer.SetActiveDocument also enforces the invariant
-        // that every populated section has a selected tab, so non-active sections that had tabs
-        // inserted during restore get a sensible default selection automatically.
-        DocumentsPanel.ActiveDocument = selectedDocumentKey;
+        // Always delegate to the panel, even when the stored value is empty or invalid.
+        // SectionContainer.SetActiveDocument restores this document when it is still open and
+        // otherwise falls back so that any open documents leave exactly one active document.
+        DocumentsPanel.ActiveDocument = activeDocument;
     }
 
     private async Task OpenDefaultReadmeAsync()

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -382,7 +382,7 @@ public class DocumentsService : IDocumentsService, IDisposable
 
     public Task StoreDocumentLayout() => _layoutStore.StoreDocumentLayoutAsync();
 
-    public Task StoreActiveDocument() => _layoutStore.StoreActiveDocumentAsync(ActiveDocument);
+    public Task StoreActiveDocument() => _layoutStore.StoreActiveDocumentAsync();
 
     public Task StoreDocumentEditorStates() => _layoutStore.StoreDocumentEditorStatesAsync();
 

--- a/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/ContributionDocumentView.xaml.cs
@@ -43,6 +43,7 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
     private readonly IWebViewService _webViewService;
     private readonly IFocusService _focusService;
     private readonly IWebViewAdapter _webViewAdapter;
+    private readonly IWebViewFocusMonitor _webViewFocusMonitor;
 
     // Latest edit availability reported by the editor over the bridge. Drives CanPerformEdit.
     private EditAvailability _editAvailability = EditAvailability.None;
@@ -139,6 +140,7 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
         _webViewService = webViewService;
         _focusService = ServiceLocator.AcquireService<IFocusService>();
         _webViewAdapter = ServiceLocator.AcquireService<IWebViewAdapter>();
+        _webViewFocusMonitor = ServiceLocator.AcquireService<IWebViewFocusMonitor>();
 
         _viewModel = serviceProvider.GetRequiredService<ContributionDocumentViewModel>();
 
@@ -290,6 +292,11 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
 
         WebView.GotFocus -= WebView_GotFocus;
         WebView.GotFocus += WebView_GotFocus;
+
+        // On macOS the WKWebView consumes clicks without raising GotFocus, and the JS client only
+        // reports DOM focus changes, which a click on non-focusable content (e.g. rendered markdown)
+        // never produces. The native monitor covers those clicks. No-op on other platforms.
+        _webViewFocusMonitor.Register(WebView.CoreWebView2, OnNativeFocusSignal);
 
         // Every contribution editor's assets (its lib, the shared client) are served from the loopback
         // file server, so register this package's folder there. The resolved loader decides where the
@@ -444,6 +451,11 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
 
         if (WebView is not null)
         {
+            if (WebView.CoreWebView2 is not null)
+            {
+                _webViewFocusMonitor.Unregister(WebView.CoreWebView2);
+            }
+
             WebView.GotFocus -= WebView_GotFocus;
 
             _webViewAdapter.CloseWebView(WebView, ContributionWebViewContainer);
@@ -870,6 +882,16 @@ public sealed partial class ContributionDocumentView : DocumentView, IHostInput,
     private void WebView_GotFocus(object sender, RoutedEventArgs e)
     {
         // Set this document as the active document when the WebView2 receives focus
+        var message = new DocumentViewFocusedMessage(FileResource);
+        _messengerService.Send(message);
+
+        _focusService.OnFocusReceived(WorkspacePanel.Documents, this, ReleaseFocus);
+    }
+
+    private void OnNativeFocusSignal()
+    {
+        // Arrives from the platform focus monitor on the UI thread when a click lands inside this
+        // view's native web surface. Same handling as the managed GotFocus path.
         var message = new DocumentViewFocusedMessage(FileResource);
         _messengerService.Send(message);
 

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
@@ -405,39 +405,44 @@ public sealed partial class DocumentSectionContainer : UserControl
     }
 
     /// <summary>
-    /// Sets the active document.
+    /// Restores the given document as the active document, falling back to the selected tab of the
+    /// first populated section when it is empty or no longer open. Guarantees that while any
+    /// documents are open, exactly one is the active document - the invariant restore depends on.
     /// </summary>
     public void SetActiveDocument(ResourceKey fileResource)
     {
-        if (fileResource.IsEmpty)
+        // Restore inserts tabs with Activate=false, so a section can end up with tabs but no
+        // selected tab. Give every populated section a selected tab first, so the fallback can
+        // choose from real per-section selections.
+        EnsureVisibleTabsSelected();
+
+        // Prefer the requested (previously active) document when it is still open.
+        var location = fileResource.IsEmpty ? null : FindDocumentTab(fileResource);
+
+        // The requested document can be empty (never saved) or point to a document that failed to
+        // restore (e.g. its file was deleted between sessions). Fall back to the selected tab of
+        // the first populated section, scanning sections in index order.
+        if (location is null)
         {
-            _activeDocument = ResourceKey.Empty;
-            _activeSectionIndex = 0;
-            UpdateTabSelectionIndicators();
-            ActiveDocumentChanged?.Invoke(_activeDocument);
-            EnsureVisibleTabsSelected();
-            return;
+            location = FindFallbackActiveDocument();
         }
 
-        // Find which section contains this document
-        var location = FindDocumentTab(fileResource);
         if (location is not null)
         {
-            // Select the tab in its section
+            // Directly update the active document; programmatic selection does not rely on events.
             location.Section.SelectTab(location.Tab);
-
-            // Directly update active document (don't rely on events for programmatic selection)
             _activeSectionIndex = location.Section.SectionIndex;
-            _activeDocument = fileResource;
-            UpdateTabSelectionIndicators();
-            ActiveDocumentChanged?.Invoke(_activeDocument);
+            _activeDocument = location.Tab.ViewModel.FileResource;
+        }
+        else
+        {
+            // No documents are open, so there is no active document.
+            _activeDocument = ResourceKey.Empty;
+            _activeSectionIndex = 0;
         }
 
-        // During workspace restore many tabs are inserted with Activate=false, so non-active
-        // sections end up with no selected tab. SetActiveDocument is the hook that runs after
-        // all of those inserts finish, so enforce the "every populated section has a visible
-        // selected tab" invariant here.
-        EnsureVisibleTabsSelected();
+        UpdateTabSelectionIndicators();
+        ActiveDocumentChanged?.Invoke(_activeDocument);
     }
 
     /// <summary>
@@ -452,6 +457,30 @@ public sealed partial class DocumentSectionContainer : UserControl
             if (tab != null)
             {
                 return new DocumentTabLocation(_sections[i], tab);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the selected document tab of the first populated section, scanning sections in index
+    /// order, or null when no section has a selected tab.
+    /// </summary>
+    private DocumentTabLocation? FindFallbackActiveDocument()
+    {
+        for (int i = 0; i < _sectionCount && i < _sections.Count; i++)
+        {
+            var section = _sections[i];
+            var selectedResource = section.GetSelectedDocument();
+            if (selectedResource.IsEmpty)
+            {
+                continue;
+            }
+
+            var tab = section.GetDocumentTab(selectedResource);
+            if (tab is not null)
+            {
+                return new DocumentTabLocation(section, tab);
             }
         }
         return null;


### PR DESCRIPTION
Fixes #753

This pull request introduces a cross-platform focus monitoring system for web views, ensuring that focus events are reliably detected on all supported operating systems, especially macOS, where native clicks inside WKWebView do not trigger managed focus events. The implementation includes a platform-specific native monitor for macOS and a no-op monitor for other platforms. Additionally, the pull request improves the logic for restoring and persisting the active document in the document panel, ensuring a more robust and consistent user experience after workspace reloads.

**Web View Focus Monitoring Improvements:**

* Added `IWebViewFocusMonitor` interface and two implementations: `MacOSWebViewFocusMonitor` (native macOS click-focus detection using AppKit event monitoring and hit-testing) and `NullWebViewFocusMonitor` (no-op for other platforms). This ensures focus is detected even when the managed `GotFocus` event does not fire, such as on macOS with external-URL documents or non-focusable content. [[1]](diffhunk://#diff-fec3dbe441dbe9835c02312d1912497eac137c1feaa7bb1bdc450958b00e4bc8R1-R26) [[2]](diffhunk://#diff-961f8bbce3d4199125ef3839fd9aa65660d0491e30e47da6d683861d784253d0R1-R258) [[3]](diffhunk://#diff-c5079087ae51aef2f2f5295f53b6e651fbe0bd539a83e538d86d0c94642c9191R1-R18)
* Registered the appropriate focus monitor implementation at runtime based on the OS in `PlatformServiceConfiguration`, enabling seamless cross-platform support.

**Integration with Document Views:**

* Injected and used `IWebViewFocusMonitor` in `WebViewDocumentView` and `ContributionDocumentView` to register/unregister web views for native focus monitoring, and to handle native focus signals equivalently to managed focus events. [[1]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37R39) [[2]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37R85) [[3]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37R235-R239) [[4]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37R393-R394) [[5]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37R790-R799) [[6]](diffhunk://#diff-3a01697b6e860385f0d905a44cb1d92b31b74f7803a5c9965f52f4f5acd965d9R46)

**Active Document Restore and Persistence Improvements:**

* Updated `DocumentLayoutStore` to always delegate active document restoration to the panel, even when the stored value is empty or invalid, ensuring the one-active-document invariant is maintained. [[1]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6L293-R313) [[2]](diffhunk://#diff-3af9a54585bc0aaca46942d489606d5492c687a82415b9470ab38b7ea2ff115bR290-R309)
* Changed the logic for persisting the active document: now reads directly from the panel's active document rather than a gated service property, preventing loss of state during workspace reloads. [[1]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6L64-R75) [[2]](diffhunk://#diff-f59601b6f3c232204d3be538551cafbc681e9be7dc1184ca1ca3c31181fd09bbL385-R385) [[3]](diffhunk://#diff-3af9a54585bc0aaca46942d489606d5492c687a82415b9470ab38b7ea2ff115bL306-R334)

**Tests:**

* Added a test to ensure that restoring panel state with no stored active document still sets the active document, maintaining UI consistency.

These changes improve cross-platform focus handling and make the document panel's active document state more robust across reloads and platform differences.