### PR TITLE
Remove app icon hiding on native title bar

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
@@ -50,13 +50,6 @@ public sealed partial class ApplicationToolbar : UserControl, ITitleBar
             // background extends behind them. The caption buttons are drawn over this column by the platform.
             CaptionButtonsColumn.Width = new Microsoft.UI.Xaml.GridLength(144);
         }
-        else
-        {
-            // The native title bar already shows the app icon, so hide the duplicate icon on this toolbar
-            // and reclaim its column.
-            AppIconImage.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
-            AppIconColumn.Width = new Microsoft.UI.Xaml.GridLength(0);
-        }
 
         _messengerService = ServiceLocator.AcquireService<IMessengerService>();
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();


### PR DESCRIPTION
Remove the else branch that was hiding the application icon when using the native title bar. This logic is no longer needed as the icon visibility is now handled separately or the platform behavior has changed.