### PR TITLE
Hide WebViews during macOS modal dialogs to prevent rendering issues

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSModalOcclusionMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSModalOcclusionMonitor.cs
@@ -1,23 +1,23 @@
 using System.Runtime.InteropServices;
-using System.Text;
 using Celbridge.Logging;
 using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
 
 namespace Celbridge.UserInterface.Platform;
 
 /// <summary>
-/// Detects hosted native WebViews rendering on top of an open modal dialog on the Uno Skia macOS head.
-/// Uno occludes native views under a modal by detaching fully covered views and masking the rest with a
-/// window-wide CAShapeLayer clip, but a detach/reattach cycle clears the masks without invalidating Uno's
-/// cached clip path, so the masks are never reapplied and the dialog renders behind the WebViews. Each
-/// dialog scope polls the native subview state while the dialog is open and logs a diagnostic dump when
-/// the occlusion invariant is violated. Detection and logging only; no native state is modified.
+/// Hides hosted native WebViews while a modal dialog is open on the Uno Skia macOS head. Uno occludes
+/// native views under a modal by detaching them or masking them with a window-wide clip, but a
+/// detach/reattach cycle clears the masks without invalidating Uno's cached clip path, and a clip update
+/// fails outright while any attached subview has an empty frame, so WebViews can render over the dialog.
+/// Hidden is the state Uno intends for a native view under a modal, so each dialog scope enforces it
+/// directly: it hides every visible native subview when the dialog opens, sweeps for late attaches while
+/// the dialog is open, and restores the hidden views when the dialog closes.
 /// </summary>
 internal static class MacOSModalOcclusionMonitor
 {
     /// <summary>
-    /// Starts occlusion monitoring for one modal dialog. Dispose the returned scope when the dialog
-    /// closes. No-op off macOS.
+    /// Starts WebView occlusion for one modal dialog. Dispose the returned scope when the dialog closes
+    /// to restore the hidden views. No-op off macOS.
     /// </summary>
     public static IDisposable BeginDialogScope(string dialogName)
     {
@@ -49,14 +49,13 @@ internal static class MacOSModalOcclusionMonitor
 
     private sealed class DialogScope : IDisposable
     {
-        // The initial delay lets the dialog entrance animation finish, so a healthy occlusion pass has
-        // settled before the first check. Later checks catch masks lost while the dialog stays open.
-        private static readonly TimeSpan InitialCheckDelay = TimeSpan.FromMilliseconds(600);
-        private static readonly TimeSpan RepeatCheckInterval = TimeSpan.FromSeconds(2);
+        // Bounds how long a WebView attached mid-dialog can render over the dialog before it is hidden.
+        private static readonly TimeSpan SweepInterval = TimeSpan.FromMilliseconds(250);
 
         private readonly ILogger _logger;
         private readonly string _dialogName;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private readonly List<IntPtr> _hiddenSubviews = [];
 
         public DialogScope(string dialogName, ILogger logger)
         {
@@ -66,30 +65,20 @@ internal static class MacOSModalOcclusionMonitor
 
         public void Start()
         {
-            _ = RunChecksAsync();
+            _ = RunSweepsAsync();
         }
 
-        private async Task RunChecksAsync()
+        private async Task RunSweepsAsync()
         {
             // The awaits capture the UI SynchronizationContext (BeginDialogScope is called from the dialog
             // service on the UI thread), so the AppKit calls below stay on the main thread.
             try
             {
                 var cancellationToken = _cancellationTokenSource.Token;
-                await Task.Delay(InitialCheckDelay, cancellationToken);
-
-                var checkNumber = 0;
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    checkNumber++;
-                    var reported = CheckOcclusionInvariant(checkNumber);
-                    if (reported)
-                    {
-                        // One diagnostic dump per dialog is enough to characterise the failure.
-                        return;
-                    }
-
-                    await Task.Delay(RepeatCheckInterval, cancellationToken);
+                    HideVisibleNativeSubviews();
+                    await Task.Delay(SweepInterval, cancellationToken);
                 }
             }
             catch (OperationCanceledException)
@@ -97,57 +86,40 @@ internal static class MacOSModalOcclusionMonitor
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Modal occlusion diagnostic check failed");
+                _logger.LogError(ex, "Modal WebView occlusion sweep failed");
             }
         }
 
-        /// <summary>
-        /// Inspects the native subviews hosting WebViews and logs a report when any of them can render
-        /// over the open dialog. Returns true when a report was logged.
-        /// </summary>
-        private bool CheckOcclusionInvariant(int checkNumber)
+        private void HideVisibleNativeSubviews()
         {
             var window = MacOSWindowInterop.GetMainWindow();
             if (window == IntPtr.Zero)
             {
-                return false;
+                return;
             }
 
             var contentViewController = SendMessage(window, GetSelector("contentViewController"));
             if (contentViewController == IntPtr.Zero)
             {
-                return false;
+                return;
             }
 
             var hostView = SendMessage(contentViewController, GetSelector("view"));
             if (hostView == IntPtr.Zero)
             {
-                return false;
+                return;
             }
 
+            // The content view controller's view holds exactly the native elements Uno hosts (WebViews);
+            // the Skia canvas lives elsewhere in the window.
             var subviewArray = SendMessage(hostView, GetSelector("subviews"));
             if (subviewArray == IntPtr.Zero)
             {
-                return false;
+                return;
             }
 
             var subviewCount = SendMessageReturnNint(subviewArray, GetSelector("count"));
-            if (subviewCount == 0)
-            {
-                // Healthy steady state: Uno detaches every native view that a modal fully covers.
-                return false;
-            }
-
-            // Dialogs are centered in the window, so the host view center is inside the dialog area. A
-            // visible native subview whose frame contains the center and whose mask does not exclude it
-            // is rendering over the dialog.
-            var hostBounds = SendMessageReturnCGRect(hostView, GetSelector("bounds"));
-            var centerX = hostBounds.Size.Width / 2;
-            var centerY = hostBounds.Size.Height / 2;
-
-            var subviewLines = new List<string>((int)subviewCount);
-            var dialogObscured = false;
-            var visibleSubviewPresent = false;
+            var hiddenThisSweep = 0;
 
             var objectAtIndexSelector = GetSelector("objectAtIndex:");
             for (nint index = 0; index < subviewCount; index++)
@@ -158,115 +130,59 @@ internal static class MacOSModalOcclusionMonitor
                     continue;
                 }
 
-                var className = GetClassName(subview);
-                var frame = SendMessageReturnCGRect(subview, GetSelector("frame"));
                 var hidden = SendMessageReturnBool(subview, GetSelector("isHidden"));
                 var alpha = SendMessageReturnDouble(subview, GetSelector("alphaValue"));
-
-                var layer = SendMessage(subview, GetSelector("layer"));
-                var mask = layer == IntPtr.Zero ? IntPtr.Zero : SendMessage(layer, GetSelector("mask"));
-                var maskPath = mask == IntPtr.Zero ? IntPtr.Zero : SendMessage(mask, GetSelector("path"));
-
-                string maskStatus;
-                if (mask == IntPtr.Zero)
-                {
-                    maskStatus = "none";
-                }
-                else
-                {
-                    var maskClassName = GetClassName(mask);
-                    maskStatus = maskPath == IntPtr.Zero ? $"{maskClassName}(no path)" : $"{maskClassName}(path)";
-                }
+                var frame = SendMessageReturnCGRect(subview, GetSelector("frame"));
 
                 var isVisible = !hidden &&
                     alpha > 0 &&
                     frame.Size.Width > 0 &&
                     frame.Size.Height > 0;
-                visibleSubviewPresent |= isVisible;
-
-                var containsCenter = isVisible &&
-                    centerX >= frame.Origin.X &&
-                    centerX <= frame.Origin.X + frame.Size.Width &&
-                    centerY >= frame.Origin.Y &&
-                    centerY <= frame.Origin.Y + frame.Size.Height;
-
-                bool? maskExcludesCenter = null;
-                if (containsCenter)
+                if (!isVisible)
                 {
-                    if (maskPath == IntPtr.Zero)
-                    {
-                        maskExcludesCenter = false;
-                    }
-                    else
-                    {
-                        // The mask path is in view-local points with the even-odd fill rule, matching how
-                        // Uno builds the CAShapeLayer clip.
-                        var centerInView = new CGPoint
-                        {
-                            X = centerX - frame.Origin.X,
-                            Y = centerY - frame.Origin.Y,
-                        };
-                        var maskContainsCenter = CGPathContainsPoint(maskPath, IntPtr.Zero, centerInView, eoFill: true);
-                        maskExcludesCenter = !maskContainsCenter;
-                    }
-
-                    if (maskExcludesCenter == false)
-                    {
-                        dialogObscured = true;
-                    }
+                    continue;
                 }
 
-                var maskCenterStatus = maskExcludesCenter switch
-                {
-                    true => "mask excludes dialog center",
-                    false => "MASK DOES NOT EXCLUDE DIALOG CENTER",
-                    null => "does not cover dialog center",
-                };
-
-                subviewLines.Add(
-                    $"  [{index}] {className} frame=({frame.Origin.X:F0},{frame.Origin.Y:F0} {frame.Size.Width:F0}x{frame.Size.Height:F0}) " +
-                    $"hidden={hidden} alpha={alpha:F2} mask={maskStatus} ({maskCenterStatus})");
+                // Retain so the handle stays valid for the restore on dispose, even if Uno disposes the
+                // native element while the dialog is open.
+                SendMessage(subview, GetSelector("retain"));
+                SendMessageVoidBool(subview, GetSelector("setHidden:"), true);
+                _hiddenSubviews.Add(subview);
+                hiddenThisSweep++;
             }
 
-            if (!visibleSubviewPresent)
+            if (hiddenThisSweep > 0)
             {
-                return false;
+                _logger.LogDebug(
+                    "Hid {Count} native subview(s) while the modal dialog '{DialogName}' is open",
+                    hiddenThisSweep,
+                    _dialogName);
             }
-
-            var report = new StringBuilder();
-            report.AppendLine(
-                $"Host bounds {hostBounds.Size.Width:F0}x{hostBounds.Size.Height:F0}, check #{checkNumber}, {subviewCount} native subview(s):");
-            foreach (var line in subviewLines)
-            {
-                report.AppendLine(line);
-            }
-
-            if (dialogObscured)
-            {
-                _logger.LogError(
-                    "Native WebView content is obscuring the open modal dialog '{DialogName}' (Uno clip-mask desync). {Report}",
-                    _dialogName,
-                    report.ToString());
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "Unexpected visible native subview(s) while the modal dialog '{DialogName}' is open; Uno normally detaches occluded native views. {Report}",
-                    _dialogName,
-                    report.ToString());
-            }
-
-            return true;
         }
 
         public void Dispose()
         {
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
+
+            if (_hiddenSubviews.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var subview in _hiddenSubviews)
+            {
+                SendMessageVoidBool(subview, GetSelector("setHidden:"), false);
+                SendMessageVoidNoArguments(subview, GetSelector("release"));
+            }
+
+            _logger.LogDebug(
+                "Restored {Count} hidden native subview(s) after the modal dialog '{DialogName}' closed",
+                _hiddenSubviews.Count,
+                _dialogName);
+            _hiddenSubviews.Clear();
         }
     }
-
-    private const string CoreGraphicsFramework = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
 
     [StructLayout(LayoutKind.Sequential)]
     private struct CGPoint
@@ -295,11 +211,12 @@ internal static class MacOSModalOcclusionMonitor
     [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
     private static extern CGRect SendMessageReturnCGRect(IntPtr receiver, IntPtr selector);
 
-    [DllImport(CoreGraphicsFramework)]
-    [return: MarshalAs(UnmanagedType.I1)]
-    private static extern bool CGPathContainsPoint(
-        IntPtr path,
-        IntPtr transform,
-        CGPoint point,
-        [MarshalAs(UnmanagedType.I1)] bool eoFill);
+    [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
+    private static extern void SendMessageVoidBool(
+        IntPtr receiver,
+        IntPtr selector,
+        [MarshalAs(UnmanagedType.I1)] bool argument);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
+    private static extern void SendMessageVoidNoArguments(IntPtr receiver, IntPtr selector);
 }


### PR DESCRIPTION
Fixes #729

This pull request updates the `MacOSModalOcclusionMonitor` to actively hide hosted native WebViews while a modal dialog is open, instead of only detecting and logging occlusion issues. The new approach enforces the intended hidden state for native views during dialogs, periodically sweeping for any visible subviews and hiding them, then restoring their visibility when the dialog closes. This change improves dialog occlusion reliability on macOS and simplifies the previous detection logic.

**WebView occlusion enforcement:**

* The monitor now hides all visible native subviews (e.g., WebViews) when a modal dialog opens, periodically sweeps for late-attached views to hide them, and restores their visibility when the dialog closes. [[1]](diffhunk://#diff-97dfec4f46c60b4d54cbabd223b421ed51979268dc24e74ba9a52c962833a5baL2-R20) [[2]](diffhunk://#diff-97dfec4f46c60b4d54cbabd223b421ed51979268dc24e74ba9a52c962833a5baL69-R122) [[3]](diffhunk://#diff-97dfec4f46c60b4d54cbabd223b421ed51979268dc24e74ba9a52c962833a5baL161-L270)

**Code and logic simplification:**

* Removed the previous diagnostic and logging logic that checked for occlusion invariant violations, including the mask analysis and detailed reporting.
* Replaced the check interval and entrance animation delay with a more frequent sweep interval to promptly hide any newly attached views.

**Interop and resource management:**

* Updated interop methods to use direct calls for hiding and restoring native views, and ensured proper reference counting (retain/release) for native handles. [[1]](diffhunk://#diff-97dfec4f46c60b4d54cbabd223b421ed51979268dc24e74ba9a52c962833a5baL161-L270) [[2]](diffhunk://#diff-97dfec4f46c60b4d54cbabd223b421ed51979268dc24e74ba9a52c962833a5baL298-R221)