### PR TITLE
Activate Explorer tab when selecting resource

### DIFF
--- a/Source/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
+++ b/Source/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
@@ -37,6 +37,12 @@ public class SelectResourceCommand : CommandBase, ISelectResourceCommand
                 command.Regions = LayoutRegion.Primary;
                 command.IsVisible = true;
             });
+
+            // Switch the activity panel to the Explorer tab. Making the Primary region visible is not
+            // enough on its own: the Explorer content stays collapsed while another activity (such as
+            // Search) is the active tab, so the selected resource would not be shown.
+            var activityPanel = _workspaceWrapper.WorkspaceService.ActivityPanel;
+            activityPanel.ShowTab(ActivityPanelTab.Explorer);
         }
 
         return Result.Ok();


### PR DESCRIPTION
Fixes #662

Ensure the Explorer tab is made active when a resource is selected. Making the Primary region visible was not enough because Explorer content could remain collapsed if another activity (e.g. Search) was the active tab. This change calls ActivityPanel.ShowTab(ActivityPanelTab.Explorer) so the selected resource is visible to the user.