### PR TITLE
Implement close-document shortcuts for all platforms

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -749,6 +749,18 @@ Do you wish to continue?</value>
   <data name="DocumentTab_CloseAll" xml:space="preserve">
     <value>Close All</value>
   </data>
+  <data name="DocumentTab_CloseShortcutCommand" xml:space="preserve">
+    <value>⌘W</value>
+  </data>
+  <data name="DocumentTab_CloseShortcutControl" xml:space="preserve">
+    <value>Ctrl+W</value>
+  </data>
+  <data name="DocumentTab_CloseAllShortcutCommand" xml:space="preserve">
+    <value>⌘⇧W</value>
+  </data>
+  <data name="DocumentTab_CloseAllShortcutControl" xml:space="preserve">
+    <value>Ctrl+Shift+W</value>
+  </data>
   <data name="DocumentTab_MoveLeft" xml:space="preserve">
     <value>Move Left</value>
   </data>

--- a/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
@@ -51,3 +51,13 @@ public record UndoRequestedMessage();
 /// </summary>
 public record RedoRequestedMessage();
 
+/// <summary>
+/// Message sent to request closing the active document tab.
+/// </summary>
+public record CloseActiveDocumentRequestedMessage();
+
+/// <summary>
+/// Message sent to request closing all document tabs in the active document's section.
+/// </summary>
+public record CloseAllDocumentsRequestedMessage();
+

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
@@ -1,20 +1,22 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Celbridge.Logging;
+using Celbridge.Messaging;
 using Celbridge.Workspace;
 using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
 
 namespace Celbridge.UserInterface.Platform;
 
 /// <summary>
-/// Installs an AppKit local key-down monitor that keeps Tab inside a focused document instead of letting it
-/// move focus out to the surrounding panels. On the Skia head a Tab press routes either natively (the WKWebView
-/// is first responder) or through Uno's focus manager, and in both cases the AppKit key-view loop advances out
-/// of the WebView regardless of what the web content does with the key. A local monitor sees the event before
-/// it is dispatched to any responder, so while a document holds focus it hands Tab to the focused editor (which
-/// indents, moves a cell, and so on) and swallows the key so focus cannot leave the document. macOS-only.
+/// Installs an AppKit local key-down monitor for the keys that act on a focused document on the Skia head,
+/// where a WKWebView is first responder and neither Uno's managed input nor the web content reliably sees the
+/// event. A local monitor sees each key before it is dispatched to any responder. While a document holds focus
+/// it keeps Tab inside the editor (indent, move a cell) instead of letting the AppKit key-view loop advance out
+/// to the surrounding panels, and it routes Command+W and Command+Shift+W to the close-document shortcuts (which
+/// WKWebView otherwise swallows as reserved key equivalents). In every case it swallows the key so it cannot
+/// reach the surrounding app UI. macOS-only.
 /// </summary>
-internal static class MacOSTabKeyMonitor
+internal static class MacOSKeyEventMonitor
 {
     private const string LibObjC = "/usr/lib/libobjc.A.dylib";
     private const string LibSystem = "/usr/lib/libSystem.dylib";
@@ -28,8 +30,11 @@ internal static class MacOSTabKeyMonitor
     // kVK_Tab hardware key code.
     private const ulong TabKeyCode = 48;
 
-    // NSEventModifierFlagShift == 1 << 17.
+    // NSEventModifierFlag bit positions.
     private const ulong ModifierFlagShift = 1UL << 17;
+    private const ulong ModifierFlagControl = 1UL << 18;
+    private const ulong ModifierFlagOption = 1UL << 19;
+    private const ulong ModifierFlagCommand = 1UL << 20;
 
     // objc_msgSend for +addLocalMonitorForEventsMatchingMask:handler: (an NSUInteger mask then a block).
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
@@ -44,9 +49,10 @@ internal static class MacOSTabKeyMonitor
     private static IntPtr _monitor;
     private static IntPtr _monitorBlock;
     private static IFocusService? _focusService;
+    private static IMessengerService? _messengerService;
     private static ILogger? _logger;
 
-    public static void Start(IFocusService focusService, ILogger logger)
+    public static void Start(IFocusService focusService, IMessengerService messengerService, ILogger logger)
     {
         if (!OperatingSystem.IsMacOS())
         {
@@ -60,6 +66,7 @@ internal static class MacOSTabKeyMonitor
 
         _started = true;
         _focusService = focusService;
+        _messengerService = messengerService;
         _logger = logger;
 
         var nsEventClass = GetClass("NSEvent");
@@ -115,33 +122,81 @@ internal static class MacOSTabKeyMonitor
         try
         {
             var keyCode = SendMessageReturnNuint(nsEvent, GetSelector("keyCode")) & 0xFFFF;
-            if (keyCode != TabKeyCode)
+            var modifierFlags = SendMessageReturnNuint(nsEvent, GetSelector("modifierFlags"));
+
+            bool isTab = keyCode == TabKeyCode;
+            bool isCommand = (modifierFlags & ModifierFlagCommand) != 0;
+
+            // Pass through anything that is neither Tab nor a Command chord before touching focus.
+            if (!isTab
+                && !isCommand)
             {
                 return nsEvent;
             }
 
-            // Only intercept Tab while a document is focused. Tab still navigates the managed panels
-            // (Explorer, Inspector, and so on) everywhere else.
+            // Only act while a document is focused. Tab still navigates the managed panels (Explorer, Inspector,
+            // and so on) everywhere else, and the close shortcuts must not close a hidden document from another
+            // panel.
             if (_focusService?.FocusedPanel != WorkspacePanel.Documents)
             {
                 return nsEvent;
             }
 
-            var modifierFlags = SendMessageReturnNuint(nsEvent, GetSelector("modifierFlags"));
             var shift = (modifierFlags & ModifierFlagShift) != 0;
 
-            // Let the focused editor act on Tab (a code editor indents or outdents). Whether or not it does,
-            // the key is swallowed below so focus can never leave the document for the surrounding app UI.
-            _focusService.EditTarget?.TryHandleTabKey(shift);
+            if (isTab)
+            {
+                // Let the focused editor act on Tab (a code editor indents or outdents). Whether or not it does,
+                // the key is swallowed below so focus can never leave the document for the surrounding app UI.
+                _focusService.EditTarget?.TryHandleTabKey(shift);
+                return IntPtr.Zero;
+            }
 
-            return IntPtr.Zero;
+            // Command+W closes the active document, Command+Shift+W closes its section. WKWebView reserves
+            // Command+W and never delivers it to the web content, so this native monitor is the only reliable
+            // delivery path on the Skia head.
+            if (IsCloseShortcut(nsEvent, modifierFlags))
+            {
+                if (shift)
+                {
+                    _messengerService?.Send(new CloseAllDocumentsRequestedMessage());
+                }
+                else
+                {
+                    _messengerService?.Send(new CloseActiveDocumentRequestedMessage());
+                }
+
+                return IntPtr.Zero;
+            }
+
+            return nsEvent;
         }
         catch (Exception exception)
         {
             // A throw must never unwind back into AppKit, so pass the event through on failure.
-            _logger?.LogError(exception, "The Tab key monitor callback failed");
+            _logger?.LogError(exception, "The key event monitor callback failed");
             return nsEvent;
         }
+    }
+
+    // True for Command+W and Command+Shift+W. Matched on the character (layout-aware) rather than the hardware
+    // key code, and rejected when Control or Option is also held so it does not fire on unrelated chords.
+    private static bool IsCloseShortcut(IntPtr nsEvent, ulong modifierFlags)
+    {
+        bool command = (modifierFlags & ModifierFlagCommand) != 0;
+        bool control = (modifierFlags & ModifierFlagControl) != 0;
+        bool option = (modifierFlags & ModifierFlagOption) != 0;
+
+        if (!command
+            || control
+            || option)
+        {
+            return false;
+        }
+
+        var characters = ReadNSString(SendMessage(nsEvent, GetSelector("charactersIgnoringModifiers")));
+
+        return string.Equals(characters, "w", StringComparison.OrdinalIgnoreCase);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
@@ -1,6 +1,10 @@
 using Celbridge.Dialog;
+using Celbridge.UserInterface.Helpers;
 using Celbridge.UserInterface.Views;
 using Celbridge.Validators;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 
 namespace Celbridge.UserInterface.Services.Dialogs;
 
@@ -14,7 +18,7 @@ public class DialogFactory : IDialogFactory
             MessageText = messageText
         };
 
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public IConfirmationDialog CreateConfirmationDialog(string titleText, string messageText, string? primaryButtonText = null, string? secondaryButtonText = null)
@@ -36,19 +40,19 @@ public class DialogFactory : IDialogFactory
             dialog.SecondaryButtonText = secondaryButtonText;
         }
 
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public IProgressDialog CreateProgressDialog()
     {
         var dialog = new ProgressDialog();
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public INewProjectDialog CreateNewProjectDialog()
     {
         var dialog = new NewProjectDialog();
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public IInputTextDialog CreateInputTextDialog(string titleText, string messageText, string defaultText, Range selectionRange, IValidator validator, string? submitButtonKey = null)
@@ -67,7 +71,7 @@ public class DialogFactory : IDialogFactory
         dialog.ViewModel.Validator = validator;
         dialog.SetDefaultText(defaultText, selectionRange);
 
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public ISecretInputDialog CreateSecretInputDialog(string titleText, string headerText, string? submitButtonKey = null)
@@ -83,7 +87,7 @@ public class DialogFactory : IDialogFactory
             dialog.SubmitButtonKey = submitButtonKey;
         }
 
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public INewFileDialog CreateNewFileDialog(string defaultFileName, Range selectionRange, IValidator validator)
@@ -93,7 +97,7 @@ public class DialogFactory : IDialogFactory
         dialog.ViewModel.Validator = validator;
         dialog.SetDefaultFileName(defaultFileName, selectionRange);
 
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public IResourcePickerDialog CreateResourcePickerDialog(IReadOnlyList<string> extensions, string? title = null, bool showPreview = false)
@@ -104,7 +108,7 @@ public class DialogFactory : IDialogFactory
         {
             dialog.SetTitle(title);
         }
-        return dialog;
+        return WithFocusGuard(dialog);
     }
 
     public IChoiceDialog CreateChoiceDialog(string titleText, string messageText, IReadOnlyList<string> options, int defaultIndex = 0, ChoiceDialogCheckbox? checkbox = null, string? primaryButtonText = null, string? secondaryButtonText = null)
@@ -123,7 +127,43 @@ public class DialogFactory : IDialogFactory
             dialog.SecondaryButtonText = secondaryButtonText;
         }
 
+        return WithFocusGuard(dialog);
+    }
+
+    // Attaches the shared focus guard to every dialog this factory creates and returns the dialog. Centralised
+    // here because the factory is the single place dialogs are constructed, so no dialog author has to remember
+    // to wire up focus handling for a new dialog.
+    private static T WithFocusGuard<T>(T dialog) where T : ContentDialog
+    {
+        dialog.Opened += (sender, args) => EnsureInitialFocus(sender);
         return dialog;
+    }
+
+    // A dialog launched from a MenuFlyout races the closing flyout's asynchronous focus restoration on the
+    // Skia heads, which can leave keyboard focus outside the dialog so the next key press is handled by the
+    // panel beneath it. When a dialog opens without having placed focus on one of its own controls, move
+    // focus to its first focusable element so the dialog reliably owns the keyboard. Dialogs that focus a
+    // specific control themselves are left untouched.
+    private static void EnsureInitialFocus(ContentDialog dialog)
+    {
+        if (dialog.XamlRoot is null)
+        {
+            return;
+        }
+
+        var focusedElement = FocusManager.GetFocusedElement(dialog.XamlRoot) as DependencyObject;
+        bool focusWithinDialog = focusedElement is not null
+            && VisualTree.GetAncestors(focusedElement, includeSelf: true).Contains(dialog);
+        if (focusWithinDialog)
+        {
+            return;
+        }
+
+        var options = new FindNextElementOptions
+        {
+            SearchRoot = dialog
+        };
+        FocusManager.TryMoveFocus(FocusNavigationDirection.Next, options);
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/Services/KeyboardShortcutService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/KeyboardShortcutService.cs
@@ -43,6 +43,22 @@ public class KeyboardShortcutService : IKeyboardShortcutService
             return true;
         }
 
+        // All platforms close all documents shortcut: Ctrl+Shift+W
+        if (control && shift && key == VirtualKey.W)
+        {
+            var message = new CloseAllDocumentsRequestedMessage();
+            _messengerService.Send(message);
+            return true;
+        }
+
+        // All platforms close active document shortcut: Ctrl+W
+        if (control && key == VirtualKey.W)
+        {
+            var message = new CloseActiveDocumentRequestedMessage();
+            _messengerService.Send(message);
+            return true;
+        }
+
         return false;
     }
 
@@ -52,6 +68,7 @@ public class KeyboardShortcutService : IKeyboardShortcutService
         {
             "z" or "Z" => VirtualKey.Z,
             "y" or "Y" => VirtualKey.Y,
+            "w" or "W" => VirtualKey.W,
             _ => VirtualKey.None
         };
 

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/MainPage.xaml.cs
@@ -76,10 +76,11 @@ public partial class MainPage : Page
         // shortcuts fall through to Uno's keyboard handling. macOS-only. A no-op elsewhere.
         Celbridge.UserInterface.Platform.MacOSManagedPanelResponder.Start(_messengerService);
 
-        // Deliver Tab to a focused code editor (indent / outdent) instead of letting the platform focus loop
-        // move focus out of it. macOS-only. A no-op elsewhere.
-        var focusServiceForTab = ServiceLocator.AcquireService<IFocusService>();
-        Celbridge.UserInterface.Platform.MacOSTabKeyMonitor.Start(focusServiceForTab, _logger);
+        // Deliver document keys the focused WKWebView would otherwise swallow: Tab to a focused code editor
+        // (indent / outdent) instead of letting the platform focus loop move focus out of it, and Command+W /
+        // Command+Shift+W to the close-document shortcuts. macOS-only. A no-op elsewhere.
+        var focusServiceForKeyMonitor = ServiceLocator.AcquireService<IFocusService>();
+        Celbridge.UserInterface.Platform.MacOSKeyEventMonitor.Start(focusServiceForKeyMonitor, _messengerService, _logger);
 
         // Register for layout mode changes
         _messengerService.Register<LayoutModeChangedMessage>(this, OnLayoutModeChanged);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -89,6 +89,22 @@ public partial class DocumentTab : TabViewItem
         OpenApplicationMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenApplication");
         ReopenMenuItem.Text = _stringLocalizer.GetString("DocumentTab_Reopen");
         ReopenWithMenuItem.Text = _stringLocalizer.GetString("DocumentTab_ReopenWith");
+
+        ApplyCloseShortcutHints();
+    }
+
+    // Displays the close shortcut hints next to the Close and Close All menu items. These are display-only
+    // labels matching the shortcuts handled in KeyboardShortcutService. The platform command modifier selects
+    // between the Command-glyph form shown on macOS and the "Ctrl" form shown on Windows.
+    private void ApplyCloseShortcutHints()
+    {
+        bool usesCommandModifier = _platformInfo.CommandModifier == CommandModifierKey.Command;
+
+        string closeHintKey = usesCommandModifier ? "DocumentTab_CloseShortcutCommand" : "DocumentTab_CloseShortcutControl";
+        string closeAllHintKey = usesCommandModifier ? "DocumentTab_CloseAllShortcutCommand" : "DocumentTab_CloseAllShortcutControl";
+
+        CloseMenuItem.KeyboardAcceleratorTextOverride = _stringLocalizer.GetString(closeHintKey);
+        CloseAllMenuItem.KeyboardAcceleratorTextOverride = _stringLocalizer.GetString(closeAllHintKey);
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -21,6 +21,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     private readonly IDialogService _dialogService;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly IWebViewFocusRegistry _webViewFocusRegistry;
+    private readonly IFocusService _focusService;
 
     private bool _isShuttingDown = false;
 
@@ -62,6 +63,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         _dialogService = dialogService;
         _stringLocalizer = stringLocalizer;
         _webViewFocusRegistry = serviceProvider.AcquireService<IWebViewFocusRegistry>();
+        _focusService = serviceProvider.AcquireService<IFocusService>();
 
         ViewModel = serviceProvider.AcquireService<DocumentsPanelViewModel>();
 
@@ -196,8 +198,59 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         // Listen for layout reset requests to reset section count
         _messengerService.Register<ResetLayoutRequestedMessage>(this, OnResetLayoutRequested);
 
+        // Listen for the close document keyboard shortcuts
+        _messengerService.Register<CloseActiveDocumentRequestedMessage>(this, OnCloseActiveDocumentRequested);
+        _messengerService.Register<CloseAllDocumentsRequestedMessage>(this, OnCloseAllDocumentsRequested);
+
         // Apply initial tab strip visibility based on the current layout mode
         UpdateTabStripVisibility(_windowModeService.LayoutMode);
+    }
+
+    private void OnCloseActiveDocumentRequested(object recipient, CloseActiveDocumentRequestedMessage message)
+    {
+        var activeTab = GetFocusedActiveDocumentTab();
+        if (activeTab is null)
+        {
+            return;
+        }
+
+        CloseTab(activeTab);
+    }
+
+    private void OnCloseAllDocumentsRequested(object recipient, CloseAllDocumentsRequestedMessage message)
+    {
+        var activeTab = GetFocusedActiveDocumentTab();
+        if (activeTab is null)
+        {
+            return;
+        }
+
+        CloseAllTabs(activeTab);
+    }
+
+    // Resolves the active document's tab, but only while the documents panel holds focus. The close shortcuts
+    // must not close a hidden document when the user is working in the console or another panel.
+    private DocumentTab? GetFocusedActiveDocumentTab()
+    {
+        if (_isShuttingDown)
+        {
+            return null;
+        }
+
+        if (_focusService.FocusedPanel != WorkspacePanel.Documents)
+        {
+            return null;
+        }
+
+        var activeResource = SectionContainer.ActiveDocument;
+        if (activeResource.IsEmpty)
+        {
+            return null;
+        }
+
+        var location = SectionContainer.FindDocumentTab(activeResource);
+
+        return location?.Tab;
     }
 
     private void OnDocumentViewFocused(object recipient, DocumentViewFocusedMessage message)


### PR DESCRIPTION
This pull request introduces major improvements to keyboard shortcut handling for closing document tabs across all platforms, with special attention to macOS behavior, and ensures consistent focus management for dialogs. It also enhances user experience by displaying the correct shortcut hints in the UI and centralizes dialog focus handling.

**Keyboard Shortcut Handling and macOS Integration:**

* Added platform-appropriate keyboard shortcuts for closing the active document (`Ctrl+W`/`⌘W`) and all documents (`Ctrl+Shift+W`/`⌘⇧W`), with new message types (`CloseActiveDocumentRequestedMessage`, `CloseAllDocumentsRequestedMessage`) to communicate these actions. [[1]](diffhunk://#diff-ab1d14d3965627a73f0923ece16b988692b27e0ed628e7f4508fabd5033e1124R54-R63) [[2]](diffhunk://#diff-3397422026baed68d5d84c674f0a0a9815933f286aa7e6c16d10fe53a473c373R46-R61)
* Refactored and renamed `MacOSTabKeyMonitor` to `MacOSKeyEventMonitor`, expanding its responsibility to intercept not only Tab but also Command+W and Command+Shift+W, ensuring these shortcuts work reliably on macOS even when the WKWebView swallows them. [[1]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69R4-R19) [[2]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69L118-R201)
* Updated the startup logic in `MainPage.xaml.cs` to use the new key event monitor, wiring in the messenger service for shortcut delivery.

**User Interface Improvements:**

* Added localized strings for displaying the close shortcuts in the document tab context menu, and updated `DocumentTab.xaml.cs` to show the correct shortcut hint based on platform (Command vs. Control). [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R752-R763) [[2]](diffhunk://#diff-a3fe39a3ebffeb9d3edc17011c85edf3b29f769023710a3f3d0e01202d3ce21fR92-R107)

**Dialog Focus Management:**

* Centralized dialog focus handling in `DialogFactory.cs` by attaching a focus guard to every dialog, ensuring dialogs reliably receive keyboard focus regardless of how they're launched. [[1]](diffhunk://#diff-c4bdedb560e2fdc13628b1ab23f1024e5f3e78d924bd672ac8f0b1fa0dec6090L17-R21) [[2]](diffhunk://#diff-c4bdedb560e2fdc13628b1ab23f1024e5f3e78d924bd672ac8f0b1fa0dec6090R130-R167)

**Supporting Changes:**

* Updated service dependencies and constructors to accommodate the new shortcut and focus management logic. [[1]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decR24) [[2]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decR66)

These changes collectively ensure a consistent, cross-platform user experience for document tab management and dialog interactions.Support close-document shortcuts across platforms and handle macOS WKWebView reservations. Changes: add resource strings for close hints; introduce CloseActiveDocumentRequestedMessage and CloseAllDocumentsRequestedMessage; rename MacOSTabKeyMonitor -> MacOSKeyEventMonitor and route Command+W / Command+Shift+W (and Tab handling) via a native monitor that now uses IMessengerService; KeyboardShortcutService maps Ctrl+W / Ctrl+Shift+W to send the new messages; DocumentsPanel listens and closes the active tab or section only when the Documents panel is focused; MainPage starts the key monitor; DialogFactory adds a focus guard for dialogs; DocumentTab displays platform-appropriate shortcut hints.