### PR TITLE
Fix focus navigation exception on Mac

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Helpers/FocusNavigationHelper.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/FocusNavigationHelper.cs
@@ -1,0 +1,23 @@
+using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
+using FocusNavigationDirection = Microsoft.UI.Xaml.Input.FocusNavigationDirection;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Keyboard focus navigation helpers shared by the views and elements that move focus in response to input.
+/// </summary>
+public static class FocusNavigationHelper
+{
+    /// <summary>
+    /// Moves keyboard focus to the next focusable element in tab order, as pressing Tab would.
+    /// </summary>
+    public static void MoveFocusToNextElement()
+    {
+        // Uno obsoletes this overload in favour of the FindNextElementOptions overload, but that overload
+        // throws for Next, Previous, and None, so this is the only FocusManager API that can move focus in
+        // tab order. Suppress the obsoletion in one place rather than at every call site.
+#pragma warning disable CS0618
+        FocusManager.TryMoveFocus(FocusNavigationDirection.Next);
+#pragma warning restore CS0618
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
@@ -164,11 +164,8 @@ public class DialogFactory : IDialogFactory
             return;
         }
 
-        var options = new FindNextElementOptions
-        {
-            SearchRoot = dialog
-        };
-        FocusManager.TryMoveFocus(FocusNavigationDirection.Next, options);
+        var firstFocusable = FocusManager.FindFirstFocusableElement(dialog) as UIElement;
+        firstFocusable?.Focus(FocusState.Programmatic);
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Forms/DropDownTextBoxElement.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Forms/DropDownTextBoxElement.cs
@@ -2,8 +2,6 @@ using Celbridge.UserInterface.Services.Forms;
 using Celbridge.UserInterface.Views.Controls;
 using System.Text.Json;
 using Windows.System;
-using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
-using FocusNavigationDirection = Microsoft.UI.Xaml.Input.FocusNavigationDirection;
 
 namespace Celbridge.UserInterface.ViewModels.Forms;
 
@@ -56,12 +54,7 @@ public partial class DropDownTextBoxElement : FormElement
             if (e.Key == VirtualKey.Enter)
             {
                 // Pressing enter moves focus to next focusable element
-                var options = new FindNextElementOptions
-                {
-                    SearchRoot = ((UIElement)sender).XamlRoot!.Content
-                };
-
-                FocusManager.TryMoveFocus(FocusNavigationDirection.Next, options);
+                FocusNavigationHelper.MoveFocusToNextElement();
 
                 e.Handled = true;
             }

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Forms/TextBoxElement.cs
@@ -1,8 +1,6 @@
 using Celbridge.UserInterface.Services.Forms;
 using System.Text.Json;
 using Windows.System;
-using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
-using FocusNavigationDirection = Microsoft.UI.Xaml.Input.FocusNavigationDirection;
 
 namespace Celbridge.UserInterface.ViewModels.Forms;
 
@@ -42,12 +40,7 @@ public partial class TextBoxElement : FormElement
             if (e.Key == VirtualKey.Enter)
             {
                 // Pressing enter moves focus to next focusable element
-                var options = new FindNextElementOptions
-                {
-                    SearchRoot = ((UIElement)sender).XamlRoot!.Content
-                };
-
-                FocusManager.TryMoveFocus(FocusNavigationDirection.Next, options);
+                FocusNavigationHelper.MoveFocusToNextElement();
 
                 e.Handled = true;
             }

--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.xaml.cs
@@ -1,7 +1,5 @@
 using Celbridge.Dialog;
 using Celbridge.Projects;
-using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
-using FocusNavigationDirection = Microsoft.UI.Xaml.Input.FocusNavigationDirection;
 
 namespace Celbridge.UserInterface.Views;
 
@@ -64,11 +62,7 @@ public sealed partial class NewProjectDialog : ContentDialog, INewProjectDialog
             e.Handled = true;
             // Move focus away from the TextBox when Enter is pressed
             // This allows the user to see validation results without submitting
-            var options = new FindNextElementOptions
-            {
-                SearchRoot = this.XamlRoot?.Content
-            };
-            FocusManager.TryMoveFocus(FocusNavigationDirection.Next, options);
+            FocusNavigationHelper.MoveFocusToNextElement();
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new helper class to standardize keyboard focus navigation and refactors several components to use this helper for moving focus to the next element. This reduces code duplication, centralizes handling of focus movement (including suppressing warnings about obsolete APIs), and simplifies the logic in multiple view and dialog classes.

Refactoring and code simplification:

* Added a new static helper class `FocusNavigationHelper` in `FocusNavigationHelper.cs`, providing a `MoveFocusToNextElement` method that encapsulates the logic for moving keyboard focus to the next focusable element, while suppressing obsoletion warnings in a single place.
* Refactored focus movement logic in `DropDownTextBoxElement.cs`, `TextBoxElement.cs`, and `NewProjectDialog.xaml.cs` to use `FocusNavigationHelper.MoveFocusToNextElement()` instead of repeating the `FocusManager.TryMoveFocus` logic at each call site. [[1]](diffhunk://#diff-6d6202379e76a1e8273282315a48c30566ba93303906fdcafb43e64a3c6b060bL59-R57) [[2]](diffhunk://#diff-e74a6be5829ce08743c68ae392957866898c4880a1cb8f4591ae374c6bdfe8a4L45-R43) [[3]](diffhunk://#diff-0af73f990dc5f051100eae35f9e9f5634ba87c73c679869f1c4537062f4eb482L67-R65)
* Removed unnecessary `using` statements for `FocusManager` and `FocusNavigationDirection` in files that now use the helper. [[1]](diffhunk://#diff-6d6202379e76a1e8273282315a48c30566ba93303906fdcafb43e64a3c6b060bL5-L6) [[2]](diffhunk://#diff-e74a6be5829ce08743c68ae392957866898c4880a1cb8f4591ae374c6bdfe8a4L4-L5) [[3]](diffhunk://#diff-0af73f990dc5f051100eae35f9e9f5634ba87c73c679869f1c4537062f4eb482L3-L4)

Focus initialization improvement:

* Updated `EnsureInitialFocus` in `DialogFactory.cs` to directly focus the first focusable element programmatically, instead of using `TryMoveFocus` with options, for more reliable initial focus behavior.Adds a shared `FocusNavigationHelper` to move focus in tab order using the only Uno-compatible `FocusManager` API, keeping the obsolete warning suppression in one place. Updates text box and dropdown form elements plus `NewProjectDialog` to use the helper on Enter key. Also changes dialog initialization to focus the first focusable control directly within the dialog instead of trying global next-focus navigation.