### PR TITLE
Implement pointer-driven tab drag for Skia head

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -97,4 +97,10 @@ public interface IPlatformInfo
     /// not bring it into view automatically. True on macOS.
     /// </summary>
     bool RequiresMacOSTabScrollIntoView { get; }
+
+    /// <summary>
+    /// Whether document tabs are dragged by the pointer-driven drag controller because the platform's
+    /// built-in tab drag-and-drop is unreliable. True on the Skia desktop head (all operating systems).
+    /// </summary>
+    bool UsesPointerDrivenTabDrag { get; }
 }

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -77,4 +77,16 @@ public sealed class PlatformInfo : IPlatformInfo
     public bool RequiresMacOSLayoutRetry => OperatingSystem.IsMacOS();
 
     public bool RequiresMacOSTabScrollIntoView => OperatingSystem.IsMacOS();
+
+    public bool UsesPointerDrivenTabDrag
+    {
+        get
+        {
+#if WINDOWS
+            return false;
+#else
+            return true;
+#endif
+        }
+    }
 }

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.TabDrag.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.TabDrag.cs
@@ -1,0 +1,159 @@
+using Celbridge.UserInterface.Helpers;
+using Microsoft.UI.Xaml.Input;
+using Windows.Foundation;
+
+namespace Celbridge.Documents.Views;
+
+/// <summary>
+/// A document tab header and its bounds relative to a reference element, used for drag hit-testing.
+/// </summary>
+public record TabHeaderBounds(DocumentTab Tab, Rect Bounds);
+
+/// <summary>
+/// Pointer-driven tab drag support for DocumentSection, used on heads where the built-in TabView
+/// drag-and-drop is disabled (see TabDragController). Kept in its own partial so the desktop-only
+/// drag surface stays discoverable and separate from the core tab management.
+/// </summary>
+public sealed partial class DocumentSection
+{
+    private readonly PointerEventHandler _tabPointerPressedHandler;
+
+    /// <summary>
+    /// Event raised when a pointer is pressed on a document tab header. Feeds the pointer-driven
+    /// tab drag controller on heads where the built-in tab drag-and-drop is disabled.
+    /// </summary>
+    public event Action<DocumentSection, DocumentTab, PointerRoutedEventArgs>? TabPointerPressed;
+
+    /// <summary>
+    /// Disables the built-in TabView drag-and-drop on heads that use the pointer-driven controller,
+    /// so the two do not compete for the same pointer gestures.
+    /// </summary>
+    private void DisableBuiltInTabDrag()
+    {
+        if (_platformInfo.UsesPointerDrivenTabDrag)
+        {
+            TabView.CanDragTabs = false;
+            TabView.CanReorderTabs = false;
+        }
+    }
+
+    private void OnTabPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        if (sender is DocumentTab tab)
+        {
+            TabPointerPressed?.Invoke(this, tab, e);
+        }
+    }
+
+    // Presses inside a tab can be marked handled by the item's own pointer logic before they
+    // bubble, so the handler must also see handled events.
+    private void AddTabPointerPressedHandler(DocumentTab tab)
+    {
+        tab.AddHandler(PointerPressedEvent, _tabPointerPressedHandler, handledEventsToo: true);
+    }
+
+    private void RemoveTabPointerPressedHandler(DocumentTab tab)
+    {
+        tab.RemoveHandler(PointerPressedEvent, _tabPointerPressedHandler);
+    }
+
+    /// <summary>
+    /// Moves a tab to the given insertion slot within this section. The slot is an insertion point
+    /// in the current tab order (0 to TabCount inclusive), as computed by drag hit-testing.
+    /// </summary>
+    public void ReorderTab(DocumentTab tab, int insertionSlot)
+    {
+        EnsureUIThread();
+
+        int currentIndex = TabView.TabItems.IndexOf(tab);
+        if (currentIndex < 0)
+        {
+            return;
+        }
+
+        // Removing the tab shifts later slots down by one.
+        int targetIndex = insertionSlot > currentIndex ? insertionSlot - 1 : insertionSlot;
+        targetIndex = Math.Clamp(targetIndex, 0, TabView.TabItems.Count - 1);
+        if (targetIndex == currentIndex)
+        {
+            return;
+        }
+
+        bool wasSelected = TabView.SelectedItem == tab;
+        TabView.TabItems.RemoveAt(currentIndex);
+        DetachStrandedContainer(tab);
+        TabView.TabItems.Insert(targetIndex, tab);
+
+        if (wasSelected)
+        {
+            SetSelectedItemWithLayoutRetry(tab, () => ScrollTabIntoView(tab));
+        }
+    }
+
+    /// <summary>
+    /// Gets the bounds of the tab strip relative to the given element, or Rect.Empty when the strip
+    /// is collapsed or not yet laid out.
+    /// </summary>
+    public Rect GetTabStripBounds(UIElement relativeTo)
+    {
+        EnsureUIThread();
+
+        var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
+        if (tabListView is null ||
+            tabListView.ActualWidth <= 0 ||
+            TabView.Visibility == Visibility.Collapsed)
+        {
+            return Rect.Empty;
+        }
+
+        var transform = tabListView.TransformToVisual(relativeTo);
+
+        return transform.TransformBounds(new Rect(0, 0, tabListView.ActualWidth, tabListView.ActualHeight));
+    }
+
+    /// <summary>
+    /// Gets each tab header and its bounds relative to the given element, in tab order.
+    /// </summary>
+    public List<TabHeaderBounds> GetTabHeaderBounds(UIElement relativeTo)
+    {
+        EnsureUIThread();
+
+        var headerBounds = new List<TabHeaderBounds>();
+        foreach (var tabItem in TabView.TabItems)
+        {
+            if (tabItem is not DocumentTab tab ||
+                tab.ActualWidth <= 0)
+            {
+                continue;
+            }
+
+            var transform = tab.TransformToVisual(relativeTo);
+            var bounds = transform.TransformBounds(new Rect(0, 0, tab.ActualWidth, tab.ActualHeight));
+            headerBounds.Add(new TabHeaderBounds(tab, bounds));
+        }
+
+        return headerBounds;
+    }
+
+    /// <summary>
+    /// Scrolls the tab strip horizontally by the given delta in pixels, clamped to the scrollable range.
+    /// </summary>
+    public void ScrollTabStripBy(double delta)
+    {
+        EnsureUIThread();
+
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is null)
+        {
+            return;
+        }
+
+        double targetOffset = Math.Clamp(scrollViewer.HorizontalOffset + delta, 0, scrollViewer.ScrollableWidth);
+        scrollViewer.ChangeView(targetOffset, null, null, disableAnimation: true);
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml
@@ -40,7 +40,7 @@
              Drop="TabView_Drop">
       <TabView.TabStripFooter>
         <ContentPresenter x:Name="FooterPresenter"
-                          MinWidth="24"/>
+                          MinWidth="0"/>
       </TabView.TabStripFooter>
     </TabView>
   </Grid>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
@@ -78,6 +78,8 @@ public sealed partial class DocumentSection : UserControl
         _logger = ServiceLocator.AcquireService<IDocumentSectionLogger>();
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
+        _tabPointerPressedHandler = OnTabPointerPressed;
+        DisableBuiltInTabDrag();
 
         // Disable tab add/remove animations so tabs snap into place immediately
         TabView.Loaded += (s, e) => DisableTabViewAnimations();
@@ -232,6 +234,7 @@ public sealed partial class DocumentSection : UserControl
         tab.VisibleSectionCount = VisibleSectionCount;
         tab.ContextMenuActionRequested += OnDocumentTabContextMenuAction;
         tab.DragStarted += OnDocumentTabDragStarted;
+        AddTabPointerPressedHandler(tab);
         TabView.TabItems.Add(tab);
         UpdateEmptyPlaceholderVisibility();
     }
@@ -243,8 +246,30 @@ public sealed partial class DocumentSection : UserControl
     {
         tab.ContextMenuActionRequested -= OnDocumentTabContextMenuAction;
         tab.DragStarted -= OnDocumentTabDragStarted;
+        RemoveTabPointerPressedHandler(tab);
         TabView.TabItems.Remove(tab);
+        DetachStrandedContainer(tab);
         UpdateEmptyPlaceholderVisibility();
+    }
+
+    /// <summary>
+    /// Works around an Uno Skia TabView bug where TabItems.Remove can leave the removed tab's
+    /// container parented to this strip's ItemsStackPanel (seen when it was the selected or last
+    /// tab). While that stale parent stands, adding the tab to another section's strip fails to
+    /// render its header: the tab is in the model and its content shows, but the header stays blank
+    /// until some later reorder rebuilds the panel. Detaching the container here lets the
+    /// destination strip take ownership. The packaged Windows head runs the real WinUI TabView and
+    /// does not hit this.
+    /// </summary>
+    private void DetachStrandedContainer(DocumentTab tab)
+    {
+        var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
+        var itemsPanel = tabListView?.ItemsPanelRoot;
+        if (itemsPanel is not null &&
+            itemsPanel.Children.Contains(tab))
+        {
+            itemsPanel.Children.Remove(tab);
+        }
     }
 
     /// <summary>
@@ -401,6 +426,7 @@ public sealed partial class DocumentSection : UserControl
 
             documentTab.ContextMenuActionRequested -= OnDocumentTabContextMenuAction;
             documentTab.DragStarted -= OnDocumentTabDragStarted;
+            RemoveTabPointerPressedHandler(documentTab);
 
             var documentView = documentTab.Content as IDocumentView;
             if (documentView != null)
@@ -442,6 +468,28 @@ public sealed partial class DocumentSection : UserControl
 
         ToolTipService.SetToolTip(TabView, null);
         UpdateEmptyPlaceholderVisibility();
+
+        // Removing tabs can leave the strip scrolled past the end of its shrunken content, clipping
+        // tabs at the leading edge while showing a blank gap at the trailing edge. Re-clamp once
+        // layout has settled.
+        _ = DispatcherQueue.TryEnqueue(ClampTabStripScrollOffset);
+    }
+
+    private void ClampTabStripScrollOffset()
+    {
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is not null &&
+            scrollViewer.HorizontalOffset > scrollViewer.ScrollableWidth)
+        {
+            scrollViewer.ChangeView(scrollViewer.ScrollableWidth, null, null, disableAnimation: true);
+        }
+    }
+
+    private ScrollViewer? GetTabStripScrollViewer()
+    {
+        var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
+
+        return tabListView is null ? null : VisualTree.FindDescendant<ScrollViewer>(tabListView);
     }
 
     private void TabView_CloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
@@ -468,8 +516,10 @@ public sealed partial class DocumentSection : UserControl
 
     private void UpdateEmptyPlaceholderVisibility()
     {
+        // Keep the TabView visible even when the section has no tabs, so its tab strip footer (which
+        // hosts the split-editor toolbar on the rightmost section) stays accessible. The empty
+        // placeholder renders behind the empty strip.
         EmptyPlaceholder.Visibility = TabView.TabItems.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
-        TabView.Visibility = TabView.TabItems.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void TabView_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
@@ -663,6 +713,7 @@ public sealed partial class DocumentSection : UserControl
         tab.VisibleSectionCount = VisibleSectionCount;
         tab.ContextMenuActionRequested += OnDocumentTabContextMenuAction;
         tab.DragStarted += OnDocumentTabDragStarted;
+        AddTabPointerPressedHandler(tab);
 
         if (index < 0 || index >= TabView.TabItems.Count)
         {

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.TabDrag.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.TabDrag.cs
@@ -1,0 +1,52 @@
+using Celbridge.Platform;
+using Microsoft.UI.Xaml.Input;
+
+namespace Celbridge.Documents.Views;
+
+/// <summary>
+/// Pointer-driven tab drag support for DocumentSectionContainer, used on heads where the built-in
+/// TabView drag-and-drop is disabled. Hosts the TabDragController and commits completed drags. Kept
+/// in its own partial so the desktop-only drag surface stays discoverable.
+/// </summary>
+public sealed partial class DocumentSectionContainer
+{
+    private TabDragController? _tabDragController;
+
+    /// <summary>
+    /// Enables the pointer-driven tab drag controller, rendering drag visuals in the given overlay.
+    /// No-op on heads that keep the built-in TabView drag-and-drop.
+    /// </summary>
+    public void InitializeTabDrag(Canvas dragOverlay)
+    {
+        var platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
+        if (!platformInfo.UsesPointerDrivenTabDrag)
+        {
+            return;
+        }
+
+        _tabDragController = new TabDragController(this, dragOverlay);
+    }
+
+    /// <summary>
+    /// Commits a completed tab drag: a reorder within the source section, or a move to another
+    /// section at the given insertion slot.
+    /// </summary>
+    internal void CommitTabDrag(DocumentTab tab, DocumentSection sourceSection, DocumentSection targetSection, int insertionSlot)
+    {
+        if (sourceSection == targetSection)
+        {
+            sourceSection.ReorderTab(tab, insertionSlot);
+            ActivateDocument(tab.ViewModel.FileResource, sourceSection.SectionIndex);
+            NotifyLayoutChanged();
+        }
+        else if (MoveTabToSection(tab, targetSection.SectionIndex, insertionSlot))
+        {
+            NotifyLayoutChanged();
+        }
+    }
+
+    private void OnSectionTabPointerPressed(DocumentSection section, DocumentTab tab, PointerRoutedEventArgs e)
+    {
+        _tabDragController?.OnTabPressed(section, tab, e);
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
@@ -20,6 +20,8 @@ public sealed partial class DocumentSectionContainer : UserControl
     private readonly List<Splitter> _splitters = new();
     private readonly Dictionary<int, SplitterHelper> _splitterHelpers = new();
 
+    private UIElement? _documentToolbar;
+
     private double _totalDragDelta = 0;
 
     private int _sectionCount = 1;
@@ -165,6 +167,16 @@ public sealed partial class DocumentSectionContainer : UserControl
         {
             _sections[_sectionCount - 1].SetTabStripFooter(content);
         }
+    }
+
+    /// <summary>
+    /// Sets the split-editor toolbar hosted in the rightmost section's tab strip footer. The toolbar
+    /// is re-placed on the current rightmost section whenever the section layout is rebuilt.
+    /// </summary>
+    public void SetDocumentToolbar(UIElement toolbar)
+    {
+        _documentToolbar = toolbar;
+        SetTabStripFooter(_documentToolbar);
     }
 
     /// <summary>
@@ -509,9 +521,10 @@ public sealed partial class DocumentSectionContainer : UserControl
     }
 
     /// <summary>
-    /// Moves a tab from its current section to the target section.
+    /// Moves a tab from its current section to the target section, appending it to the tab strip or
+    /// inserting it at the given insertion slot.
     /// </summary>
-    public bool MoveTabToSection(DocumentTab tab, int targetSectionIndex)
+    public bool MoveTabToSection(DocumentTab tab, int targetSectionIndex, int? insertionSlot = null)
     {
         if (targetSectionIndex < 0 || targetSectionIndex >= _sectionCount)
         {
@@ -532,10 +545,31 @@ public sealed partial class DocumentSectionContainer : UserControl
             return false; // Already in the target section
         }
 
+        bool wasSelectedInSource = sourceSection.GetSelectedDocument() == tab.ViewModel.FileResource;
+        int sourceTabIndex = sourceSection.GetTabIndex(tab);
+
         // Move the tab
         sourceSection.RemoveTab(tab);
-        targetSection.AddTab(tab);
+        if (insertionSlot is int slot)
+        {
+            targetSection.InsertTab(tab, slot);
+        }
+        else
+        {
+            targetSection.AddTab(tab);
+        }
         targetSection.SelectTab(tab);
+
+        // Restore a visible selection in the source section. The Uno Skia TabView does not reliably
+        // select a neighbouring tab when its selected tab is removed, which leaves every tab in the
+        // strip rendered in the unselected style (the whole row reads as disabled).
+        if (wasSelectedInSource &&
+            sourceSection.TabCount > 0)
+        {
+            int neighbourIndex = Math.Clamp(sourceTabIndex, 0, sourceSection.TabCount - 1);
+            var neighbourTab = sourceSection.GetAllTabs().ElementAt(neighbourIndex);
+            sourceSection.SelectTab(neighbourTab);
+        }
 
         // Always make the moved tab the active document
         _activeSectionIndex = targetSectionIndex;
@@ -559,6 +593,7 @@ public sealed partial class DocumentSectionContainer : UserControl
         section.ContextMenuActionRequested += OnSectionContextMenuActionRequested;
         section.TabDroppedInside += OnSectionTabDroppedInside;
         section.FilesDropped += OnSectionFilesDropped;
+        section.TabPointerPressed += OnSectionTabPointerPressed;
 
         _sections.Add(section);
     }
@@ -604,42 +639,36 @@ public sealed partial class DocumentSectionContainer : UserControl
 
     private void RebuildGrid()
     {
-        // Unsubscribe from existing splitter events
+        // Remove the existing splitters. They hold no content and are recreated for the new layout.
         foreach (var splitter in _splitters)
         {
             splitter.DragStarted -= Splitter_DragStarted;
             splitter.DragDelta -= Splitter_DragDelta;
             splitter.DragCompleted -= Splitter_DragCompleted;
             splitter.DoubleClicked -= Splitter_DoubleClicked;
+            RootGrid.Children.Remove(splitter);
+        }
+        _splitters.Clear();
+
+        // Detach sections that are no longer visible. Sections that stay visible are left attached:
+        // reparenting a section resets its TabView measurement and leaves the tab strip stuck in an
+        // overflow-scroll state (clipping tabs and reserving phantom trailing space) until the next
+        // real resize. Clearing ColumnDefinitions below does not detach children, so it is safe.
+        for (int i = _sectionCount; i < _sections.Count; i++)
+        {
+            var hiddenSection = _sections[i];
+            if (RootGrid.Children.Contains(hiddenSection))
+            {
+                RootGrid.Children.Remove(hiddenSection);
+            }
         }
 
-        RootGrid.Children.Clear();
         RootGrid.ColumnDefinitions.Clear();
-        _splitters.Clear();
 
         // Update VisibleSectionCount on all sections
         foreach (var section in _sections)
         {
             section.VisibleSectionCount = _sectionCount;
-        }
-
-        // Ensure all sections have events wired up (defensive check)
-        for (int i = 0; i < _sections.Count; i++)
-        {
-            var section = _sections[i];
-
-            // Unwire and rewire to ensure no duplicates
-            section.SelectionChanged -= OnSectionSelectionChanged;
-            section.DocumentsLayoutChanged -= OnSectionDocumentsLayoutChanged;
-            section.CloseRequested -= OnSectionCloseRequested;
-            section.ContextMenuActionRequested -= OnSectionContextMenuActionRequested;
-            section.TabDroppedInside -= OnSectionTabDroppedInside;
-
-            section.SelectionChanged += OnSectionSelectionChanged;
-            section.DocumentsLayoutChanged += OnSectionDocumentsLayoutChanged;
-            section.CloseRequested += OnSectionCloseRequested;
-            section.ContextMenuActionRequested += OnSectionContextMenuActionRequested;
-            section.TabDroppedInside += OnSectionTabDroppedInside;
         }
 
         for (int i = 0; i < _sectionCount; i++)
@@ -654,7 +683,10 @@ public sealed partial class DocumentSectionContainer : UserControl
 
             var section = _sections[i];
             Grid.SetColumn(section, i * 2);
-            RootGrid.Children.Add(section);
+            if (!RootGrid.Children.Contains(section))
+            {
+                RootGrid.Children.Add(section);
+            }
 
             // Add splitter after each section except the last
             if (i < _sectionCount - 1)
@@ -667,6 +699,10 @@ public sealed partial class DocumentSectionContainer : UserControl
                 _splitters.Add(splitter);
             }
         }
+
+        // The split-editor toolbar lives in the rightmost visible section's footer, so re-place it
+        // whenever the section layout changes.
+        SetTabStripFooter(_documentToolbar);
     }
 
     private Splitter CreateSplitter(int index)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml
@@ -8,10 +8,11 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     ui:FocusTracking.Panel="Documents">
   <Grid>
+    <!-- The split-editor toolbar is hosted in the rightmost section's tab strip footer,
+         placed there by DocumentSectionContainer. -->
     <local:DocumentSectionContainer x:Name="SectionContainer"/>
-    <local:DocumentToolbar x:Name="DocumentToolbar" 
-                           HorizontalAlignment="Right"
-                           VerticalAlignment="Top"
-                           Margin="0,6"/>
+    <!-- Topmost display-only layer for tab drag visuals (ghost and insertion indicator) -->
+    <Canvas x:Name="TabDragOverlay"
+            IsHitTestVisible="False"/>
   </Grid>
 </UserControl>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     private readonly IStringLocalizer _stringLocalizer;
     private readonly IWebViewFocusRegistry _webViewFocusRegistry;
     private readonly IFocusService _focusService;
+    private readonly DocumentToolbar _documentToolbar = new();
 
     private bool _isShuttingDown = false;
 
@@ -78,8 +79,13 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         SectionContainer.SectionRatiosChanged += OnSectionRatiosChanged;
         SectionContainer.FilesDropped += OnSectionFilesDropped;
 
+        SectionContainer.InitializeTabDrag(TabDragOverlay);
+
+        // Host the split-editor toolbar in the rightmost section's tab strip footer.
+        SectionContainer.SetDocumentToolbar(_documentToolbar);
+
         // Wire up toolbar events
-        DocumentToolbar.SectionCountChangeRequested += OnToolbarSectionCountChangeRequested;
+        _documentToolbar.SectionCountChangeRequested += OnToolbarSectionCountChangeRequested;
 
         Loaded += DocumentsPanel_Loaded;
         Unloaded += DocumentsPanel_Unloaded;
@@ -118,7 +124,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     private void OnSectionCountChanged(int newCount)
     {
         // Update toolbar to reflect new section count
-        DocumentToolbar.UpdateSectionCount(newCount);
+        _documentToolbar.UpdateSectionCount(newCount);
         // Note: Ratios are persisted via OnSectionRatiosChanged which fires after count changes
     }
 
@@ -328,7 +334,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         // In all other modes, show the tab strip and toolbar.
         bool showTabStrip = layoutMode != LayoutMode.Presentation;
         SectionContainer.UpdateTabStripVisibility(showTabStrip);
-        DocumentToolbar.Visibility = showTabStrip ? Visibility.Visible : Visibility.Collapsed;
+        _documentToolbar.Visibility = showTabStrip ? Visibility.Visible : Visibility.Collapsed;
     }
 
     public void SetSectionRatios(List<double> ratios)

--- a/Source/Workspace/Celbridge.Documents/Views/TabDragController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/TabDragController.cs
@@ -1,0 +1,546 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
+
+namespace Celbridge.Documents.Views;
+
+/// <summary>
+/// The drop target a tab drag is currently over: the section that will receive the tab, the
+/// insertion slot within its tab order (computed from the pointer X whether over the strip or the
+/// body), and whether the pointer is over the section body rather than the tab strip.
+/// </summary>
+internal record TabDropTarget(DocumentSection Section, int InsertionSlot, bool OverSectionBody);
+
+/// <summary>
+/// Pointer-driven drag controller for document tabs, replacing the built-in TabView drag-and-drop
+/// on heads where it is unreliable. Tracks a pressed tab through a drag threshold, renders a ghost
+/// and insertion indicator in an overlay canvas, and commits the reorder or move on release.
+/// </summary>
+internal sealed class TabDragController
+{
+    private const double DragThreshold = 5.0;
+    private const double GhostOpacity = 0.85;
+    private const double IndicatorWidth = 2.0;
+    private const double AutoScrollEdgeWidth = 28.0;
+    private const double AutoScrollStep = 16.0;
+
+    private readonly DocumentSectionContainer _container;
+    private readonly Canvas _overlay;
+    private readonly PointerEventHandler _pointerMovedHandler;
+    private readonly PointerEventHandler _pointerReleasedHandler;
+    private readonly PointerEventHandler _pointerCaptureLostHandler;
+    private readonly KeyEventHandler _keyDownHandler;
+    private readonly DispatcherQueueTimer _autoScrollTimer;
+
+    private DocumentTab? _pressedTab;
+    private DocumentSection? _sourceSection;
+    private Point _pressPosition;
+    private Point _lastPointerPosition;
+    private bool _isDragging;
+    private double _autoScrollDelta;
+    private UIElement? _keyEventRoot;
+    private TabDropTarget? _currentTarget;
+    private Border? _ghost;
+    private Border? _insertionIndicator;
+    private Border? _sectionHighlight;
+
+    public TabDragController(DocumentSectionContainer container, Canvas overlay)
+    {
+        _container = container;
+        _overlay = overlay;
+        _pointerMovedHandler = OnPointerMoved;
+        _pointerReleasedHandler = OnPointerReleased;
+        _pointerCaptureLostHandler = OnPointerCaptureLost;
+        _keyDownHandler = OnRootKeyDown;
+
+        _autoScrollTimer = container.DispatcherQueue.CreateTimer();
+        _autoScrollTimer.Interval = TimeSpan.FromMilliseconds(50);
+        _autoScrollTimer.Tick += OnAutoScrollTick;
+    }
+
+    /// <summary>
+    /// Begins tracking a pointer press on a tab header. The drag itself starts only if the pointer
+    /// travels past the drag threshold, so plain clicks are unaffected.
+    /// </summary>
+    public void OnTabPressed(DocumentSection section, DocumentTab tab, PointerRoutedEventArgs e)
+    {
+        if (_pressedTab is not null)
+        {
+            // A stale press whose release was delivered elsewhere - reset before tracking anew.
+            EndTracking();
+        }
+
+        var pointerPoint = e.GetCurrentPoint(tab);
+        if (!pointerPoint.Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        // Presses on interactive children (the tab close button) never start a drag.
+        if (IsPressOnInteractiveChild(e.OriginalSource, tab))
+        {
+            return;
+        }
+
+        _pressedTab = tab;
+        _sourceSection = section;
+        _pressPosition = e.GetCurrentPoint(_overlay).Position;
+
+        // Track the pointer on the container, not the tab: the tab strip's list captures the pointer
+        // on press, which routes subsequent events to the capture owner and up its ancestor chain.
+        // The container is on that chain; the tab is not.
+        _container.AddHandler(UIElement.PointerMovedEvent, _pointerMovedHandler, handledEventsToo: true);
+        _container.AddHandler(UIElement.PointerReleasedEvent, _pointerReleasedHandler, handledEventsToo: true);
+        _container.AddHandler(UIElement.PointerCaptureLostEvent, _pointerCaptureLostHandler, handledEventsToo: true);
+    }
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_pressedTab is null)
+        {
+            return;
+        }
+
+        var position = e.GetCurrentPoint(_overlay).Position;
+
+        if (!_isDragging)
+        {
+            if (Math.Abs(position.X - _pressPosition.X) < DragThreshold &&
+                Math.Abs(position.Y - _pressPosition.Y) < DragThreshold)
+            {
+                return;
+            }
+
+            BeginDrag(e);
+        }
+
+        UpdateDrag(position);
+        e.Handled = true;
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (_pressedTab is null)
+        {
+            return;
+        }
+
+        var tab = _pressedTab;
+        var sourceSection = _sourceSection!;
+        var target = _currentTarget;
+        bool wasDragging = _isDragging;
+
+        EndTracking();
+
+        if (!wasDragging)
+        {
+            // A plain click - leave selection and activation to the normal tap handling.
+            return;
+        }
+
+        e.Handled = true;
+
+        if (target is not null)
+        {
+            _container.CommitTabDrag(tab, sourceSection, target.Section, target.InsertionSlot);
+        }
+    }
+
+    private void OnPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (_pressedTab is null)
+        {
+            return;
+        }
+
+        // Stealing capture in BeginDrag raises PointerCaptureLost on the strip's list; only the
+        // dragged tab losing its own capture cancels the drag.
+        if (_isDragging &&
+            ReferenceEquals(e.OriginalSource, _pressedTab))
+        {
+            EndTracking();
+        }
+    }
+
+    private void OnRootKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == Windows.System.VirtualKey.Escape &&
+            _pressedTab is not null)
+        {
+            e.Handled = true;
+            EndTracking();
+        }
+    }
+
+    private void BeginDrag(PointerRoutedEventArgs e)
+    {
+        var tab = _pressedTab!;
+
+        _isDragging = true;
+        tab.CapturePointer(e.Pointer);
+        tab.Opacity = 0.5;
+        CreateDragVisuals(tab);
+
+        // Escape cancels the drag. Wired on the window content so it fires wherever managed focus
+        // sits; keystrokes inside a native web view do not reach the managed layer.
+        _keyEventRoot = _container.XamlRoot?.Content as UIElement;
+        _keyEventRoot?.AddHandler(UIElement.KeyDownEvent, _keyDownHandler, handledEventsToo: true);
+    }
+
+    private void UpdateDrag(Point position)
+    {
+        var tab = _pressedTab!;
+        _lastPointerPosition = position;
+        _currentTarget = ResolveDropTarget(position);
+
+        // The ghost rides along the tab strip band rather than following the pointer freely. Native
+        // web views composite above the managed layer on this head, so a free-floating ghost would
+        // vanish over editor content; clamping also signals that tabs drop into a strip.
+        if (_ghost is not null)
+        {
+            var stripBounds = GetDragStripBounds();
+            double ghostX = Math.Clamp(position.X - (_ghost.ActualWidth / 2), 0, Math.Max(0, _overlay.ActualWidth - _ghost.ActualWidth));
+            double ghostY = stripBounds.IsEmpty ? 0 : stripBounds.Y;
+            Canvas.SetLeft(_ghost, ghostX);
+            Canvas.SetTop(_ghost, ghostY);
+        }
+
+        UpdateInsertionIndicator(tab);
+        UpdateSectionHighlight();
+        UpdateAutoScroll(position);
+    }
+
+    /// <summary>
+    /// Classifies the pointer position against the visible sections. The insertion slot is the pointer
+    /// X against the tab centres in both cases, so the indicator tracks the pointer over the body just
+    /// as it does over the strip; the body hit only differs in showing the section highlight.
+    /// </summary>
+    private TabDropTarget? ResolveDropTarget(Point position)
+    {
+        for (int i = 0; i < _container.SectionCount; i++)
+        {
+            var section = _container.GetSection(i);
+
+            var stripBounds = section.GetTabStripBounds(_overlay);
+            if (!stripBounds.IsEmpty &&
+                stripBounds.Contains(position))
+            {
+                int insertionSlot = ComputeInsertionSlot(section, position.X);
+                return new TabDropTarget(section, insertionSlot, OverSectionBody: false);
+            }
+
+            var sectionBounds = GetElementBounds(section);
+            if (sectionBounds.Contains(position))
+            {
+                int insertionSlot = ComputeInsertionSlot(section, position.X);
+                return new TabDropTarget(section, insertionSlot, OverSectionBody: true);
+            }
+        }
+
+        return null;
+    }
+
+    private int ComputeInsertionSlot(DocumentSection section, double pointerX)
+    {
+        var headerBounds = section.GetTabHeaderBounds(_overlay);
+        for (int i = 0; i < headerBounds.Count; i++)
+        {
+            var bounds = headerBounds[i].Bounds;
+            double centerX = bounds.X + (bounds.Width / 2);
+            if (pointerX < centerX)
+            {
+                return i;
+            }
+        }
+
+        return headerBounds.Count;
+    }
+
+    private void UpdateInsertionIndicator(DocumentTab draggedTab)
+    {
+        if (_insertionIndicator is null)
+        {
+            return;
+        }
+
+        var target = _currentTarget;
+        if (target is null)
+        {
+            _insertionIndicator.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var stripBounds = target.Section.GetTabStripBounds(_overlay);
+        if (stripBounds.IsEmpty)
+        {
+            _insertionIndicator.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var headerBounds = target.Section.GetTabHeaderBounds(_overlay);
+        int slot = target.InsertionSlot;
+        int draggedIndex = target.Section.GetTabIndex(draggedTab);
+
+        // Position the indicator at the slot boundary: the left edge of the slot's tab, the right
+        // edge of the last tab for the trailing slot (append), or the strip start when empty. A slot
+        // adjacent to the dragged tab's own position is a no-op drop, so mark the tab's left edge -
+        // that is where it stays.
+        bool dropsInPlace = draggedIndex >= 0 &&
+            (slot == draggedIndex || slot == draggedIndex + 1);
+        double indicatorX;
+        if (dropsInPlace &&
+            draggedIndex < headerBounds.Count)
+        {
+            indicatorX = headerBounds[draggedIndex].Bounds.X;
+        }
+        else if (headerBounds.Count == 0)
+        {
+            indicatorX = stripBounds.X;
+        }
+        else if (slot < headerBounds.Count)
+        {
+            indicatorX = headerBounds[slot].Bounds.X;
+        }
+        else
+        {
+            var lastBounds = headerBounds[^1].Bounds;
+            indicatorX = lastBounds.X + lastBounds.Width;
+        }
+
+        _insertionIndicator.Height = stripBounds.Height;
+        Canvas.SetLeft(_insertionIndicator, indicatorX - (IndicatorWidth / 2));
+        Canvas.SetTop(_insertionIndicator, stripBounds.Y);
+        _insertionIndicator.Visibility = Visibility.Visible;
+    }
+
+    private void UpdateSectionHighlight()
+    {
+        if (_sectionHighlight is null)
+        {
+            return;
+        }
+
+        if (_currentTarget is not { OverSectionBody: true } target)
+        {
+            _sectionHighlight.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        // Cover only the content area below the tab strip band. The ghost tab rides in that band, so
+        // highlighting it too would read as a phantom strip - most visibly on an empty section, where
+        // the ghost is the only thing in an otherwise bare strip.
+        var sectionBounds = GetElementBounds(target.Section);
+        var stripBand = GetDragStripBounds();
+        double top = stripBand.IsEmpty ? sectionBounds.Y : stripBand.Bottom;
+
+        _sectionHighlight.Width = sectionBounds.Width;
+        _sectionHighlight.Height = Math.Max(0, sectionBounds.Bottom - top);
+        Canvas.SetLeft(_sectionHighlight, sectionBounds.X);
+        Canvas.SetTop(_sectionHighlight, top);
+        _sectionHighlight.Visibility = Visibility.Visible;
+    }
+
+    private void UpdateAutoScroll(Point position)
+    {
+        double delta = 0;
+        if (_currentTarget is { OverSectionBody: false } target)
+        {
+            var stripBounds = target.Section.GetTabStripBounds(_overlay);
+            if (position.X < stripBounds.X + AutoScrollEdgeWidth)
+            {
+                delta = -AutoScrollStep;
+            }
+            else if (position.X > stripBounds.Right - AutoScrollEdgeWidth)
+            {
+                delta = AutoScrollStep;
+            }
+        }
+
+        _autoScrollDelta = delta;
+        if (delta != 0)
+        {
+            if (!_autoScrollTimer.IsRunning)
+            {
+                _autoScrollTimer.Start();
+            }
+        }
+        else
+        {
+            _autoScrollTimer.Stop();
+        }
+    }
+
+    private void OnAutoScrollTick(DispatcherQueueTimer sender, object args)
+    {
+        if (!_isDragging ||
+            _autoScrollDelta == 0 ||
+            _currentTarget is not { OverSectionBody: false } target)
+        {
+            sender.Stop();
+            return;
+        }
+
+        target.Section.ScrollTabStripBy(_autoScrollDelta);
+
+        // Tabs slide under the stationary pointer, so recompute the slot and indicator.
+        UpdateDrag(_lastPointerPosition);
+    }
+
+    private void CreateDragVisuals(DocumentTab tab)
+    {
+        var ghostLabel = new TextBlock
+        {
+            Text = tab.ViewModel.DocumentName,
+            Foreground = GetThemeBrush("TextFillColorPrimaryBrush", Microsoft.UI.Colors.Black),
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        _ghost = new Border
+        {
+            Background = GetThemeBrush("LayerFillColorDefaultBrush", Microsoft.UI.Colors.LightGray),
+            BorderBrush = GetThemeBrush("ControlStrokeColorDefaultBrush", Microsoft.UI.Colors.Gray),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(10, 4, 10, 4),
+            Opacity = GhostOpacity,
+            IsHitTestVisible = false,
+            Child = ghostLabel
+        };
+
+        _insertionIndicator = new Border
+        {
+            Width = IndicatorWidth,
+            Background = GetThemeBrush("AccentFillColorDefaultBrush", Microsoft.UI.Colors.DodgerBlue),
+            IsHitTestVisible = false,
+            Visibility = Visibility.Collapsed
+        };
+
+        _sectionHighlight = new Border
+        {
+            Background = CreateAccentHighlightBrush(),
+            BorderBrush = GetThemeBrush("AccentFillColorDefaultBrush", Microsoft.UI.Colors.DodgerBlue),
+            BorderThickness = new Thickness(1),
+            IsHitTestVisible = false,
+            Visibility = Visibility.Collapsed
+        };
+
+        _overlay.Children.Add(_sectionHighlight);
+        _overlay.Children.Add(_insertionIndicator);
+        _overlay.Children.Add(_ghost);
+    }
+
+    private void EndTracking()
+    {
+        var tab = _pressedTab!;
+
+        _container.RemoveHandler(UIElement.PointerMovedEvent, _pointerMovedHandler);
+        _container.RemoveHandler(UIElement.PointerReleasedEvent, _pointerReleasedHandler);
+        _container.RemoveHandler(UIElement.PointerCaptureLostEvent, _pointerCaptureLostHandler);
+        _keyEventRoot?.RemoveHandler(UIElement.KeyDownEvent, _keyDownHandler);
+        _keyEventRoot = null;
+
+        _autoScrollTimer.Stop();
+        tab.ReleasePointerCaptures();
+        tab.Opacity = 1.0;
+
+        if (_ghost is not null)
+        {
+            _overlay.Children.Remove(_ghost);
+            _ghost = null;
+        }
+        if (_insertionIndicator is not null)
+        {
+            _overlay.Children.Remove(_insertionIndicator);
+            _insertionIndicator = null;
+        }
+        if (_sectionHighlight is not null)
+        {
+            _overlay.Children.Remove(_sectionHighlight);
+            _sectionHighlight = null;
+        }
+
+        _pressedTab = null;
+        _sourceSection = null;
+        _isDragging = false;
+        _autoScrollDelta = 0;
+        _currentTarget = null;
+    }
+
+    /// <summary>
+    /// Gets the tab strip band relevant to the current drag: the target section's strip when over
+    /// one, otherwise the source section's. The ghost rides this band and the section highlight
+    /// starts just below it.
+    /// </summary>
+    private Rect GetDragStripBounds()
+    {
+        if (_currentTarget is not null)
+        {
+            var targetBounds = _currentTarget.Section.GetTabStripBounds(_overlay);
+            if (!targetBounds.IsEmpty)
+            {
+                return targetBounds;
+            }
+        }
+
+        return _sourceSection?.GetTabStripBounds(_overlay) ?? Rect.Empty;
+    }
+
+    private Rect GetElementBounds(UIElement element)
+    {
+        if (element is FrameworkElement frameworkElement &&
+            frameworkElement.ActualWidth > 0)
+        {
+            var transform = element.TransformToVisual(_overlay);
+            return transform.TransformBounds(new Rect(0, 0, frameworkElement.ActualWidth, frameworkElement.ActualHeight));
+        }
+
+        return Rect.Empty;
+    }
+
+    private static bool IsPressOnInteractiveChild(object? originalSource, DocumentTab tab)
+    {
+        var current = originalSource as DependencyObject;
+        while (current is not null && current != tab)
+        {
+            if (current is ButtonBase)
+            {
+                return true;
+            }
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return false;
+    }
+
+    private static Brush GetThemeBrush(string resourceKey, Windows.UI.Color fallbackColor)
+    {
+        if (Application.Current.Resources.TryGetValue(resourceKey, out var resource) &&
+            resource is Brush brush)
+        {
+            return brush;
+        }
+
+        return new SolidColorBrush(fallbackColor);
+    }
+
+    private static Windows.UI.Color GetThemeColor(string resourceKey, Windows.UI.Color fallbackColor)
+    {
+        if (Application.Current.Resources.TryGetValue(resourceKey, out var resource) &&
+            resource is SolidColorBrush brush)
+        {
+            return brush.Color;
+        }
+
+        return fallbackColor;
+    }
+
+    private static Brush CreateAccentHighlightBrush()
+    {
+        var color = GetThemeColor("AccentFillColorDefaultBrush", Microsoft.UI.Colors.DodgerBlue);
+        color.A = 0x28;
+
+        return new SolidColorBrush(color);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the document tab drag-and-drop experience, especially for desktop platforms using the Skia head. It adds a pointer-driven tab drag controller for platforms where the built-in drag-and-drop is unreliable, ensures tab strip layout and scrolling behave correctly when tabs are added, removed, or moved, and addresses several platform-specific bugs and usability issues. The changes are organized as follows:

**Pointer-driven Tab Drag Support:**

* Added the `UsesPointerDrivenTabDrag` property to `IPlatformInfo` and implemented it in `PlatformInfo` to enable pointer-driven tab dragging on non-Windows platforms [[1]](diffhunk://#diff-b257f60457d58b6ae4298898a1a2d694c9bf680f8559f312927c0d4eaa15fc9eR100-R105) [[2]](diffhunk://#diff-2f19b32886f05d35ec891cc468f7e8aed6872c8db3de61eb9e52880397581945R80-R91).
* Introduced `DocumentSection.TabDrag.cs` and `DocumentSectionContainer.TabDrag.cs` partials, implementing pointer-driven tab drag logic, event handling, and drag commit operations [[1]](diffhunk://#diff-ddb00aa25d852904c838d1c305c4c2c755172fec76a7e7159286714299fcd726R1-R159) [[2]](diffhunk://#diff-fbc5ae2ddf62635049d84494a03782f4f37bc60d5e9f01f76452aec41a48e397R1-R52).
* Hooked up pointer event handlers in `DocumentSection` and `DocumentSectionContainer` to support the new drag mechanism and ensure clean-up on tab removal or shutdown [[1]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00R81-R82) [[2]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00R237) [[3]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00R249-R274) [[4]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00R429) [[5]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00R716) [[6]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256R596).

**Tab Movement and Layout Fixes:**

* Enhanced tab movement logic to allow moving tabs to a specific insertion slot and improved selection restoration when a tab is removed from the source section [[1]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L512-R527) [[2]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256R548-R573).
* Added logic to detach stranded tab containers to work around a Skia-specific bug where removed tabs could leave their headers orphaned and not render correctly when re-added.

**Tab Strip Scrolling and Visibility:**

* Ensured tab strip scroll offset is clamped when tabs are removed to prevent blank gaps and clipped tabs.
* Modified the empty placeholder and tab strip visibility logic to keep the tab strip and its footer accessible even when there are no tabs.
* Set the tab strip footer minimum width to zero to improve layout flexibility.

**Toolbar and Section Layout Handling:**

* Added support for setting and re-placing a document toolbar in the tab strip footer of the rightmost section [[1]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256R23-R24) [[2]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256R172-R181).
* Improved section and splitter management to avoid unnecessary reparenting and layout issues during grid rebuilds.Add `UsesPointerDrivenTabDrag` capability to `IPlatformInfo` to identify heads where the built-in TabView drag-and-drop is unreliable (Skia). Implement `TabDragController` to handle pointer tracking, drag visuals (ghost, insertion indicator, section highlight), and drop target resolution with auto-scroll support. Disable built-in TabView drag on Skia, keep it on Windows. Fix Skia-specific layout bugs: preserve visible sections during grid rebuild to avoid scroll state reset, detach stray tab containers on removal, restore selection when the selected tab moves, and clamp tab strip scroll offset. Move the split-editor toolbar to the rightmost section's tab strip footer and add a canvas overlay for drag rendering.