### PR TITLE
Rename Settings page labels and update messages

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -295,7 +295,7 @@
     <value>Enter a name for the destination folder:</value>
   </data>
   <data name="Settings_Page_Title" xml:space="preserve">
-    <value>Settings</value>
+    <value>Application Settings</value>
   </data>
   <data name="ResourceTree_EnterNewName" xml:space="preserve">
     <value>Enter a new name:</value>
@@ -1218,7 +1218,7 @@ Do you wish to continue?</value>
     <value>Cannot Publish</value>
   </data>
   <data name="Workshop_PublishBlocked_Message" xml:space="preserve">
-    <value>No Author is set. Add one on the Settings page, then try again.</value>
+    <value>No Author is set. Add one on the Application Settings page, then try again.</value>
   </data>
   <data name="DocumentEditor_SpreadsheetEditor" xml:space="preserve">
     <value>Spreadsheet Editor</value>


### PR DESCRIPTION
Fixes #759

This pull request makes minor improvements to the application’s user interface text for clarity and consistency. The main changes are updates to the naming of the settings page in user-facing messages.

- UI Text Updates:
  * Changed the label from "Settings" to "Application Settings" for the settings page title in `Resources.resw`.
  * Updated a message to refer to the "Application Settings page" instead of just "Settings page" when prompting users to add an author.Updates the Settings page title to "Application Settings" and rewrites the publish-blocked message to match the new label.