### PR TITLE
Make file manager references platform-aware

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -522,8 +522,17 @@
   <data name="NewProjectDialog_SaveLocationTooltip" xml:space="preserve">
     <value>The project will be saved at this location.</value>
   </data>
-  <data name="ResourceTree_OpenFileExplorer" xml:space="preserve">
-    <value>Open in File Explorer</value>
+  <data name="ResourceTree_OpenFileManager" xml:space="preserve">
+    <value>Open in {0}</value>
+  </data>
+  <data name="ResourceTree_DoubleClickToOpen" xml:space="preserve">
+    <value>Double-click to open in {0}</value>
+  </data>
+  <data name="Platform_FileManager_Finder" xml:space="preserve">
+    <value>Finder</value>
+  </data>
+  <data name="Platform_FileManager_FileExplorer" xml:space="preserve">
+    <value>File Explorer</value>
   </data>
   <data name="ResourceTree_OpenApplication" xml:space="preserve">
     <value>Open with Application</value>
@@ -761,8 +770,8 @@ Do you wish to continue?</value>
   <data name="DocumentTab_CopyFilePath" xml:space="preserve">
     <value>Copy File Path</value>
   </data>
-  <data name="DocumentTab_OpenFileExplorer" xml:space="preserve">
-    <value>Open in File Explorer</value>
+  <data name="DocumentTab_OpenFileManager" xml:space="preserve">
+    <value>Open in {0}</value>
   </data>
   <data name="DocumentTab_OpenApplication" xml:space="preserve">
     <value>Open in Application</value>

--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -57,6 +57,12 @@ public interface IPlatformInfo
     CommandModifierKey CommandModifier { get; }
 
     /// <summary>
+    /// The localization key for the platform's system file manager name, resolved by the consumer for menu
+    /// labels and hints. Names Finder on macOS. Names File Explorer on Windows and Linux.
+    /// </summary>
+    string FileManagerNameStringKey { get; }
+
+    /// <summary>
     /// Whether the platform treats Backspace as a delete key in addition to Delete, following the macOS
     /// keyboard convention where the main Delete key is Backspace. True on macOS.
     /// </summary>

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -52,6 +52,10 @@ public sealed class PlatformInfo : IPlatformInfo
         ? CommandModifierKey.Command
         : CommandModifierKey.Control;
 
+    public string FileManagerNameStringKey => OperatingSystem.IsMacOS()
+        ? "Platform_FileManager_Finder"
+        : "Platform_FileManager_FileExplorer";
+
     public bool TreatsBackspaceAsDeleteKey => OperatingSystem.IsMacOS();
 
     public bool TreatsCtrlYAsRedo => OperatingSystem.IsWindows();

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -1,6 +1,7 @@
 using Celbridge.Commands;
 using Celbridge.Documents.ViewModels;
 using Celbridge.Messaging;
+using Celbridge.Platform;
 using Celbridge.UserInterface;
 using Microsoft.Extensions.Localization;
 
@@ -34,6 +35,7 @@ public partial class DocumentTab : TabViewItem
     private readonly IStringLocalizer _stringLocalizer;
     private readonly ICommandService _commandService;
     private readonly IMessengerService _messengerService;
+    private readonly IPlatformInfo _platformInfo;
 
     public DocumentTabViewModel ViewModel { get; }
 
@@ -69,6 +71,7 @@ public partial class DocumentTab : TabViewItem
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _commandService = ServiceLocator.AcquireService<ICommandService>();
         _messengerService = ServiceLocator.AcquireService<IMessengerService>();
+        _platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
         ViewModel = ServiceLocator.AcquireService<DocumentTabViewModel>();
 
         CloseMenuItem.Text = _stringLocalizer.GetString("DocumentTab_Close");
@@ -81,7 +84,8 @@ public partial class DocumentTab : TabViewItem
         CopyResourceKeyMenuItem.Text = _stringLocalizer.GetString("DocumentTab_CopyResourceKey");
         CopyFilePathMenuItem.Text = _stringLocalizer.GetString("DocumentTab_CopyFilePath");
         SelectFileMenuItem.Text = _stringLocalizer.GetString("DocumentTab_SelectFile");
-        OpenFileExplorerMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenFileExplorer");
+        string fileManagerName = _stringLocalizer.GetString(_platformInfo.FileManagerNameStringKey);
+        OpenFileExplorerMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenFileManager", fileManagerName);
         OpenApplicationMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenApplication");
         ReopenMenuItem.Text = _stringLocalizer.GetString("DocumentTab_Reopen");
         ReopenWithMenuItem.Text = _stringLocalizer.GetString("DocumentTab_ReopenWith");

--- a/Source/Workspace/Celbridge.Explorer/Menu/Options/OpenFileExplorerMenuOption.cs
+++ b/Source/Workspace/Celbridge.Explorer/Menu/Options/OpenFileExplorerMenuOption.cs
@@ -1,18 +1,20 @@
 using Celbridge.Commands;
 using Celbridge.ContextMenu;
+using Celbridge.Platform;
 using Celbridge.Workspace;
 using Microsoft.Extensions.Localization;
 
 namespace Celbridge.Explorer.Menu.Options;
 
 /// <summary>
-/// Menu option to open a resource in Windows File Explorer.
+/// Menu option to open a resource in the platform's system file manager.
 /// </summary>
 public class OpenFileExplorerMenuOption : IMenuOption<ExplorerMenuContext>
 {
     private readonly IStringLocalizer _stringLocalizer;
     private readonly ICommandService _commandService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
+    private readonly IPlatformInfo _platformInfo;
 
     public int Priority => 1;
     public string GroupId => nameof(ExplorerMenuGroup.FileSystem);
@@ -20,16 +22,20 @@ public class OpenFileExplorerMenuOption : IMenuOption<ExplorerMenuContext>
     public OpenFileExplorerMenuOption(
         IStringLocalizer stringLocalizer,
         ICommandService commandService,
-        IWorkspaceWrapper workspaceWrapper)
+        IWorkspaceWrapper workspaceWrapper,
+        IPlatformInfo platformInfo)
     {
         _stringLocalizer = stringLocalizer;
         _commandService = commandService;
         _workspaceWrapper = workspaceWrapper;
+        _platformInfo = platformInfo;
     }
 
     public MenuItemDisplayInfo GetDisplayInfo(ExplorerMenuContext context)
     {
-        return new MenuItemDisplayInfo(_stringLocalizer.GetString("ResourceTree_OpenFileExplorer"));
+        string fileManagerName = _stringLocalizer.GetString(_platformInfo.FileManagerNameStringKey);
+        var label = _stringLocalizer.GetString("ResourceTree_OpenFileManager", fileManagerName);
+        return new MenuItemDisplayInfo(label);
     }
 
     public MenuItemState GetState(ExplorerMenuContext context)

--- a/Source/Workspace/Celbridge.Explorer/Models/ResourceViewItem.cs
+++ b/Source/Workspace/Celbridge.Explorer/Models/ResourceViewItem.cs
@@ -86,6 +86,12 @@ public partial class ResourceViewItem : ObservableObject
     public string ReadOnlyMessage { get; }
 
     /// <summary>
+    /// Localised affordance hint shown when hovering the project folder, naming
+    /// the platform's file manager. Empty for non-project-folder items.
+    /// </summary>
+    public string ProjectFolderTooltip { get; }
+
+    /// <summary>
     /// The tooltip shown when the user hovers the item. The project folder
     /// retains its existing affordance hint; non-editable items show the
     /// read-only reason; editable items have no tooltip (returns null so the
@@ -97,7 +103,7 @@ public partial class ResourceViewItem : ObservableObject
         {
             if (IsProjectFolder)
             {
-                return "Double-click to open in File Explorer";
+                return ProjectFolderTooltip;
             }
 
             return string.IsNullOrEmpty(ReadOnlyMessage)
@@ -116,7 +122,8 @@ public partial class ResourceViewItem : ObservableObject
         bool hasChildren,
         bool isProjectFolder = false,
         string? displayName = null,
-        string? readOnlyMessage = null)
+        string? readOnlyMessage = null,
+        string? projectFolderTooltip = null)
     {
         Resource = resource;
         IndentLevel = indentLevel;
@@ -125,5 +132,6 @@ public partial class ResourceViewItem : ObservableObject
         IsProjectFolder = isProjectFolder;
         Name = displayName ?? resource.Name;
         ReadOnlyMessage = readOnlyMessage ?? string.Empty;
+        ProjectFolderTooltip = projectFolderTooltip ?? string.Empty;
     }
 }

--- a/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
+++ b/Source/Workspace/Celbridge.Explorer/ViewModels/ResourceTreeViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using Celbridge.DataTransfer;
 using Celbridge.Explorer.Models;
 using Celbridge.Logging;
+using Celbridge.Platform;
 using Celbridge.UserInterface.Helpers;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -17,6 +18,7 @@ public partial class ResourceTreeViewModel : ObservableObject
     private readonly ILogger<ResourceTreeViewModel> _logger;
     private readonly IMessengerService _messengerService;
     private readonly IStringLocalizer _stringLocalizer;
+    private readonly IPlatformInfo _platformInfo;
     private readonly IResourceRegistry _resourceRegistry;
     private readonly IFolderStateService _folderStateService;
     private readonly IDataTransferService _dataTransferService;
@@ -69,6 +71,7 @@ public partial class ResourceTreeViewModel : ObservableObject
         _logger = logger;
         _messengerService = messengerService;
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        _platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
         _resourceRegistry = workspaceWrapper.WorkspaceService.ResourceService.Registry;
         _folderStateService = workspaceWrapper.WorkspaceService.ExplorerService.FolderStateService;
         _dataTransferService = workspaceWrapper.WorkspaceService.DataTransferService;
@@ -166,13 +169,16 @@ public partial class ResourceTreeViewModel : ObservableObject
         // Add the project folder as the first item (always expanded, never collapsible)
         var hasChildren = projectFolder.Children.Count > 0;
         var projectName = Path.GetFileName(_resourceRegistry.ProjectFolderPath);
+        string fileManagerName = _stringLocalizer.GetString(_platformInfo.FileManagerNameStringKey);
+        var projectFolderTooltip = _stringLocalizer.GetString("ResourceTree_DoubleClickToOpen", fileManagerName);
         var projectFolderItem = new ResourceViewItem(
             projectFolder,
             indentLevel: 0,
             isExpanded: true,
             hasChildren,
             isProjectFolder: true,
-            displayName: projectName);
+            displayName: projectName,
+            projectFolderTooltip: projectFolderTooltip);
         items.Add(projectFolderItem);
 
         // Add children at indent level 0 (project folder uses negative margin, so children at 0 align correctly)

--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml.cs
@@ -308,7 +308,7 @@ public sealed partial class ResourceTree : UserControl, IResourceTree
     {
         if (item.Resource is IFolderResource)
         {
-            // Double-clicking the project folder opens it in File Explorer
+            // Double-clicking the project folder opens it in the system file manager
             if (item.IsProjectFolder)
             {
                 var resourceKey = _resourceRegistry.GetResourceKey(item.Resource);


### PR DESCRIPTION
Fixes #719

Add IPlatformInfo.FileManagerNameStringKey property to provide platform-specific file manager names (Finder on macOS, File Explorer on Windows/Linux). Update string resources and UI code to use the new capability for menu labels and tooltips in Documents and Explorer.