### PR TITLE
Enhance split editor icon visuals and tooltip alignment

### DIFF
--- a/Source/Workspace/Celbridge.Documents/Views/DocumentToolbar.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentToolbar.xaml
@@ -18,6 +18,7 @@
             Width="24"
             Height="24"
             ToolTipService.ToolTip="{x:Bind SplitEditorTooltipString}"
+            ToolTipService.Placement="Bottom"
             Padding="4"
             VerticalAlignment="Center">
       <controls:SplitEditorIcon x:Name="ButtonIcon"

--- a/Source/Workspace/Celbridge.Documents/Views/SplitEditorIcon.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/SplitEditorIcon.xaml
@@ -1,35 +1,62 @@
-﻿<UserControl
+<UserControl
     x:Class="Celbridge.Documents.Views.Controls.SplitEditorIcon"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    
+
     <Viewbox Width="16" Height="16">
         <Grid Width="16" Height="16">
-            <!-- Outer rounded rectangle border -->
+            <!-- Solid outer box -->
             <Rectangle Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
                        StrokeThickness="1.2"
                        RadiusX="2" RadiusY="2"/>
-            
-            <!-- Center divider for 2 sections -->
-            <Line x:Name="CenterDivider"
-                  X1="8" Y1="1" X2="8" Y2="15"
-                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                  StrokeThickness="1.2"
-                  Visibility="Collapsed"/>
-            
-            <!-- Left divider for 3 sections (at 1/3 position) -->
-            <Line x:Name="LeftDivider"
-                  X1="5.4" Y1="1" X2="5.3" Y2="15"
-                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                  StrokeThickness="1.2"
-                  Visibility="Collapsed"/>
-            
-            <!-- Right divider for 3 sections (at 2/3 position) -->
-            <Line x:Name="RightDivider"
-                  X1="10.6" Y1="1" X2="10.7" Y2="15"
-                  Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                  StrokeThickness="1.2"
-                  Visibility="Collapsed"/>
+
+            <!-- One section: a single editor with hinted lines of text -->
+            <Canvas x:Name="OneSectionContent">
+                <Line X1="2.6" Y1="5" X2="10" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="2.6" Y1="7.5" X2="8" Y2="7.5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+            </Canvas>
+
+            <!-- Two sections: divider with text hinted in each editor -->
+            <Canvas x:Name="TwoSectionContent" Visibility="Collapsed">
+                <Line X1="8" Y1="1" X2="8" Y2="15"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1.2"/>
+                <Line X1="2.3" Y1="5" X2="6.4" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="2.3" Y1="7.5" X2="5.4" Y2="7.5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="9.6" Y1="5" X2="13.7" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="9.6" Y1="7.5" X2="12.7" Y2="7.5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+            </Canvas>
+
+            <!-- Three sections: two dividers with text hinted in each editor -->
+            <Canvas x:Name="ThreeSectionContent" Visibility="Collapsed">
+                <Line X1="5.33" Y1="1" X2="5.33" Y2="15"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1.2"/>
+                <Line X1="10.67" Y1="1" X2="10.67" Y2="15"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1.2"/>
+                <Line X1="1.9" Y1="5" X2="4.4" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="6.2" Y1="5" X2="9.8" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+                <Line X1="11.5" Y1="5" X2="14.1" Y2="5"
+                      Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                      StrokeThickness="1"/>
+            </Canvas>
         </Grid>
     </Viewbox>
 </UserControl>

--- a/Source/Workspace/Celbridge.Documents/Views/SplitEditorIcon.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/SplitEditorIcon.xaml.cs
@@ -1,8 +1,9 @@
 namespace Celbridge.Documents.Views.Controls;
 
 /// <summary>
-/// An icon representing editor split layout with 1, 2, or 3 vertical sections.
-/// Set the SectionCount property to control how many sections are displayed.
+/// An icon representing an editor split layout, drawn as a box divided into 1, 2, or 3
+/// editor sections with hinted lines of text. Set the SectionCount property to control
+/// how many sections are displayed.
 /// </summary>
 public sealed partial class SplitEditorIcon : UserControl
 {
@@ -25,42 +26,23 @@ public sealed partial class SplitEditorIcon : UserControl
     public SplitEditorIcon()
     {
         InitializeComponent();
-        UpdateDividers();
+        UpdateSections();
     }
 
     private static void OnSectionCountChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is SplitEditorIcon icon)
         {
-            icon.UpdateDividers();
+            icon.UpdateSections();
         }
     }
 
-    private void UpdateDividers()
+    private void UpdateSections()
     {
-        // Clamp section count to valid range
         var count = Math.Clamp(SectionCount, 1, 3);
 
-        // 1 section: no dividers
-        // 2 sections: center divider only
-        // 3 sections: left and right dividers
-        if (count == 1)
-        {
-            CenterDivider.Visibility = Visibility.Collapsed;
-            LeftDivider.Visibility = Visibility.Collapsed;
-            RightDivider.Visibility = Visibility.Collapsed;
-        }
-        else if (count == 2)
-        {
-            CenterDivider.Visibility = Visibility.Visible;
-            LeftDivider.Visibility = Visibility.Collapsed;
-            RightDivider.Visibility = Visibility.Collapsed;
-        }
-        else // count == 3
-        {
-            CenterDivider.Visibility = Visibility.Collapsed;
-            LeftDivider.Visibility = Visibility.Visible;
-            RightDivider.Visibility = Visibility.Visible;
-        }
+        OneSectionContent.Visibility = count == 1 ? Visibility.Visible : Visibility.Collapsed;
+        TwoSectionContent.Visibility = count == 2 ? Visibility.Visible : Visibility.Collapsed;
+        ThreeSectionContent.Visibility = count == 3 ? Visibility.Visible : Visibility.Collapsed;
     }
 }


### PR DESCRIPTION
Fixes #761

This pull request refactors the `SplitEditorIcon` control to improve its visual clarity and maintainability, updating both its XAML and code-behind. The icon now visually represents one, two, or three editor sections with "hinted" lines of text, and the logic for switching between layouts has been simplified.

**Split editor icon improvements:**

* [`SplitEditorIcon.xaml`](diffhunk://#diff-e9b8ac24c87972a545667fcc53253fe7706c75cac1713e77ec509690fe63ccbfL1-R59): Replaced the previous divider-based approach with three separate `Canvas` elements (`OneSectionContent`, `TwoSectionContent`, `ThreeSectionContent`), each drawing the appropriate number of editor sections and text hints. Visibility is toggled to show the correct layout for 1, 2, or 3 sections.
* [`SplitEditorIcon.xaml.cs`](diffhunk://#diff-99237d5c5328586fdb82e18121748b7675e36746059aeb4df164502618040521L28-R46): Renamed and refactored the logic from `UpdateDividers` to `UpdateSections`, now toggling the visibility of the new canvas elements rather than individual divider lines. The logic is more straightforward and easier to extend.
* [`SplitEditorIcon.xaml.cs`](diffhunk://#diff-99237d5c5328586fdb82e18121748b7675e36746059aeb4df164502618040521L4-R6): Updated the XML comment to clarify that the icon visually represents a split editor layout with lines of text, and that the `SectionCount` property determines the layout.

**UI/UX improvement:**

* [`DocumentToolbar.xaml`](diffhunk://#diff-470fad0c7d4759d243152b7f5e7ecda0a3b82a0d38c865d3b241bf2ea8b167c9R21): Sets the tooltip placement for the split editor button to appear below the button, improving discoverability and consistency.Update the split editor toolbar icon to show text hints inside each section and switch the toolbar tooltip to bottom placement for better alignment.