### PR TITLE
Fix WKWebView snapshot scaling for macOS

### DIFF
--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -13,8 +13,8 @@ public sealed record MacWebViewSnapshot(byte[] Bytes, int Width, int Height);
 
 /// <summary>
 /// Parameters for a WKWebView snapshot. The clip rectangle (CSS pixels, in the web view's coordinate space)
-/// selects the region to capture. SnapshotWidth is the target output width in points (0 leaves the capture
-/// at native resolution). Format is "png" or "jpeg" (Quality 1-100 applies to JPEG).
+/// selects the region to capture. SnapshotWidth is the target output width in device pixels (0 leaves the
+/// capture at native resolution). Format is "png" or "jpeg" (Quality 1-100 applies to JPEG).
 /// </summary>
 public sealed record MacSnapshotRequest(
     double ClipX,
@@ -348,15 +348,16 @@ public static class MacOSWebViewInterop
     /// takeSnapshotWithConfiguration:completionHandler:], clipping to the request's rect and rendering at
     /// its SnapshotWidth, then encodes to the requested format ("png" or "jpeg", quality 1-100 for JPEG).
     /// Returns null if the snapshot does not complete within the timeout. This is the macOS replacement for
-    /// the Chrome DevTools Protocol Page.captureScreenshot, which is unavailable on WKWebView. On a Retina
-    /// display the captured pixels can be up to the backing-scale multiple of SnapshotWidth.
+    /// the Chrome DevTools Protocol Page.captureScreenshot, which is unavailable on WKWebView. SnapshotWidth
+    /// is treated as a device-pixel target, so the returned bitmap matches it on both Retina and non-Retina
+    /// displays.
     /// </summary>
     public static async Task<MacWebViewSnapshot?> TakeSnapshotAsync(IntPtr webView, MacSnapshotRequest request)
     {
         _snapshotCompletion = new TaskCompletionSource<IntPtr>();
         var completionBlock = EnsureSnapshotBlock();
 
-        var configuration = BuildSnapshotConfiguration(request);
+        var configuration = BuildSnapshotConfiguration(webView, request);
 
         var selector = GetSelector("takeSnapshotWithConfiguration:completionHandler:");
         SendMessageVoid(webView, selector, configuration, completionBlock);
@@ -389,7 +390,7 @@ public static class MacOSWebViewInterop
         }
     }
 
-    private static IntPtr BuildSnapshotConfiguration(MacSnapshotRequest request)
+    private static IntPtr BuildSnapshotConfiguration(IntPtr webView, MacSnapshotRequest request)
     {
         var configurationClass = GetClass("WKSnapshotConfiguration");
         if (configurationClass == IntPtr.Zero)
@@ -417,11 +418,46 @@ public static class MacOSWebViewInterop
 
         if (request.SnapshotWidth > 0)
         {
-            var snapshotWidthNumber = SendMessage(GetClass("NSNumber"), GetSelector("numberWithDouble:"), request.SnapshotWidth);
+            // WKSnapshotConfiguration.snapshotWidth is in points, and WebKit renders the bitmap at
+            // backingScale times that many pixels. The caller's SnapshotWidth is a device-pixel target
+            // (matching the Windows CDP contract), so convert to points by dividing out the backing scale.
+            var backingScaleFactor = GetBackingScaleFactor(webView);
+            var snapshotWidthInPoints = request.SnapshotWidth / backingScaleFactor;
+            var snapshotWidthNumber = SendMessage(GetClass("NSNumber"), GetSelector("numberWithDouble:"), snapshotWidthInPoints);
             SendMessage(configuration, GetSelector("setSnapshotWidth:"), snapshotWidthNumber);
         }
 
         return configuration;
+    }
+
+    private static double GetBackingScaleFactor(IntPtr webView)
+    {
+        // The web view's window carries the backing scale of the display it is on. Fall back to the main
+        // screen, then to 1.0, if the view is not yet attached to a window.
+        if (webView != IntPtr.Zero)
+        {
+            var window = SendMessage(webView, GetSelector("window"));
+            if (window != IntPtr.Zero)
+            {
+                var windowScale = SendMessageReturnDouble(window, GetSelector("backingScaleFactor"));
+                if (windowScale > 0)
+                {
+                    return windowScale;
+                }
+            }
+        }
+
+        var mainScreen = SendMessage(GetClass("NSScreen"), GetSelector("mainScreen"));
+        if (mainScreen != IntPtr.Zero)
+        {
+            var screenScale = SendMessageReturnDouble(mainScreen, GetSelector("backingScaleFactor"));
+            if (screenScale > 0)
+            {
+                return screenScale;
+            }
+        }
+
+        return 1.0;
     }
 
     private static MacWebViewSnapshot? ConvertNSImage(IntPtr nsImage, string format, int quality)

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -169,7 +169,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     {
         // Page.captureScreenshot (CDP) is not implemented, so snapshot the native WKWebView. The bridge resolves
         // the clip rect (viewport or selector) and a Scale that fits MaxEdge. Map that to the native snapshot:
-        // clip to the rect, render at Width * Scale points.
+        // clip to the rect, render at Width * Scale device pixels (the native path divides out the backing scale).
         if (!MacOSWebViewInterop.TryGetNativeWebViewHandle(webView.CoreWebView2, out var nativeHandle, out var detail))
         {
             throw new InvalidOperationException(


### PR DESCRIPTION
This pull request updates the macOS WKWebView snapshot logic to ensure that requested snapshot widths are interpreted as device pixels rather than points, improving consistency across Retina and non-Retina displays. The changes clarify documentation, update the snapshot configuration to convert device pixels to points using the backing scale factor, and add a helper to retrieve the correct scale factor from the web view or display.

**Snapshot width handling and device pixel scaling:**

* Updated documentation in `MacSnapshotRequest` and related comments to clarify that `SnapshotWidth` is now a device-pixel target, not points, and that the output bitmap matches the requested width on both Retina and non-Retina displays. [[1]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL16-R17) [[2]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL351-R360) [[3]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0L172-R172)
* Modified `BuildSnapshotConfiguration` to accept the `webView` handle and convert the requested `SnapshotWidth` from device pixels to points by dividing by the backing scale factor, ensuring correct rendering on all displays. [[1]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL392-R393) [[2]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL420-R462)
* Added the `GetBackingScaleFactor` helper, which retrieves the backing scale from the web view’s window or falls back to the main screen or 1.0 if unavailable.Treat `SnapshotWidth` as a device-pixel target when taking WKWebView snapshots. The macOS interop now converts that width to points using the view's backing scale, with a fallback to the main screen or 1.0 so captures match the Windows CDP contract on Retina and non-Retina displays.