### PR TITLE
Rename contribution terminology to custom editor across codebase

### DIFF
--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentContentProvider.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentContentProvider.cs
@@ -2,7 +2,7 @@ namespace Celbridge.Documents;
 
 /// <summary>
 /// Generates document content on the host side for a given file resource.
-/// Used by contribution editors that render derived content (e.g., an HTML preview
+/// Used by custom editors that render derived content (e.g., an HTML preview
 /// produced from a parsed source file) rather than surfacing the raw file bytes.
 /// </summary>
 public interface IDocumentContentProvider
@@ -14,7 +14,7 @@ public interface IDocumentContentProvider
     bool CanHandle(ResourceKey fileResource);
 
     /// <summary>
-    /// Generates the content string that will be returned to the contribution editor
+    /// Generates the content string that will be returned to the custom editor
     /// via the InitializeAsync / LoadAsync RPC path. The returned string is treated
     /// as opaque by the host and is delivered verbatim to the editor's onContent callback.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Documents/IGetUtilitiesStateCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IGetUtilitiesStateCommand.cs
@@ -16,13 +16,13 @@ public record class UtilityInfo(
     bool IsShown);
 
 /// <summary>
-/// Snapshot of every available utility (built-in and contributed) produced by IGetUtilitiesStateCommand.
+/// Snapshot of every available utility (built-in and custom) produced by IGetUtilitiesStateCommand.
 /// </summary>
 public record class UtilitiesStateSnapshot(
     IReadOnlyList<UtilityInfo> Utilities);
 
 /// <summary>
-/// Read-only query that snapshots the catalog of available utilities (built-in and contributed) and their
+/// Read-only query that snapshots the catalog of available utilities (built-in and custom) and their
 /// current shown state.
 /// </summary>
 public interface IGetUtilitiesStateCommand : IExecutableCommand<UtilitiesStateSnapshot>

--- a/Source/Core/Celbridge.Foundation/Documents/IShowUtilityCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IShowUtilityCommand.cs
@@ -5,13 +5,13 @@ namespace Celbridge.Documents;
 
 /// <summary>
 /// Reveals a utility by its fully-qualified id, optionally moving it to a dock location first. Resolves the
-/// whole id space: a built-in id (BuiltInUtilityIds) selects its Utility Panel rail tab, and a contributed
+/// whole id space: a built-in id (BuiltInUtilityIds) selects its Utility Panel rail tab, and a custom
 /// utility is revealed wherever it lives. This is the single reveal entry point behind the agent tools.
 /// </summary>
 public interface IShowUtilityCommand : IExecutableCommand
 {
     /// <summary>
-    /// The id of the utility to reveal: a built-in id (e.g. "celbridge.explorer") or a contributed id.
+    /// The id of the utility to reveal: a built-in id (e.g. "celbridge.explorer") or a custom id.
     /// </summary>
     UtilityId UtilityId { get; set; }
 

--- a/Source/Core/Celbridge.Foundation/Modules/IModule.cs
+++ b/Source/Core/Celbridge.Foundation/Modules/IModule.cs
@@ -10,12 +10,12 @@ namespace Celbridge.Modules;
 public interface IModule
 {
     /// <summary>
-    /// Configures the dependency injection framework to support the types provided by the extension.
+    /// Configures the dependency injection framework to support the types provided by the module.
     /// </summary>
     void ConfigureServices(IModuleServiceCollection serviceCollection);
 
     /// <summary>
-    /// Initializes the extension during application startup.
+    /// Initializes the module during application startup.
     /// </summary>
     Result Initialize();
 

--- a/Source/Core/Celbridge.Foundation/Packages/CodeDocumentEditorContribution.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/CodeDocumentEditorContribution.cs
@@ -1,20 +1,20 @@
 namespace Celbridge.Packages;
 
 /// <summary>
-/// Preview configuration for a code extension.
+/// Preview configuration for a code editor.
 /// When present, enables the split editor with a preview panel.
 /// </summary>
 public record CodePreviewConfig
 {
     /// <summary>
     /// The preview page to load in the split editor preview panel,
-    /// relative to the extension directory (e.g., "markdown-preview/index.html").
+    /// relative to the package folder (e.g., "markdown-preview/index.html").
     /// </summary>
     public string EntryPoint { get; init; } = string.Empty;
 }
 
 /// <summary>
-/// Monaco editor configuration for code extensions.
+/// Monaco editor configuration for code editors.
 /// </summary>
 public record CodeEditorConfig
 {
@@ -34,7 +34,7 @@ public record CodeEditorConfig
     public bool? MinimapEnabled { get; init; }
 
     /// <summary>
-    /// Path to a JavaScript customization script, relative to the extension directory (e.g., "customize.js").
+    /// Path to a JavaScript customization script, relative to the package folder (e.g., "customize.js").
     /// The script is loaded after Monaco initializes and should export an
     /// activate(monaco, editor, container, celbridge) function.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Packages/CustomDocumentEditorContribution.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/CustomDocumentEditorContribution.cs
@@ -2,7 +2,7 @@ namespace Celbridge.Packages;
 
 /// <summary>
 /// A custom webView-based document editor contribution.
-/// The extension provides the entire UI via an HTML entry point.
+/// The package provides the entire UI via an HTML entry point.
 /// Communicates with the host via the IHostDocument JSON-RPC protocol.
 /// </summary>
 public partial record CustomDocumentEditorContribution : DocumentEditorContribution

--- a/Source/Core/Celbridge.Foundation/Packages/DocumentEditorContribution.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/DocumentEditorContribution.cs
@@ -4,7 +4,7 @@ namespace Celbridge.Packages;
 
 /// <summary>
 /// Base class for document editor contributions parsed from a TOML document manifest.
-/// Each extension can contribute one or more document editors via its extension.toml.
+/// Each package can contribute one or more document editors via its document manifests.
 /// Subclasses define the specific editor type and its configuration.
 /// </summary>
 public abstract partial record DocumentEditorContribution
@@ -36,7 +36,7 @@ public abstract partial record DocumentEditorContribution
     public EditorPriority Priority { get; init; }
 
     /// <summary>
-    /// Optional list of document templates provided by this extension.
+    /// Optional list of document templates provided by this package.
     /// </summary>
     public IReadOnlyList<DocumentTemplate> Templates { get; init; } = [];
 }

--- a/Source/Core/Celbridge.Foundation/Packages/DocumentFileType.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/DocumentFileType.cs
@@ -1,7 +1,7 @@
 namespace Celbridge.Packages;
 
 /// <summary>
-/// A document file type declared by an extension.
+/// A document file type declared by a package.
 /// Declares the file extension the editor handles and an optional display name or localization key
 /// shown in the Add File dialog.
 /// </summary>

--- a/Source/Core/Celbridge.Foundation/Packages/DocumentTemplate.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/DocumentTemplate.cs
@@ -1,13 +1,13 @@
 namespace Celbridge.Packages;
 
 /// <summary>
-/// A document template declared by an extension.
-/// Templates provide starter content for new files of the extension's type.
+/// A document template declared by a package.
+/// Templates provide starter content for new files of the package's file type.
 /// </summary>
 public partial record DocumentTemplate
 {
     /// <summary>
-    /// Unique identifier for this template within the extension.
+    /// Unique identifier for this template within the package.
     /// </summary>
     public string Id { get; init; } = string.Empty;
 
@@ -17,7 +17,7 @@ public partial record DocumentTemplate
     public string DisplayName { get; init; } = string.Empty;
 
     /// <summary>
-    /// Path to the template file, relative to the extension directory.
+    /// Path to the template file, relative to the package folder.
     /// </summary>
     public string TemplateFile { get; init; } = string.Empty;
 

--- a/Source/Core/Celbridge.Foundation/Server/IMcpToolBridge.cs
+++ b/Source/Core/Celbridge.Foundation/Server/IMcpToolBridge.cs
@@ -28,7 +28,7 @@ public record ToolCallResult(bool IsSuccess, string ErrorMessage, object? Value)
 
 /// <summary>
 /// Typed gateway onto the MCP tool registry, used by consumers that enumerate
-/// or invoke tools from C# (contribution editors, automation, etc.).
+/// or invoke tools from C# (custom editors, automation, etc.).
 /// </summary>
 public interface IMcpToolBridge
 {

--- a/Source/Core/Celbridge.Foundation/Settings/SettingCatalog.cs
+++ b/Source/Core/Celbridge.Foundation/Settings/SettingCatalog.cs
@@ -66,7 +66,7 @@ public static class SettingCatalog
         public static readonly SettingDescriptor<bool> IsConsoleMaximized =
             new("Layout.IsConsoleMaximized", SettingScope.Workspace, false);
 
-        // The utility id of the active rail surface (e.g. "celbridge.explorer" or a contributed id). Restored on
+        // The utility id of the active rail surface (e.g. "celbridge.explorer" or a custom id). Restored on
         // load, falling back to Explorer when the persisted id no longer resolves to a rail item.
         public static readonly SettingDescriptor<string> UtilityPanelSelectedUtility =
             new("Layout.UtilityPanelSelectedUtility", SettingScope.Workspace, "");

--- a/Source/Core/Celbridge.Foundation/WebHost/IDocumentWebViewToolBridge.cs
+++ b/Source/Core/Celbridge.Foundation/WebHost/IDocumentWebViewToolBridge.cs
@@ -140,7 +140,7 @@ public interface IDocumentWebViewToolBridge
 
     /// <summary>
     /// Registers a supported WebView with the tool bridge. Called by document views
-    /// (contribution editors and HTML viewers) once their WebView is initialized.
+    /// (custom editors and HTML viewers) once their WebView is initialized.
     /// The screenshot delegate is optional. Pass null on platforms or surfaces that
     /// do not support a native snapshot API.
     /// </summary>
@@ -158,7 +158,7 @@ public interface IDocumentWebViewToolBridge
     /// <summary>
     /// Notifies the bridge that the editor's content has finished loading and gated
     /// tool calls (eval, inspection) may dispatch. Document views call this on the
-    /// editor's readiness signal — notifyContentLoaded for contribution editors and
+    /// editor's readiness signal — notifyContentLoaded for custom editors and
     /// NavigationCompleted for the HTML viewer. Idempotent. Safe to call repeatedly
     /// and in any order relative to NotifyContentLoading. No effect if the resource
     /// is not registered.

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
@@ -4,8 +4,8 @@ using Celbridge.Search;
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// Ids for the built-in Utility Panel surfaces, in the same "{scope}.{name}" form as contributed utility ids,
-/// so one id scheme addresses every utility (built-in and contributed).
+/// Ids for the built-in Utility Panel surfaces, in the same "{scope}.{name}" form as custom utility ids,
+/// so one id scheme addresses every utility (built-in and custom).
 /// </summary>
 public static class BuiltInUtilityIds
 {
@@ -21,11 +21,11 @@ public static class BuiltInUtilityIds
 }
 
 /// <summary>
-/// A contributed utility surface hosted as a rail item in the Utility Panel. Content is the utility's panel
+/// A custom utility surface hosted as a rail item in the Utility Panel. Content is the utility's panel
 /// view (a UIElement), typed as object so this Foundation contract does not depend on the UI framework.
 /// FocusPanel gives the panel's content keyboard focus, called when its rail item is selected.
 /// </summary>
-public sealed record ContributedUtility(
+public sealed record CustomUtility(
     UtilityId UtilityId,
     string IconGlyphName,
     string Tooltip,
@@ -34,7 +34,7 @@ public sealed record ContributedUtility(
     Action FocusPanel);
 
 /// <summary>
-/// Interface for the Utility Panel, which hosts the Explorer and Search surfaces plus any contributed utilities.
+/// Interface for the Utility Panel, which hosts the Explorer and Search surfaces plus any custom utilities.
 /// </summary>
 public interface IUtilityPanel
 {
@@ -50,31 +50,31 @@ public interface IUtilityPanel
 
     /// <summary>
     /// The utility id of the surface currently active in the rail: a built-in id (BuiltInUtilityIds) for Explorer
-    /// or Search, or a contributed utility id. Empty when no rail surface is active.
+    /// or Search, or a custom utility id. Empty when no rail surface is active.
     /// </summary>
     UtilityId ActiveUtilityId { get; }
 
     /// <summary>
     /// Reveals a utility wherever it currently lives: activates its document tab when it is docked as a document,
-    /// otherwise selects its rail surface in the Utility Panel. Works for built-in and contributed utilities. A
+    /// otherwise selects its rail surface in the Utility Panel. Works for built-in and custom utilities. A
     /// no-op when no utility has that id.
     /// </summary>
     void ShowUtility(UtilityId utilityId);
 
     /// <summary>
-    /// Appends contributed utility rail items and their content hosts after the built-in items. Replaces any
+    /// Appends custom utility rail items and their content hosts after the built-in items. Replaces any
     /// previously built items. Called on project load once the utility panels have been created.
     /// </summary>
-    void BuildContributedUtilities(IReadOnlyList<ContributedUtility> utilities);
+    void BuildCustomUtilities(IReadOnlyList<CustomUtility> utilities);
 
     /// <summary>
-    /// Removes all contributed utility rail items and their content hosts. Called on project unload. Reverts
-    /// the selection to Explorer if a contributed utility was showing.
+    /// Removes all custom utility rail items and their content hosts. Called on project unload. Reverts
+    /// the selection to Explorer if a custom utility was showing.
     /// </summary>
-    void ClearContributedUtilities();
+    void ClearCustomUtilities();
 
     /// <summary>
-    /// Updates a contributed utility's rail button to reflect its current dock location. When docked as a
+    /// Updates a custom utility's rail button to reflect its current dock location. When docked as a
     /// Document the button shows a docked cue and its click activates documentResource's tab; when in the
     /// UtilityPanel the button returns to normal and its click shows the panel surface. documentResource is
     /// ignored for the UtilityPanel location.

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
@@ -14,7 +14,7 @@ public interface IUtilityService
     /// Creates each utility as a persistent workspace surface and returns the rail tabs describing them. Each
     /// utility is owned by this service until the workspace unloads. Contributions are given in display order.
     /// </summary>
-    Task<IReadOnlyList<ContributedUtility>> CreateUtilitiesAsync(IReadOnlyList<CustomDocumentEditorContribution> contributions);
+    Task<IReadOnlyList<CustomUtility>> CreateUtilitiesAsync(IReadOnlyList<CustomDocumentEditorContribution> contributions);
 
     /// <summary>
     /// Restores a utility that was docked as a document in the previous session into a document tab at the given

--- a/Source/Core/Celbridge.Foundation/Workspace/LayoutTypes.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/LayoutTypes.cs
@@ -36,9 +36,9 @@ public enum WorkspacePanel
     Console,
 
     /// <summary>
-    /// The contributed-utility surface in the Utility Panel (Explorer and Search have their own values).
+    /// The custom-utility surface in the Utility Panel (Explorer and Search have their own values).
     /// </summary>
-    Utility
+    CustomUtility
 }
 
 /// <summary>

--- a/Source/Core/Celbridge.Foundation/Workspace/UtilityId.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/UtilityId.cs
@@ -1,9 +1,9 @@
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// A strongly-typed identifier for a utility, built-in or contributed, in "{scope}.{name}" form (e.g.
+/// A strongly-typed identifier for a utility, built-in or custom, in "{scope}.{name}" form (e.g.
 /// "celbridge.explorer", "acme.notepad"). The same value addresses a utility on the rail, as a docked document,
-/// and across the agent tools. A contributed utility's id equals its document editor id. Empty is the
+/// and across the agent tools. A custom utility's id equals its document editor id. Empty is the
 /// "no utility" value.
 /// </summary>
 public readonly struct UtilityId : IEquatable<UtilityId>
@@ -27,7 +27,7 @@ public readonly struct UtilityId : IEquatable<UtilityId>
 
     /// <summary>
     /// Builds a utility id from a package name and document id, as "{packageName}.{documentId}". Built-in and
-    /// contributed utilities share this form.
+    /// custom utilities share this form.
     /// </summary>
     public static UtilityId Create(string packageName, string documentId)
     {

--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
@@ -43,7 +43,7 @@ public record PanelFocusChangedMessage(WorkspacePanel FocusedPanel);
 
 /// <summary>
 /// Sent when the surface shown in the Utility Panel rail changes. UtilityId is the fully-qualified id of the
-/// now-active utility (a built-in id such as "celbridge.explorer", or a contributed id), or empty when none.
+/// now-active utility (a built-in id such as "celbridge.explorer", or a custom id), or empty when none.
 /// </summary>
 public record ActiveUtilityChangedMessage(string UtilityId);
 

--- a/Source/Core/Celbridge.Host/Services/IHostContext.cs
+++ b/Source/Core/Celbridge.Host/Services/IHostContext.cs
@@ -8,7 +8,7 @@ public static class ContextRpcMethods
 }
 
 /// <summary>
-/// RPC service interface for retrieving the contribution editor's capability context.
+/// RPC service interface for retrieving the custom editor's capability context.
 /// </summary>
 public interface IHostContext
 {

--- a/Source/Core/Celbridge.Host/Services/PackageToolsHandler.cs
+++ b/Source/Core/Celbridge.Host/Services/PackageToolsHandler.cs
@@ -25,12 +25,12 @@ public static class ToolRpcErrorCodes
 /// Per-WebView RPC target for tools/list and tools/call, gated by a package's
 /// [permissions] tools allowlist.
 /// </summary>
-public sealed class ContributionToolsHandler
+public sealed class PackageToolsHandler
 {
     private readonly IMcpToolBridge _bridge;
     private readonly IReadOnlyList<string> _allowedPatterns;
 
-    public ContributionToolsHandler(IMcpToolBridge bridge, IReadOnlyList<string> allowedPatterns)
+    public PackageToolsHandler(IMcpToolBridge bridge, IReadOnlyList<string> allowedPatterns)
     {
         _bridge = bridge;
         _allowedPatterns = allowedPatterns;
@@ -46,7 +46,7 @@ public sealed class ContributionToolsHandler
 
         foreach (var tool in allTools)
         {
-            if (IsContributionRestricted(tool.Alias))
+            if (IsCustomEditorRestricted(tool.Alias))
             {
                 continue;
             }
@@ -73,11 +73,11 @@ public sealed class ContributionToolsHandler
 
         // The webview_* namespace is reserved for the MCP path. Blocking it here
         // (regardless of the package's permitted tools) closes the
-        // cross-document attack vector where a contribution editor's JS could
+        // cross-document attack vector where a custom editor's JS could
         // call webview.eval against another open document.
-        if (IsContributionRestricted(name))
+        if (IsCustomEditorRestricted(name))
         {
-            throw new LocalRpcException($"Tool '{name}' is not accessible from contribution editors")
+            throw new LocalRpcException($"Tool '{name}' is not accessible from custom editors")
             {
                 ErrorCode = ToolRpcErrorCodes.ToolDenied
             };
@@ -110,11 +110,11 @@ public sealed class ContributionToolsHandler
 
     /// <summary>
     /// Returns true if the tool name belongs to a namespace that is forbidden inside
-    /// contribution WebViews. Currently this is the webview_* namespace, which is
+    /// custom editor WebViews. Currently this is the webview_* namespace, which is
     /// available on the MCP path only. Both MCP-style names (webview_eval) and alias
     /// dotted names (webview.eval) are matched.
     /// </summary>
-    private static bool IsContributionRestricted(string name)
+    private static bool IsCustomEditorRestricted(string name)
     {
         return name.StartsWith("webview.", StringComparison.Ordinal)
             || name.StartsWith("webview_", StringComparison.Ordinal);

--- a/Source/Core/Celbridge.Host/Services/RpcTypes.cs
+++ b/Source/Core/Celbridge.Host/Services/RpcTypes.cs
@@ -12,7 +12,7 @@ public record DocumentMetadata(string FilePath, string ResourceKey, string FileN
 public record InitializeResult(string Content, DocumentMetadata Metadata, string? EditorStateJson = null);
 
 /// <summary>
-/// The host capability context for a contribution editor: the resolved tool allowlist, the package's
+/// The host capability context for a custom editor: the resolved tool allowlist, the package's
 /// secrets, and its options.
 /// </summary>
 public record CelbridgeContext(

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/utility_documents.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/utility_documents.md
@@ -86,8 +86,8 @@ A utility persists through the standard editable-save path: the WebView calls `c
 
 ## Agent interaction
 
-- `app_list_utilities` lists every available utility — the built-in Explorer and Search plus contributed utilities — with each one's id, display name, `location` (`"panel"` or `"document"`, its current dock location), and whether it is currently shown.
-- `app_show_utility` reveals a utility by id wherever it currently lives: it selects a utility's rail tab when it is in the panel, or activates its document tab when it is docked as a document. Pass an optional `location` (`"panel"` or `"document"`) to move it there first. A contributed utility's id is `{packageName}.{documentId}`.
+- `app_list_utilities` lists every available utility — the built-in Explorer and Search plus custom utilities — with each one's id, display name, `location` (`"panel"` or `"document"`, its current dock location), and whether it is currently shown.
+- `app_show_utility` reveals a utility by id wherever it currently lives: it selects a utility's rail tab when it is in the panel, or activates its document tab when it is docked as a document. Pass an optional `location` (`"panel"` or `"document"`) to move it there first. A custom utility's id is `{packageName}.{documentId}`.
 - `app_get_state` reports `activeUtility`, the id of the surface currently shown in the Utility Panel rail.
 - `app_spotlight` can point at a utility's button: `{utilityId}-utility-button` for its rail item in the Utility Panel.
 - `utils:` is a registered root, so `file.*` tools can read and write a utility's backing file when the package declares `file.*` under `[permissions] tools`. This is useful for preparing or inspecting a utility's state. The editor's own `client.document.save`/`load` contract needs no permission — it is framework-level, distinct from the `cel.*` tool proxies.

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/workspace_panels.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/workspace_panels.md
@@ -12,7 +12,7 @@ The left sidebar is the **Utility Panel**: an icon rail switches its content bet
 
 ## Utilities
 
-A utility is an auxiliary surface a package contributes — a colour picker, a scratchpad, a process view. It lives as a rail item in the Utility Panel alongside Explorer and Search, and the user can dock it into a document tab and back into the panel at will (the same surface, moved, not a copy). Use `app_list_utilities` to see every utility (built-in and contributed) with its current `location` (panel or document), and `app_show_utility` to reveal one by id wherever it currently is (optionally moving it to a `location` first). See `utility_documents` for how they are authored.
+A utility is an auxiliary surface a package contributes — a colour picker, a scratchpad, a process view. It lives as a rail item in the Utility Panel alongside Explorer and Search, and the user can dock it into a document tab and back into the panel at will (the same surface, moved, not a copy). Use `app_list_utilities` to see every utility (built-in and custom) with its current `location` (panel or document), and `app_show_utility` to reveal one by id wherever it currently is (optionally moving it to a `location` first). See `utility_documents` for how they are authored.
 
 ## Resolving ambiguous file references
 

--- a/Source/Core/Celbridge.Tools/Guides/Tools/app_list_utilities.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/app_list_utilities.md
@@ -1,19 +1,19 @@
 # app_list_utilities
 
-Lists every utility the app can show: the built-in Utility Panel surfaces (Explorer, Search) and any package-contributed utilities. Use it to discover what utilities exist and their ids before calling `app_show_utility`, and to see how each is currently presented and which one the user is looking at.
+Lists every utility the app can show: the built-in Utility Panel surfaces (Explorer, Search) and any custom utilities. Use it to discover what utilities exist and their ids before calling `app_show_utility`, and to see how each is currently presented and which one the user is looking at.
 
 `app_get_state` reports only which single utility is currently active in the Utility Panel rail; this tool is the full catalog.
 
 ## When to call it
 
-Before `app_show_utility`, to learn the valid ids. Also when the user asks what a project offers, or which panels are available: contributed utilities vary per project, so this list is not fixed.
+Before `app_show_utility`, to learn the valid ids. Also when the user asks what a project offers, or which panels are available: custom utilities vary per project, so this list is not fixed.
 
 ## Returns
 
 A JSON object with one field:
 
 - `utilities` (array) — every available utility. Each entry has:
-  - `utilityId` (string) — the id to pass to `app_show_utility` (e.g. `celbridge.explorer`, or `{packageName}.{documentId}` for a contributed one).
+  - `utilityId` (string) — the id to pass to `app_show_utility` (e.g. `celbridge.explorer`, or `{packageName}.{documentId}` for a custom one).
   - `displayName` (string) — the human-readable, localized name.
   - `location` (string) — the utility's current dock location: `"panel"` when it is a rail surface in the Utility Panel, or `"document"` when the user has docked it into a document tab. A utility can move between the two at runtime; the built-in Explorer and Search are always `"panel"`.
   - `isShown` (bool) — whether the utility is currently surfaced to the user: for a `panel`, whether it is the active rail tab; for a `document`, whether its tab is the active document.

--- a/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
@@ -1,6 +1,6 @@
 # app_show_utility
 
-Reveals a utility by its id, optionally moving it to a dock location first. Utilities are auxiliary surfaces the app hosts alongside the user's documents: the built-in Explorer and Search live in the Utility Panel rail on the left, and contributed utilities live there too until the user docks one into a document tab. This one tool reveals a utility wherever it currently is, so you do not need to know where it lives to bring it up.
+Reveals a utility by its id, optionally moving it to a dock location first. Utilities are auxiliary surfaces the app hosts alongside the user's documents: the built-in Explorer and Search live in the Utility Panel rail on the left, and custom utilities live there too until the user docks one into a document tab. This one tool reveals a utility wherever it currently is, so you do not need to know where it lives to bring it up.
 
 Call `app_list_utilities` first to discover the valid ids, each utility's current `location`, and which are already shown.
 
@@ -8,12 +8,12 @@ Call `app_list_utilities` first to discover the valid ids, each utility's curren
 
 - `utilityId` — the id of the utility to show. Two forms, one scheme:
   - Built-in Utility Panel surfaces: `celbridge.explorer` and `celbridge.search`.
-  - Package-contributed utilities: `{packageName}.{documentId}` (the same id `app_list_utilities` reports).
+  - Custom utilities: `{packageName}.{documentId}` (the same id `app_list_utilities` reports).
 - `location` (optional) — a dock location to move the utility to before revealing it: `"panel"` (the Utility Panel rail) or `"document"` (a document tab). Omit to reveal the utility wherever it currently is without moving it. Ignored for the built-in utilities, which are always in the panel.
 
 ## Behaviour
 
-- With no `location`, the tool reveals the utility where it already lives: a utility in the **panel** has its rail tab selected (revealing the panel if another tab was showing); a utility docked as a **document** has its tab activated and brought to the front. A contributed utility's backing file is seeded on first reveal.
+- With no `location`, the tool reveals the utility where it already lives: a utility in the **panel** has its rail tab selected (revealing the panel if another tab was showing); a utility docked as a **document** has its tab activated and brought to the front. A custom utility's backing file is seeded on first reveal.
 - With `location`, the utility is first moved to that dock location — reparenting its single live WebView, keeping all its state — and then revealed there. Moving to `"document"` docks it into the active document's section; moving to `"panel"` returns it to the rail.
 
 ## Gotchas
@@ -21,4 +21,4 @@ Call `app_list_utilities` first to discover the valid ids, each utility's curren
 - An unknown id returns an error. Use `app_list_utilities` to get the exact ids rather than guessing.
 - An invalid `location` (anything other than `"panel"` or `"document"`) returns an error.
 - Revealing a utility that is already at the requested location is a no-op (it stays put, with a brief highlight when it is a document).
-- This tool reveals or relocates a utility; it never closes or destroys one. A contributed utility is never destroyed — closing its document tab docks it back into the Utility Panel rather than closing it.
+- This tool reveals or relocates a utility; it never closes or destroys one. A custom utility is never destroyed — closing its document tab docks it back into the Utility Panel rather than closing it.

--- a/Source/Core/Celbridge.Tools/Tools/App/AppTools.ListUtilities.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppTools.ListUtilities.cs
@@ -17,14 +17,14 @@ public record class UtilityListEntry(
     bool IsShown);
 
 /// <summary>
-/// Result returned by app_list_utilities: the catalog of every available utility, built-in and contributed.
+/// Result returned by app_list_utilities: the catalog of every available utility, built-in and custom.
 /// </summary>
 public record class UtilitiesListResult(
     IReadOnlyList<UtilityListEntry> Utilities);
 
 public partial class AppTools
 {
-    /// <summary>List every available utility (built-in and contributed) with its shown state.</summary>
+    /// <summary>List every available utility (built-in and custom) with its shown state.</summary>
     [McpServerTool(Name = "app_list_utilities", ReadOnly = true, Idempotent = true)]
     [ToolAlias("app.list_utilities")]
     [RelatedGuides("workspace_panels")]

--- a/Source/Core/Celbridge.Tools/Tools/App/AppTools.ShowUtility.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppTools.ShowUtility.cs
@@ -8,7 +8,7 @@ namespace Celbridge.Tools;
 public partial class AppTools
 {
     /// <summary>Show a utility by id: reveal it where it is, or move it to a dock location first.</summary>
-    /// <param name="utilityId">The utility to show: a built-in id ("celbridge.explorer", "celbridge.search") or a contributed id in "{packageName}.{documentId}" form.</param>
+    /// <param name="utilityId">The utility to show: a built-in id ("celbridge.explorer", "celbridge.search") or a custom id in "{packageName}.{documentId}" form.</param>
     /// <param name="location">Optional dock location to move the utility to before revealing it: "panel" (the Utility Panel rail) or "document" (a document tab). Omit to reveal the utility wherever it currently is. Ignored for the built-in utilities, which are always in the panel.</param>
     [McpServerTool(Name = "app_show_utility")]
     [ToolAlias("app.show_utility")]

--- a/Source/Core/Celbridge.Tools/Tools/WebView/WebViewTools.cs
+++ b/Source/Core/Celbridge.Tools/Tools/WebView/WebViewTools.cs
@@ -3,7 +3,7 @@ using ModelContextProtocol.Server;
 namespace Celbridge.Tools;
 
 /// <summary>
-/// MCP tools for inspecting and exercising contribution editor and HTML viewer
+/// MCP tools for inspecting and exercising custom editor and HTML viewer
 /// WebViews. Provides agents authoring custom editors with a feedback loop:
 /// reload after a package edit, evaluate JavaScript, and inspect DOM, console, and network state.
 /// </summary>

--- a/Source/Core/Celbridge.WebHost/ICustomEditorLoader.cs
+++ b/Source/Core/Celbridge.WebHost/ICustomEditorLoader.cs
@@ -3,11 +3,11 @@ using Celbridge.Packages;
 namespace Celbridge.WebHost;
 
 /// <summary>
-/// Loads a contribution editor's entry page into its WebView and declares the host-channel transport and
+/// Loads a custom editor's entry page into its WebView and declares the host-channel transport and
 /// navigation origin that page can reach. The default loads every editor over the loopback file server. A
 /// package may supply a custom loader for content that must load under a different origin.
 /// </summary>
-public interface IContributionEditorLoader
+public interface ICustomEditorLoader
 {
     /// <summary>
     /// True when this loader handles the given package. The loopback default matches every package and is
@@ -23,17 +23,17 @@ public interface IContributionEditorLoader
     /// <summary>
     /// The origin prefix the editor is pinned to. The view cancels any navigation outside it.
     /// </summary>
-    string GetAllowedNavigationOrigin(ContributionEditorLoadRequest request);
+    string GetAllowedNavigationOrigin(CustomEditorLoadRequest request);
 
     /// <summary>
     /// Loads the editor's entry page, owning any platform-specific hosting needed to place it under its
     /// origin.
     /// </summary>
-    Task LoadAsync(ContributionEditorLoadRequest request);
+    Task LoadAsync(CustomEditorLoadRequest request);
 }
 
 /// <summary>
-/// The transport a contribution editor's page uses to reach the Celbridge host.
+/// The transport a custom editor's page uses to reach the Celbridge host.
 /// </summary>
 public enum HostChannelTransport
 {
@@ -50,10 +50,10 @@ public enum HostChannelTransport
 }
 
 /// <summary>
-/// The inputs a loader needs to place a contribution editor's entry page into its WebView. The view has
+/// The inputs a loader needs to place a custom editor's entry page into its WebView. The view has
 /// already created the control and brought up its CoreWebView2 before the loader runs.
 /// </summary>
-public sealed record ContributionEditorLoadRequest(
+public sealed record CustomEditorLoadRequest(
     WebView2 WebView,
     PackageInfo Package,
     string PackageUrlName,

--- a/Source/Core/Celbridge.WebHost/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.WebHost/ServiceConfiguration.cs
@@ -16,7 +16,7 @@ public static class ServiceConfiguration
 
         // The loopback default is registered first, so it is the fallback loader. A module may register a
         // custom loader, which resolves ahead of it (the view picks the last matching loader).
-        services.AddSingleton<IContributionEditorLoader, LoopbackContributionEditorLoader>();
+        services.AddSingleton<ICustomEditorLoader, LoopbackCustomEditorLoader>();
 
         // The per-platform WebView adapter (WebView2 SDK on Windows, Skia/native fallbacks elsewhere).
         Platform.PlatformServiceConfiguration.ConfigureServices(services);

--- a/Source/Core/Celbridge.WebHost/Services/DocumentWebViewToolBridge.cs
+++ b/Source/Core/Celbridge.WebHost/Services/DocumentWebViewToolBridge.cs
@@ -744,7 +744,7 @@ public partial class DocumentWebViewToolBridge : IDocumentWebViewToolBridge
                 var completed = await Task.WhenAny(readyTask, delayTask);
                 if (completed != readyTask)
                 {
-                    return Result.Fail($"Timed out after {timeout.TotalSeconds:0.#}s waiting for the editor's content-ready signal. The editor must call celbridge.notifyContentLoaded() (contribution editors) or finish navigation (HTML viewer) before WebView tools can dispatch.");
+                    return Result.Fail($"Timed out after {timeout.TotalSeconds:0.#}s waiting for the editor's content-ready signal. The editor must call celbridge.notifyContentLoaded() (custom editors) or finish navigation (HTML viewer) before WebView tools can dispatch.");
                 }
 
                 cts.Cancel();

--- a/Source/Core/Celbridge.WebHost/Services/LoopbackCustomEditorLoader.cs
+++ b/Source/Core/Celbridge.WebHost/Services/LoopbackCustomEditorLoader.cs
@@ -3,14 +3,14 @@ using Celbridge.Server;
 
 namespace Celbridge.WebHost.Services;
 
-// Default contribution editor loader: serves the editor from the loopback file server over the WebSocket
+// Default custom editor loader: serves the editor from the loopback file server over the WebSocket
 // host channel. Matches every package and is resolved as the fallback, so it hosts any editor a custom
 // loader does not claim.
-internal sealed class LoopbackContributionEditorLoader : IContributionEditorLoader
+internal sealed class LoopbackCustomEditorLoader : ICustomEditorLoader
 {
     private readonly IFileServer _fileServer;
 
-    public LoopbackContributionEditorLoader(IFileServer fileServer)
+    public LoopbackCustomEditorLoader(IFileServer fileServer)
     {
         _fileServer = fileServer;
     }
@@ -19,12 +19,12 @@ internal sealed class LoopbackContributionEditorLoader : IContributionEditorLoad
 
     public HostChannelTransport GetTransport(PackageInfo package) => HostChannelTransport.LoopbackWebSocket;
 
-    public string GetAllowedNavigationOrigin(ContributionEditorLoadRequest request)
+    public string GetAllowedNavigationOrigin(CustomEditorLoadRequest request)
     {
         return _fileServer.GetPackageUrl(request.PackageUrlName, string.Empty);
     }
 
-    public Task LoadAsync(ContributionEditorLoadRequest request)
+    public Task LoadAsync(CustomEditorLoadRequest request)
     {
         var entryUrl = _fileServer.GetPackageUrl(request.PackageUrlName, request.EntryPoint);
         var navigationUrl = HostChannelFactory.AppendConnectionToken(entryUrl, request.ConnectionToken);

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/tools-api.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/tools-api.js
@@ -1,6 +1,6 @@
-// Tools API: MCP tool dispatch wrapper and dynamic `cel.*` proxy for contribution editors.
+// Tools API: MCP tool dispatch wrapper and dynamic `cel.*` proxy for custom editors.
 //
-// Contribution packages declare the tools they need via `[permissions] tools` in package.toml.
+// Packages declare the tools they need via `[permissions] tools` in package.toml.
 // The client fetches the resolved allowlist over the bridge via `host/getContext`. This module
 // builds a dynamic proxy that exposes only the allowed tools as
 // `celbridge.cel.<namespace>.<tool>(...)`.

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.js
@@ -285,7 +285,7 @@ export class Celbridge {
      * Editor state contract: the string returned by `onRequestState` must survive both
      * external-reload cycles (host calls `onRequestState` -> replaces content -> calls
      * `onRestoreState` with the same string) and session restore (host persists the string
-     * as EditorStateJson and replays it on the next session). Contributions define their
+     * as EditorStateJson and replays it on the next session). Editors define their
      * own schema for this string. The host treats it as opaque. Anything the editor needs
      * to reconstruct view state (scroll position, selection, pending unsaved edits, etc.)
      * must be encoded here.

--- a/Source/Modules/Celbridge.Spreadsheet/Module.cs
+++ b/Source/Modules/Celbridge.Spreadsheet/Module.cs
@@ -32,8 +32,8 @@ public class Module : IModule
         services.AddSingleton<ISpreadsheetReader, SpreadsheetReader>();
 
         // Hosts the SpreadJS editor under its synthetic origin. Registered after the core loopback default,
-        // so the contribution view resolves it ahead of the default for the spreadsheet package.
-        services.AddSingleton<IContributionEditorLoader, SyntheticOriginEditorLoader>();
+        // so the custom view resolves it ahead of the default for the spreadsheet package.
+        services.AddSingleton<ICustomEditorLoader, SyntheticOriginEditorLoader>();
 
         services.AddTransient<IWriteCellsCommand, WriteCellsCommand>();
         services.AddTransient<IAppendRowsCommand, AppendRowsCommand>();

--- a/Source/Modules/Celbridge.Spreadsheet/Services/SyntheticOriginEditorLoader.cs
+++ b/Source/Modules/Celbridge.Spreadsheet/Services/SyntheticOriginEditorLoader.cs
@@ -12,7 +12,7 @@ namespace Celbridge.Spreadsheet.Services;
 /// a WebView2 virtual host on the Windows heads, native loadHTMLString on the macOS and Linux Skia heads.
 /// Either way the page is a faked origin; its lib and the shared client resolve cross-origin.
 /// </summary>
-public sealed class SyntheticOriginEditorLoader : IContributionEditorLoader
+public sealed class SyntheticOriginEditorLoader : ICustomEditorLoader
 {
     private const string SpreadsheetPackageName = "celbridge.spreadsheet";
     private const string SyntheticHost = "spreadjs.celbridge";
@@ -40,9 +40,9 @@ public sealed class SyntheticOriginEditorLoader : IContributionEditorLoader
 
     // http (not https) on every head: the faked-origin page must open the insecure loopback WebSocket and
     // fetch the http loopback assets without a mixed-content block. The licence validates on the hostname.
-    public string GetAllowedNavigationOrigin(ContributionEditorLoadRequest request) => $"http://{SyntheticHost}/";
+    public string GetAllowedNavigationOrigin(CustomEditorLoadRequest request) => $"http://{SyntheticHost}/";
 
-    public async Task LoadAsync(ContributionEditorLoadRequest request)
+    public async Task LoadAsync(CustomEditorLoadRequest request)
     {
         // The faked-origin page fetches its lib and the shared client cross-origin from the loopback file
         // server, so allow that specific origin to read /assets/ and /package/. No effect on the Windows
@@ -83,7 +83,7 @@ public sealed class SyntheticOriginEditorLoader : IContributionEditorLoader
     /// loadHTMLString ignores a base element), and the WebSocket host channel URL is injected (the faked-origin
     /// page cannot derive it from its own location).
     /// </summary>
-    private async Task<string> BuildSyntheticOriginHtmlAsync(ContributionEditorLoadRequest request)
+    private async Task<string> BuildSyntheticOriginHtmlAsync(CustomEditorLoadRequest request)
     {
         var packageBaseUrl = _fileServer.GetPackageUrl(request.PackageUrlName, string.Empty);
         var assetsBaseUrl = $"http://127.0.0.1:{request.ServerPort}/assets/";

--- a/Source/Tests/Documents/GetUtilitiesStateCommandTests.cs
+++ b/Source/Tests/Documents/GetUtilitiesStateCommandTests.cs
@@ -15,7 +15,7 @@ namespace Celbridge.Tests.Documents;
 public class GetUtilitiesStateCommandTests
 {
     [Test]
-    public async Task Execute_ReturnsBuiltInsAndContributedUtilitiesWithShownState()
+    public async Task Execute_ReturnsBuiltInsAndCustomUtilitiesWithShownState()
     {
         var panelUtility = new CustomDocumentEditorContribution
         {

--- a/Source/Tests/Host/PackageToolsHandlerTests.cs
+++ b/Source/Tests/Host/PackageToolsHandlerTests.cs
@@ -6,7 +6,7 @@ using StreamJsonRpc;
 namespace Celbridge.Tests.Host;
 
 [TestFixture]
-public class ContributionToolsHandlerTests
+public class PackageToolsHandlerTests
 {
     [Test]
     public async Task ListToolsAsync_FiltersByAllowlist()
@@ -20,7 +20,7 @@ public class ContributionToolsHandlerTests
                 Descriptor("file_read",       "file.read")
             }
         };
-        var handler = new ContributionToolsHandler(bridge, new[] { "app.*", "document.open" });
+        var handler = new PackageToolsHandler(bridge, new[] { "app.*", "document.open" });
 
         var result = await handler.ListToolsAsync();
 
@@ -39,7 +39,7 @@ public class ContributionToolsHandlerTests
                 Descriptor("webview_reload",  "webview.reload")
             }
         };
-        var handler = new ContributionToolsHandler(bridge, new[] { "*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "*" });
 
         var result = await handler.ListToolsAsync();
 
@@ -50,7 +50,7 @@ public class ContributionToolsHandlerTests
     public void CallToolAsync_WebViewNamespace_ThrowsDeniedRegardlessOfAllowlist()
     {
         var bridge = new StubToolBridge();
-        var handler = new ContributionToolsHandler(bridge, new[] { "*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "*" });
 
         Func<Task> act = () => handler.CallToolAsync("webview.eval", (JsonElement?)null);
 
@@ -67,7 +67,7 @@ public class ContributionToolsHandlerTests
     public void CallToolAsync_WebViewMcpStyleName_ThrowsDenied()
     {
         var bridge = new StubToolBridge();
-        var handler = new ContributionToolsHandler(bridge, new[] { "*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "*" });
 
         Func<Task> act = () => handler.CallToolAsync("webview_eval", (JsonElement?)null);
 
@@ -85,7 +85,7 @@ public class ContributionToolsHandlerTests
         {
             CallResult = new ToolCallResult(true, string.Empty, "0.2.5")
         };
-        var handler = new ContributionToolsHandler(bridge, new[] { "app.*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "app.*" });
 
         var result = await handler.CallToolAsync("app.get_state", (JsonElement?)null);
 
@@ -98,7 +98,7 @@ public class ContributionToolsHandlerTests
     public void CallToolAsync_DeniedTool_ThrowsLocalRpcExceptionWithDeniedCode()
     {
         var bridge = new StubToolBridge();
-        var handler = new ContributionToolsHandler(bridge, new[] { "app.*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "app.*" });
 
         Func<Task> act = () => handler.CallToolAsync("file.read", (JsonElement?)null);
 
@@ -115,7 +115,7 @@ public class ContributionToolsHandlerTests
     public void CallToolAsync_EmptyName_ThrowsInvalidArgs()
     {
         var bridge = new StubToolBridge();
-        var handler = new ContributionToolsHandler(bridge, new[] { "*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "*" });
 
         Func<Task> act = () => handler.CallToolAsync("", (JsonElement?)null);
 
@@ -133,7 +133,7 @@ public class ContributionToolsHandlerTests
         {
             CallThrows = new InvalidOperationException("boom")
         };
-        var handler = new ContributionToolsHandler(bridge, new[] { "*" });
+        var handler = new PackageToolsHandler(bridge, new[] { "*" });
 
         Func<Task> act = () => handler.CallToolAsync("app.get_state", (JsonElement?)null);
 
@@ -147,7 +147,7 @@ public class ContributionToolsHandlerTests
     [Test]
     public void AllowedPatterns_IsSurfaced()
     {
-        var handler = new ContributionToolsHandler(new StubToolBridge(), new[] { "app.*", "file.read" });
+        var handler = new PackageToolsHandler(new StubToolBridge(), new[] { "app.*", "file.read" });
         handler.AllowedPatterns.Should().Equal("app.*", "file.read");
     }
 

--- a/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
+++ b/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
@@ -110,12 +110,12 @@ public class UtilityPanelViewModelTests
     }
 
     [Test]
-    public void ContributedUtility_FocusReportedAsUtility_LightsAccent()
+    public void CustomUtility_FocusReportedAsUtility_LightsAccent()
     {
-        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.Utility);
+        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.CustomUtility);
 
         _viewModel.SelectUtility(NotepadUtilityId);
-        _viewModel.ReconcileFocus(WorkspacePanel.Utility);
+        _viewModel.ReconcileFocus(WorkspacePanel.CustomUtility);
 
         notepad.IsSelected.Should().BeTrue();
         notepad.IsFocused.Should().BeTrue();
@@ -125,7 +125,7 @@ public class UtilityPanelViewModelTests
     [Test]
     public void SetDocked_MarksTheItemDocked()
     {
-        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.Utility);
+        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.CustomUtility);
 
         _viewModel.SetDocked(NotepadUtilityId, true);
         notepad.IsDocked.Should().BeTrue();
@@ -137,7 +137,7 @@ public class UtilityPanelViewModelTests
     [Test]
     public void RemoveItem_RemovesItFromTheRail()
     {
-        _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.Utility);
+        _viewModel.AddItem(NotepadUtilityId, WorkspacePanel.CustomUtility);
         _viewModel.Items.Should().HaveCount(3);
 
         _viewModel.RemoveItem(NotepadUtilityId);

--- a/Source/Tests/WebHost/WebViewServiceSupportTests.cs
+++ b/Source/Tests/WebHost/WebViewServiceSupportTests.cs
@@ -46,7 +46,7 @@ public class WebViewServiceSupportTests
     }
 
     [Test]
-    public void GetWebViewToolSupport_ContributionEditorWithDevToolsBlocked_NamesThePackageAndPolicy()
+    public void GetWebViewToolSupport_CustomEditorWithDevToolsBlocked_NamesThePackageAndPolicy()
     {
         var resource = new ResourceKey("budget.spreadsheet");
         var editorId = "celbridge.spreadsheet.spreadsheet-document";

--- a/Source/Workspace/Celbridge.Documents/Commands/GetUtilitiesStateCommand.cs
+++ b/Source/Workspace/Celbridge.Documents/Commands/GetUtilitiesStateCommand.cs
@@ -76,7 +76,7 @@ public class GetUtilitiesStateCommand : CommandBase, IGetUtilitiesStateCommand
             Location: DockLocation.UtilityPanel,
             IsShown: activeUtilityId == BuiltInUtilityIds.Search));
 
-        // Package-contributed utilities. Each is a persistent surface, in the rail or docked as a document tab.
+        // Package-custom utilities. Each is a persistent surface, in the rail or docked as a document tab.
         // When it is a document it is shown if its tab is the active document; when it is in the panel it is
         // shown if it is the active rail surface.
         foreach (var contribution in packageService.GetAllDocumentEditors())

--- a/Source/Workspace/Celbridge.Documents/ServiceConfiguration.cs
+++ b/Source/Workspace/Celbridge.Documents/ServiceConfiguration.cs
@@ -23,8 +23,8 @@ public static class ServiceConfiguration
 
         services.AddTransient<IDocumentsPanel, DocumentsPanel>();
         services.AddTransient<TextBoxDocumentView>();
-        services.AddTransient<ContributionDocumentView>();
-        services.AddTransient<ContributionPanelView>();
+        services.AddTransient<CustomDocumentView>();
+        services.AddTransient<CustomUtilityView>();
 
         //
         // Register view models
@@ -33,7 +33,7 @@ public static class ServiceConfiguration
         services.AddTransient<DocumentsPanelViewModel>();
         services.AddTransient<DocumentTabViewModel>();
         services.AddTransient<DefaultDocumentViewModel>();
-        services.AddTransient<ContributionDocumentViewModel>();
+        services.AddTransient<CustomDocumentViewModel>();
 
         //
         // Register commands

--- a/Source/Workspace/Celbridge.Documents/Services/CustomDocumentViewFactory.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/CustomDocumentViewFactory.cs
@@ -5,8 +5,8 @@ using Celbridge.Settings;
 namespace Celbridge.Documents.Services;
 
 /// <summary>
-/// Factory for creating ContributionDocumentView instances for custom (WebView-based)
-/// extension editors. One instance per discovered CustomDocumentEditorContribution.
+/// Factory for creating CustomDocumentView instances for custom (WebView-based)
+/// editors. One instance per discovered CustomDocumentEditorContribution.
 /// </summary>
 public class CustomDocumentViewFactory : DocumentEditorFactoryBase
 {
@@ -75,7 +75,7 @@ public class CustomDocumentViewFactory : DocumentEditorFactoryBase
 
     public override Result<IDocumentView> CreateDocumentView(ResourceKey fileResource)
     {
-        var view = _serviceProvider.GetRequiredService<ContributionDocumentView>();
+        var view = _serviceProvider.GetRequiredService<CustomDocumentView>();
         view.Contribution = _contribution;
         view.EditorId = EditorId;
 

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -177,13 +177,13 @@ public class DocumentsService : IDocumentsService, IDisposable
                     if (result.IsFailure)
                     {
                         _logger.LogWarning(result,
-                            $"Failed to register contribution editor factory for: {contribution?.Package?.Name}");
+                            $"Failed to register custom editor factory for: {contribution?.Package?.Name}");
                     }
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex,
-                        $"An exception occurred while registering contribution editor for: {contribution.Package?.Name ?? contribution.Id}");
+                        $"An exception occurred while registering custom editor for: {contribution.Package?.Name ?? contribution.Id}");
                 }
             }
 
@@ -250,7 +250,7 @@ public class DocumentsService : IDocumentsService, IDisposable
         }
 
         // Applied after SetFileResource and before LoadContent so the editor
-        // enters read-only mode before its first setValue. For ContributionDocumentView
+        // enters read-only mode before its first setValue. For CustomDocumentView
         // the state ships through the document/initialize handshake; for editors
         // that drive their surface directly, OnWritableStateChanged fires here.
         var operationService = _workspaceWrapper.WorkspaceService.ResourceService.Operations;

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -15,7 +15,7 @@ public class UtilityService : IUtilityService, IDisposable
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly UtilityDocumentSeeder _utilityDocumentSeeder;
 
-    private readonly List<ContributionPanelView> _utilities = new();
+    private readonly List<CustomUtilityView> _utilities = new();
 
     private bool _disposed;
 
@@ -40,11 +40,11 @@ public class UtilityService : IUtilityService, IDisposable
             serviceProvider.GetRequiredService<ILogger<UtilityDocumentSeeder>>());
     }
 
-    public async Task<IReadOnlyList<ContributedUtility>> CreateUtilitiesAsync(IReadOnlyList<CustomDocumentEditorContribution> contributions)
+    public async Task<IReadOnlyList<CustomUtility>> CreateUtilitiesAsync(IReadOnlyList<CustomDocumentEditorContribution> contributions)
     {
         var localizationService = _serviceProvider.GetRequiredService<IPackageLocalizationService>();
 
-        var tabs = new List<ContributedUtility>();
+        var tabs = new List<CustomUtility>();
         foreach (var contribution in contributions)
         {
             var descriptor = contribution.UtilityDescriptor;
@@ -70,7 +70,7 @@ public class UtilityService : IUtilityService, IDisposable
 
             var displayName = ResolveLocalizedString(localizationService, contribution.Package, contribution.DisplayName);
 
-            var panelView = _serviceProvider.GetRequiredService<ContributionPanelView>();
+            var panelView = _serviceProvider.GetRequiredService<CustomUtilityView>();
             var initResult = await panelView.InitializeAsync(contribution, resource, displayName);
             if (initResult.IsFailure)
             {
@@ -81,7 +81,7 @@ public class UtilityService : IUtilityService, IDisposable
             _utilities.Add(panelView);
 
             var tooltip = ResolveLocalizedString(localizationService, contribution.Package, descriptor.Tooltip);
-            tabs.Add(new ContributedUtility(utilityId, descriptor.Icon, tooltip, displayName, panelView, panelView.FocusPanel));
+            tabs.Add(new CustomUtility(utilityId, descriptor.Icon, tooltip, displayName, panelView, panelView.FocusPanel));
         }
 
         return tabs;
@@ -149,7 +149,7 @@ public class UtilityService : IUtilityService, IDisposable
 
     // Docks a utility into a document tab in the active document's section, reusing its live WebView. Activates
     // the tab if the utility is already there.
-    private Result DockUtilityAsDocument(ContributionPanelView panelView)
+    private Result DockUtilityAsDocument(CustomUtilityView panelView)
     {
         var documentsPanel = (DocumentsPanel)DocumentsPanel;
 
@@ -188,7 +188,7 @@ public class UtilityService : IUtilityService, IDisposable
 
     // Docks a utility back into the Utility Panel, reparenting its WebView out of its document tab and removing
     // the tab. The utility itself is never torn down.
-    private Result DockUtilityInPanel(ContributionPanelView panelView)
+    private Result DockUtilityInPanel(CustomUtilityView panelView)
     {
         if (panelView.Location == DockLocation.UtilityPanel)
         {

--- a/Source/Workspace/Celbridge.Documents/ViewModels/CustomDocumentViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/CustomDocumentViewModel.cs
@@ -6,9 +6,9 @@ namespace Celbridge.Documents.ViewModels;
 /// <summary>
 /// View model for contribution document editors.
 /// Provides text file I/O, file-change monitoring, path resolution, and template content
-/// for custom contribution editors.
+/// for custom editors.
 /// </summary>
-public partial class ContributionDocumentViewModel : DocumentViewModel
+public partial class CustomDocumentViewModel : DocumentViewModel
 {
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly IResourceRegistry _resourceRegistry;
@@ -21,7 +21,7 @@ public partial class ContributionDocumentViewModel : DocumentViewModel
     /// </summary>
     public CustomDocumentEditorContribution? Contribution { get; set; }
 
-    public ContributionDocumentViewModel(
+    public CustomDocumentViewModel(
         IWorkspaceWrapper workspaceWrapper,
         ILocalFileSystem fileSystem,
         IEnumerable<IDocumentContentProvider> contentProviders)

--- a/Source/Workspace/Celbridge.Documents/Views/CustomDialogHandler.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomDialogHandler.cs
@@ -9,16 +9,16 @@ namespace Celbridge.Documents.Views;
 /// Handles IHostDialog RPC methods for contribution document views.
 /// Provides image picking, file picking, and alert dialogs.
 /// </summary>
-internal sealed class ContributionDialogHandler : IHostDialog
+internal sealed class CustomDialogHandler : IHostDialog
 {
     private readonly IDialogService _dialogService;
     private readonly IStringLocalizer _stringLocalizer;
-    private readonly ContributionDocumentViewModel _viewModel;
+    private readonly CustomDocumentViewModel _viewModel;
 
-    public ContributionDialogHandler(
+    public CustomDialogHandler(
         IDialogService dialogService,
         IStringLocalizer stringLocalizer,
-        ContributionDocumentViewModel viewModel)
+        CustomDocumentViewModel viewModel)
     {
         _dialogService = dialogService;
         _stringLocalizer = stringLocalizer;

--- a/Source/Workspace/Celbridge.Documents/Views/CustomDocumentHandler.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomDocumentHandler.cs
@@ -8,9 +8,9 @@ namespace Celbridge.Documents.Views;
 /// Handles IHostDocument RPC methods for contribution document views.
 /// Manages document initialization, loading, saving, and change tracking.
 /// </summary>
-internal sealed class ContributionDocumentHandler : IHostDocument
+internal sealed class CustomDocumentHandler : IHostDocument
 {
-    private readonly ContributionDocumentViewModel _viewModel;
+    private readonly CustomDocumentViewModel _viewModel;
     private readonly ILogger _logger;
     private readonly Func<DocumentMetadata> _createMetadata;
     private readonly Func<bool> _completeSave;
@@ -27,8 +27,8 @@ internal sealed class ContributionDocumentHandler : IHostDocument
     /// </summary>
     internal event Action<ContentLoadedReason>? ContentLoaded;
 
-    public ContributionDocumentHandler(
-        ContributionDocumentViewModel viewModel,
+    public CustomDocumentHandler(
+        CustomDocumentViewModel viewModel,
         ILogger logger,
         Func<DocumentMetadata> createMetadata,
         Func<bool> completeSave)

--- a/Source/Workspace/Celbridge.Documents/Views/CustomDocumentView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomDocumentView.xaml
@@ -1,11 +1,11 @@
 ﻿<views:DocumentView
-    x:Class="Celbridge.Documents.Views.ContributionDocumentView"
+    x:Class="Celbridge.Documents.Views.CustomDocumentView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:views="using:Celbridge.Documents.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 
-    <Grid x:Name="ContributionWebViewContainer"
+    <Grid x:Name="CustomWebViewContainer"
           HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch" />
 </views:DocumentView>

--- a/Source/Workspace/Celbridge.Documents/Views/CustomDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomDocumentView.xaml.cs
@@ -8,14 +8,14 @@ namespace Celbridge.Documents.Views;
 
 /// <summary>
 /// Document view for contribution-based editors, hosted via a WebView2. A thin adapter over
-/// ContributionEditorController: it satisfies the DocumentView contract (open, save timer, close, editor-state
+/// CustomEditorController: it satisfies the DocumentView contract (open, save timer, close, editor-state
 /// persistence) and forwards the WebView-hosting work to the controller.
 /// </summary>
-public sealed partial class ContributionDocumentView : DocumentView
+public sealed partial class CustomDocumentView : DocumentView
 {
     private readonly IMessengerService _messengerService;
-    private readonly ContributionDocumentViewModel _viewModel;
-    private readonly ContributionEditorController _controller;
+    private readonly CustomDocumentViewModel _viewModel;
+    private readonly CustomEditorController _controller;
 
     protected override DocumentViewModel DocumentViewModel => _viewModel;
 
@@ -25,23 +25,23 @@ public sealed partial class ContributionDocumentView : DocumentView
     /// </summary>
     public CustomDocumentEditorContribution? Contribution { get; set; }
 
-    public ContributionDocumentView(
+    public CustomDocumentView(
         IServiceProvider serviceProvider,
         IMessengerService messengerService)
     {
         _messengerService = messengerService;
-        _viewModel = serviceProvider.GetRequiredService<ContributionDocumentViewModel>();
+        _viewModel = serviceProvider.GetRequiredService<CustomDocumentViewModel>();
 
         this.InitializeComponent();
 
-        var focusContext = new ContributionEditorFocusContext(
+        var focusContext = new CustomEditorFocusContext(
             WorkspacePanel.Documents,
             () => _messengerService.Send(new DocumentViewFocusedMessage(_viewModel.FileResource)));
 
-        _controller = new ContributionEditorController(
+        _controller = new CustomEditorController(
             serviceProvider,
             _viewModel,
-            ContributionWebViewContainer,
+            CustomWebViewContainer,
             focusContext);
     }
 
@@ -66,7 +66,7 @@ public sealed partial class ContributionDocumentView : DocumentView
     {
         if (Contribution is null)
         {
-            return Result.Fail("Cannot initialize contribution view: Contribution is not set");
+            return Result.Fail("Cannot initialize custom view: Contribution is not set");
         }
 
         return await _controller.InitializeAsync(Contribution);

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -19,20 +19,20 @@ using Windows.ApplicationModel.DataTransfer;
 namespace Celbridge.Documents.Views;
 
 /// <summary>
-/// The hosting surface a consumer supplies to a ContributionEditorController: the workspace panel the
+/// The hosting surface a consumer supplies to a CustomEditorController: the workspace panel the
 /// editor's web surface reports focus through, and the side effect to run when it gains focus. The document
 /// view reports the Documents panel and marks itself the active document; a panel host reports its own panel.
 /// </summary>
-public sealed record ContributionEditorFocusContext(WorkspacePanel Panel, Action OnFocusGained);
+public sealed record CustomEditorFocusContext(WorkspacePanel Panel, Action OnFocusGained);
 
 /// <summary>
-/// Drives a contribution (WebView-based) editor: it acquires and tears down the WebView, owns the JSON-RPC
+/// Drives a custom (WebView-based) editor: it acquires and tears down the WebView, owns the JSON-RPC
 /// host channel and its RPC targets, mirrors app/view state, bridges the webview_* tools, coordinates saves
 /// and external reloads, and implements the edit-target and link-routing behaviour. It has no dependency on
-/// DocumentView, the documents panel, or tab machinery; ContributionDocumentView and (later) a panel view are
+/// DocumentView, the documents panel, or tab machinery; CustomDocumentView and (later) a panel view are
 /// thin adapters that construct one and forward their lifecycle to it.
 /// </summary>
-public sealed class ContributionEditorController : IHostInput, IHostContext, IEditTarget
+public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarget
 {
     private const int SaveRequestTimeoutSeconds = 30;
     private const int ReloadStateWaitSeconds = 5;
@@ -42,7 +42,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     // the serial command queue. Kept under the command watchdog's 5s threshold.
     private const int EditorStateRequestTimeoutSeconds = 3;
 
-    private readonly ILogger<ContributionEditorController> _logger;
+    private readonly ILogger<CustomEditorController> _logger;
     private readonly ICommandService _commandService;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly IDialogService _dialogService;
@@ -52,12 +52,12 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     private readonly IWebViewAdapter _webViewAdapter;
     private readonly IWebViewFocusRegistry _webViewFocusRegistry;
 
-    private readonly ContributionDocumentViewModel _viewModel;
+    private readonly CustomDocumentViewModel _viewModel;
 
     // The container the WebView currently lives in, and the focus identity it reports through. Both are
     // reassigned by Redock when a utility moves between dock locations; the WebView is moved, never rebuilt.
     private Panel _webViewContainer;
-    private ContributionEditorFocusContext _focusContext;
+    private CustomEditorFocusContext _focusContext;
 
     // Set by InitializeAsync before the WebView is configured.
     private CustomDocumentEditorContribution? _contribution;
@@ -69,8 +69,8 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     // Latest edit availability reported by the editor over the bridge. Drives CanPerformEdit.
     private EditAvailability _editAvailability = EditAvailability.None;
 
-    private ContributionDocumentHandler? _documentHandler;
-    private ContributionToolsHandler? _toolsHandler;
+    private CustomDocumentHandler? _documentHandler;
+    private PackageToolsHandler? _toolsHandler;
     private IDisposable? _appStateConnection;
 
     // This editor's own state store (writability), mirrored to its WebView over the viewState channel.
@@ -114,7 +114,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     // notification that was in transit when the previous transport died.
     private bool _forceReload;
 
-    // Completed by InitContributionViewAsync with the init outcome. InitializeAsync
+    // Completed by InitCustomViewAsync with the init outcome. InitializeAsync
     // triggers the init on first call and awaits this TCS so the open-document
     // flow returns only when the WebView and host are ready for RPCs.
     private TaskCompletionSource<Result>? _initTcs;
@@ -129,18 +129,18 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     /// </summary>
     private CelbridgeHost? Host { get; set; }
 
-    public ContributionEditorController(
+    public CustomEditorController(
         IServiceProvider serviceProvider,
-        ContributionDocumentViewModel viewModel,
+        CustomDocumentViewModel viewModel,
         Panel webViewContainer,
-        ContributionEditorFocusContext focusContext)
+        CustomEditorFocusContext focusContext)
     {
         _serviceProvider = serviceProvider;
         _viewModel = viewModel;
         _webViewContainer = webViewContainer;
         _focusContext = focusContext;
 
-        _logger = serviceProvider.GetRequiredService<ILogger<ContributionEditorController>>();
+        _logger = serviceProvider.GetRequiredService<ILogger<CustomEditorController>>();
         _commandService = serviceProvider.GetRequiredService<ICommandService>();
         _stringLocalizer = serviceProvider.GetRequiredService<IStringLocalizer>();
         _dialogService = serviceProvider.GetRequiredService<IDialogService>();
@@ -166,7 +166,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         if (_initTcs is null)
         {
             _initTcs = new TaskCompletionSource<Result>();
-            _ = InitContributionViewAsync();
+            _ = InitCustomViewAsync();
         }
 
         var initResult = await _initTcs.Task;
@@ -212,7 +212,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
             _documentHandler.SaveResultTcs = null;
             CompleteSave();
 
-            var errorMessage = $"Contribution editor failed to respond within {SaveRequestTimeoutSeconds} seconds. " +
+            var errorMessage = $"Custom editor failed to respond within {SaveRequestTimeoutSeconds} seconds. " +
                                $"File: {_viewModel.FilePath}";
 
             _logger.LogError(errorMessage);
@@ -252,12 +252,12 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         return false;
     }
 
-    private IContributionEditorLoader ResolveContributionEditorLoader(PackageInfo package)
+    private ICustomEditorLoader ResolveCustomEditorLoader(PackageInfo package)
     {
         // The loopback default is registered first and matches every package, so it is the fallback. A
         // module's custom loader is registered later and wins as the last matching loader.
-        IContributionEditorLoader? selected = null;
-        foreach (var candidate in _serviceProvider.GetServices<IContributionEditorLoader>())
+        ICustomEditorLoader? selected = null;
+        foreach (var candidate in _serviceProvider.GetServices<ICustomEditorLoader>())
         {
             if (candidate.CanLoad(package))
             {
@@ -270,17 +270,17 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         return selected;
     }
 
-    private async Task InitContributionViewAsync()
+    private async Task InitCustomViewAsync()
     {
         if (_contribution is null)
         {
-            var error = "Cannot initialize contribution view: Contribution is not set";
+            var error = "Cannot initialize custom view: Contribution is not set";
             _logger.LogError(error);
             _initTcs!.TrySetResult(Result.Fail(error));
             return;
         }
 
-        var editorLoader = ResolveContributionEditorLoader(_contribution.Package);
+        var editorLoader = ResolveCustomEditorLoader(_contribution.Package);
 
         // The factory hands back a control with CoreWebView2 already live (pre-warmed where possible), so
         // the host is configured immediately and init is signalled once the editor's navigation has started.
@@ -295,9 +295,9 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, $"Failed to initialize contribution view: {_contribution.Package.Name}");
+            _logger.LogError(ex, $"Failed to initialize custom view: {_contribution.Package.Name}");
             TeardownWebViewState();
-            var failure = Result.Fail($"Failed to initialize contribution view: {_contribution.Package.Name}")
+            var failure = Result.Fail($"Failed to initialize custom view: {_contribution.Package.Name}")
                 .WithException(ex);
             _initTcs!.TrySetResult(failure);
         }
@@ -305,7 +305,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
 
     // Configures a live WebView (CoreWebView2 ready): host channel, RPC targets, tool bridge, navigation gate,
     // and the editor load. Shared by the pooled and in-place init paths.
-    private async Task ConfigureWebViewHostAsync(IContributionEditorLoader editorLoader)
+    private async Task ConfigureWebViewHostAsync(ICustomEditorLoader editorLoader)
     {
         Guard.IsNotNull(_contribution);
         Guard.IsNotNull(WebView);
@@ -319,7 +319,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         // Register this editor's web surface; it hosts an edit target (this) for the Edit commands.
         RegisterWebSurfaceFocus();
 
-        // Every contribution editor's assets (its lib, the shared client) are served from the loopback
+        // Every custom editor's assets (its lib, the shared client) are served from the loopback
         // file server, so register this package's folder there. The resolved loader decides where the
         // entry page itself loads from.
         var fileServer = _serviceProvider.GetRequiredService<IFileServer>();
@@ -371,7 +371,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         Host.AddLocalRpcTarget<IHostInput>(this);
         Host.AddLocalRpcTarget<IHostContext>(this);
 
-        _documentHandler = new ContributionDocumentHandler(
+        _documentHandler = new CustomDocumentHandler(
             _viewModel,
             _logger,
             CreateDocumentMetadata,    // Callback to construct document metadata on demand
@@ -379,7 +379,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
 
         _documentHandler.ContentLoaded += SetContentLoaded;
 
-        var dialogHandler = new ContributionDialogHandler(
+        var dialogHandler = new CustomDialogHandler(
             _dialogService,
             _stringLocalizer,
             _viewModel);
@@ -390,8 +390,8 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
         var mcpToolBridge = _serviceProvider.GetService<IMcpToolBridge>();
         if (mcpToolBridge is not null)
         {
-            _toolsHandler = new ContributionToolsHandler(mcpToolBridge, _contribution.Package.PermittedTools);
-            Host.AddLocalRpcTarget<ContributionToolsHandler>(_toolsHandler);
+            _toolsHandler = new PackageToolsHandler(mcpToolBridge, _contribution.Package.PermittedTools);
+            Host.AddLocalRpcTarget<PackageToolsHandler>(_toolsHandler);
         }
 
         Host.StartListening();
@@ -420,7 +420,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
 
         var entryPoint = _contribution.EntryPoint;
         var serverPort = _serviceProvider.GetRequiredService<IServerService>().Port;
-        var loadRequest = new ContributionEditorLoadRequest(
+        var loadRequest = new CustomEditorLoadRequest(
             WebView!,
             _contribution.Package,
             packageUrlName,
@@ -474,7 +474,7 @@ public sealed class ContributionEditorController : IHostInput, IHostContext, IEd
     /// while it moves between dock locations (the Utility Panel and a document tab). Called before the WebView
     /// is acquired, it just records the target container so the pending init lands there.
     /// </summary>
-    public void Redock(Panel newContainer, ContributionEditorFocusContext focusContext)
+    public void Redock(Panel newContainer, CustomEditorFocusContext focusContext)
     {
         _focusContext = focusContext;
 

--- a/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
@@ -1,5 +1,5 @@
 <UserControl
-    x:Class="Celbridge.Documents.Views.ContributionPanelView"
+    x:Class="Celbridge.Documents.Views.CustomUtilityView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Celbridge.WorkspaceUI.Views"
@@ -7,7 +7,7 @@
     xmlns:ui="using:Celbridge.UserInterface"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Background="Transparent"
-    ui:FocusTracking.Panel="Utility">
+    ui:FocusTracking.Panel="CustomUtility">
 
     <Grid Background="Transparent">
         <Grid.RowDefinitions>
@@ -29,7 +29,7 @@
             </controls:PanelHeader.ToolbarContent>
         </controls:PanelHeader>
 
-        <Grid x:Name="ContributionWebViewContainer"
+        <Grid x:Name="CustomWebViewContainer"
               Grid.Row="1"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"/>

--- a/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml.cs
@@ -10,27 +10,27 @@ using Microsoft.Extensions.Localization;
 namespace Celbridge.Documents.Views;
 
 /// <summary>
-/// Hosts a contributed utility in the Utility Panel, adapting the shared ContributionEditorController to
+/// Hosts a custom utility in the Utility Panel, adapting the shared CustomEditorController to
 /// panel chrome.
 /// </summary>
-public sealed partial class ContributionPanelView : UserControl
+public sealed partial class CustomUtilityView : UserControl
 {
     private readonly IMessengerService _messengerService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly ICommandService _commandService;
-    private readonly ContributionDocumentViewModel _viewModel;
-    private readonly ContributionEditorController _controller;
-    private readonly ContributionEditorFocusContext _panelFocusContext;
+    private readonly CustomDocumentViewModel _viewModel;
+    private readonly CustomEditorController _controller;
+    private readonly CustomEditorFocusContext _panelFocusContext;
 
     // The utility's id, set on Initialize. Used by the dock orchestration to address this panel.
     private UtilityId _utilityId = UtilityId.Empty;
 
-    public ContributionPanelView(IServiceProvider serviceProvider)
+    public CustomUtilityView(IServiceProvider serviceProvider)
     {
         _messengerService = serviceProvider.GetRequiredService<IMessengerService>();
         _workspaceWrapper = serviceProvider.GetRequiredService<IWorkspaceWrapper>();
         _commandService = serviceProvider.GetRequiredService<ICommandService>();
-        _viewModel = serviceProvider.GetRequiredService<ContributionDocumentViewModel>();
+        _viewModel = serviceProvider.GetRequiredService<CustomDocumentViewModel>();
 
         this.InitializeComponent();
 
@@ -40,14 +40,14 @@ public sealed partial class ContributionPanelView : UserControl
 
         // A utility in the panel is not a document, so it does not mark itself the active document on focus. The
         // registry still reports its Utility focus identity from the registration, which is all a utility needs.
-        _panelFocusContext = new ContributionEditorFocusContext(
-            WorkspacePanel.Utility,
+        _panelFocusContext = new CustomEditorFocusContext(
+            WorkspacePanel.CustomUtility,
             () => { });
 
-        _controller = new ContributionEditorController(
+        _controller = new CustomEditorController(
             serviceProvider,
             _viewModel,
-            ContributionWebViewContainer,
+            CustomWebViewContainer,
             _panelFocusContext);
     }
 
@@ -55,19 +55,19 @@ public sealed partial class ContributionPanelView : UserControl
     /// The utility's persistent editor controller. Owned by this panel for the workspace lifetime; the dock
     /// orchestration borrows it to present the utility in a document tab and hands it back when it returns.
     /// </summary>
-    public ContributionEditorController Controller => _controller;
+    public CustomEditorController Controller => _controller;
 
     /// <summary>
     /// This panel's WebView container. Docking the utility back into the panel reparents the controller's
     /// WebView into it.
     /// </summary>
-    public Panel PanelContainer => ContributionWebViewContainer;
+    public Panel PanelContainer => CustomWebViewContainer;
 
     /// <summary>
     /// The focus context the utility reports through while docked in the Utility Panel. Re-applied when the
     /// utility is docked back into the panel.
     /// </summary>
-    public ContributionEditorFocusContext PanelFocusContext => _panelFocusContext;
+    public CustomEditorFocusContext PanelFocusContext => _panelFocusContext;
 
     /// <summary>
     /// The utility's id.

--- a/Source/Workspace/Celbridge.Documents/Views/DockedUtilityDocumentView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DockedUtilityDocumentView.xaml.cs
@@ -6,32 +6,32 @@ namespace Celbridge.Documents.Views;
 
 /// <summary>
 /// Document view for a utility docked as a document: a utility whose presentation has moved from the Utility
-/// Panel into a document tab. It borrows the utility's persistent ContributionEditorController (owned by its
-/// ContributionPanelView) rather than creating one, so the utility keeps a single WebView as it moves between
+/// Panel into a document tab. It borrows the utility's persistent CustomEditorController (owned by its
+/// CustomUtilityView) rather than creating one, so the utility keeps a single WebView as it moves between
 /// dock locations. The view is inert on saves (the owning panel drives the save tick) and never tears the
 /// controller down on close; the documents panel reparents the WebView back to the panel instead.
 /// </summary>
 public sealed partial class DockedUtilityDocumentView : DocumentView
 {
-    private readonly ContributionDocumentViewModel _viewModel;
-    private readonly ContributionEditorController _controller;
-    private readonly ContributionEditorFocusContext _focusContext;
+    private readonly CustomDocumentViewModel _viewModel;
+    private readonly CustomEditorController _controller;
+    private readonly CustomEditorFocusContext _focusContext;
 
     protected override DocumentViewModel DocumentViewModel => _viewModel;
 
     public DockedUtilityDocumentView(
         IServiceProvider serviceProvider,
         IMessengerService messengerService,
-        ContributionEditorController controller)
+        CustomEditorController controller)
     {
         _controller = controller;
-        _viewModel = serviceProvider.GetRequiredService<ContributionDocumentViewModel>();
+        _viewModel = serviceProvider.GetRequiredService<CustomDocumentViewModel>();
 
         this.InitializeComponent();
 
         // A docked utility reports the Documents panel and marks itself the active document on focus, matching
         // any other document tab. Docking back into the panel re-points the controller at its Utility context.
-        _focusContext = new ContributionEditorFocusContext(
+        _focusContext = new CustomEditorFocusContext(
             WorkspacePanel.Documents,
             () => messengerService.Send(new DocumentViewFocusedMessage(_viewModel.FileResource)));
     }

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -622,10 +622,10 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     /// and whether the tab is activated; the controller's WebView is reparented into the tab once it is in the
     /// visual tree.
     /// </summary>
-    public Result DockUtility(ContributionPanelView panelView, DockUtilityPlacement placement)
+    public Result DockUtility(CustomUtilityView panelView, DockUtilityPlacement placement)
     {
         var resource = panelView.FileResource;
-        // A contributed utility's id string is its document editor id.
+        // A custom utility's id string is its document editor id.
         var editorId = new DocumentEditorId(panelView.UtilityId.ToString());
 
         var resolveResult = ViewModel.ResolveResourcePath(resource);

--- a/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
@@ -104,7 +104,7 @@ public class PackageRegistry
 
     public Package? GetContributingPackage(DocumentEditorId editorId)
     {
-        // Custom contribution editor IDs are formatted as "{packageName}.{contributionId}"
+        // Custom editor IDs are formatted as "{packageName}.{contributionId}"
         // by CustomDocumentViewFactory. Bundled package names themselves contain
         // dots (e.g. "celbridge.notes"), so match by full-name prefix rather than
         // splitting on the first separator.
@@ -426,7 +426,7 @@ public class PackageRegistry
             var manifestPath = resolveResult.Value;
             var packageFolder = Path.GetDirectoryName(manifestPath)!;
 
-            // Project packages are served over the loopback file server. Their contribution editors run on
+            // Project packages are served over the loopback file server. Their custom editors run on
             // every head.
             var loadResult = PackageManifestLoader.LoadPackage(
                 manifestPath,

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceLoader.cs
@@ -388,7 +388,7 @@ public class WorkspaceLoader
             return;
         }
 
-        _workspaceWrapper.WorkspaceService.UtilityPanel.BuildContributedUtilities(tabs);
+        _workspaceWrapper.WorkspaceService.UtilityPanel.BuildCustomUtilities(tabs);
     }
 
     // Enumerates enabled utility contributions in the rail's stable order: bundled before project, each

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityItemViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityItemViewModel.cs
@@ -4,7 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace Celbridge.WorkspaceUI.ViewModels;
 
 /// <summary>
-/// View model for a single Utility Panel rail item (a built-in Explorer/Search surface or a contributed
+/// View model for a single Utility Panel rail item (a built-in Explorer/Search surface or a custom
 /// utility). The rail button binds its visual state to IsSelected, IsFocused, and IsDocked; the owning
 /// UtilityPanelViewModel is the only writer of those properties.
 /// </summary>
@@ -17,7 +17,7 @@ public partial class UtilityItemViewModel : ObservableObject
 
     /// <summary>
     /// The workspace panel identity used to decide whether this surface currently holds focus. Built-in
-    /// Explorer and Search have their own identities; every contributed utility reports as Utility.
+    /// Explorer and Search have their own identities; every custom utility reports as CustomUtility.
     /// </summary>
     public WorkspacePanel FocusIdentity { get; }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
@@ -23,7 +23,7 @@ public partial class UtilityPanelViewModel : ObservableObject
     private bool _awaitingSelectionFocus;
 
     /// <summary>
-    /// The rail items in display order: built-in surfaces first, then contributed utilities.
+    /// The rail items in display order: built-in surfaces first, then custom utilities.
     /// </summary>
     public IReadOnlyList<UtilityItemViewModel> Items => _items;
 
@@ -34,7 +34,7 @@ public partial class UtilityPanelViewModel : ObservableObject
 
     /// <summary>
     /// Appends a rail item and returns its view model. focusIdentity is the workspace panel this surface
-    /// reports focus as (WorkspacePanel.Utility for every contributed utility).
+    /// reports focus as (WorkspacePanel.CustomUtility for every custom utility).
     /// </summary>
     public UtilityItemViewModel AddItem(UtilityId id, WorkspacePanel focusIdentity)
     {

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspacePageViewModel.cs
@@ -127,7 +127,7 @@ public partial class WorkspacePageViewModel : ObservableObject
 
             // Tear down the utilities, then clear the rail.
             await _workspaceService.UtilityService.TeardownUtilitiesAsync();
-            _workspaceService.UtilityPanel.ClearContributedUtilities();
+            _workspaceService.UtilityPanel.ClearCustomUtilities();
         }
         catch (Exception exception)
         {

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     private const string ExplorerLandmarkId = "explorer-utility-button";
     private const string SearchLandmarkId = "search-utility-button";
 
-    // Rail buttons, content hosts, and focus callbacks for every surface (built-in and contributed), keyed by
+    // Rail buttons, content hosts, and focus callbacks for every surface (built-in and custom), keyed by
     // utility id. The view owns content hosting and focus acquisition; the view model owns the rail selection
     // and focus state, which the buttons bind to.
     private readonly Dictionary<UtilityId, UtilityButton> _buttons = new();
@@ -255,19 +255,19 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _messengerService.Send(new ActiveUtilityChangedMessage(ActiveUtilityId.ToString()));
     }
 
-    public void BuildContributedUtilities(IReadOnlyList<ContributedUtility> utilities)
+    public void BuildCustomUtilities(IReadOnlyList<CustomUtility> utilities)
     {
-        ClearContributedUtilities();
+        ClearCustomUtilities();
 
         foreach (var utility in utilities)
         {
-            var item = ViewModel.AddItem(utility.UtilityId, WorkspacePanel.Utility);
+            var item = ViewModel.AddItem(utility.UtilityId, WorkspacePanel.CustomUtility);
 
             var railButton = new UtilityButton();
             railButton.SetIcon(utility.IconGlyphName);
             railButton.SetTooltip(utility.Tooltip);
 
-            var landmarkId = ContributedLandmarkId(utility.UtilityId);
+            var landmarkId = CustomLandmarkId(utility.UtilityId);
             railButton.SetAutomationId(landmarkId);
 
             BindButton(railButton, item);
@@ -294,19 +294,19 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         }
     }
 
-    public void ClearContributedUtilities()
+    public void ClearCustomUtilities()
     {
         // This runs on unload and on rebuild, so the revert-to-Explorer below must not persist over the user's
         // saved selection. RestoreSelectedUtility re-enables persistence once the rebuilt rail is restored.
         _selectionPersistenceEnabled = false;
 
         // Revert to Explorer before removing items so a removed utility is never left showing or highlighted.
-        if (IsContributedSurfaceSelected())
+        if (IsCustomSurfaceSelected())
         {
             ShowSurface(BuiltInUtilityIds.Explorer);
         }
 
-        foreach (var utilityId in GetContributedUtilityIds())
+        foreach (var utilityId in GetCustomUtilityIds())
         {
             var railButton = _buttons[utilityId];
             RailItems.Children.Remove(railButton);
@@ -315,7 +315,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             contentControl.Content = null;
             ContentArea.Children.Remove(contentControl);
 
-            _spotlightRegistry.UnregisterLandmark(ContributedLandmarkId(utilityId));
+            _spotlightRegistry.UnregisterLandmark(CustomLandmarkId(utilityId));
 
             _buttons.Remove(utilityId);
             _contentControls.Remove(utilityId);
@@ -384,38 +384,38 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _settings.Set(SettingCatalog.Layout.UtilityPanelSelectedUtility, tag);
     }
 
-    private bool IsContributedSurfaceSelected()
+    private bool IsCustomSurfaceSelected()
     {
-        return IsContributedUtility(ViewModel.SelectedUtilityId);
+        return IsCustomUtility(ViewModel.SelectedUtilityId);
     }
 
-    private static bool IsContributedUtility(UtilityId utilityId)
+    private static bool IsCustomUtility(UtilityId utilityId)
     {
         return !utilityId.IsEmpty
             && utilityId != BuiltInUtilityIds.Explorer
             && utilityId != BuiltInUtilityIds.Search;
     }
 
-    // Spotlight landmark id for a contributed utility's rail button: its utility id followed by "-utility-button",
+    // Spotlight landmark id for a custom utility's rail button: its utility id followed by "-utility-button",
     // matching the AutomationId set on the button and the app_spotlight guide so an agent can resolve it. The rail
     // is always visible when the Primary region is shown, so these landmarks need only a region reveal, matching
     // the built-in Explorer and Search rail buttons.
-    private static string ContributedLandmarkId(UtilityId utilityId)
+    private static string CustomLandmarkId(UtilityId utilityId)
     {
         return $"{utilityId}-utility-button";
     }
 
-    private List<UtilityId> GetContributedUtilityIds()
+    private List<UtilityId> GetCustomUtilityIds()
     {
-        var contributedUtilityIds = new List<UtilityId>();
+        var customUtilityIds = new List<UtilityId>();
         foreach (var utilityId in _contentControls.Keys)
         {
-            if (IsContributedUtility(utilityId))
+            if (IsCustomUtility(utilityId))
             {
-                contributedUtilityIds.Add(utilityId);
+                customUtilityIds.Add(utilityId);
             }
         }
 
-        return contributedUtilityIds;
+        return customUtilityIds;
     }
 }


### PR DESCRIPTION
This pull request updates terminology throughout the codebase to replace "extension" and "contributed" with "package" and "custom" respectively, clarifying the distinction between built-in and user/customized components. The changes are primarily documentation and API naming updates, with some renaming of types and method signatures to reflect the new terminology. No functional or behavioral changes are introduced.

**Terminology and Documentation Updates:**

* Replaced references to "extension" with "package" in class summaries, property descriptions, and comments across files such as `DocumentEditorContribution.cs`, `DocumentFileType.cs`, `DocumentTemplate.cs`, and `CustomDocumentEditorContribution.cs`. [[1]](diffhunk://#diff-d4f14b528fb5c186c47e97806a776c48a5abfe68d8c1b0733e5d40f968c83cddL7-R7) [[2]](diffhunk://#diff-f865dbbb2b5cb44af7e28defff94f96f4ba9f30f4f37479cdfecbac2d9520b84L4-R4) [[3]](diffhunk://#diff-0c54b7e5fffd735ddc73954bc9525e60f7603189a64c4c252f8a541a4915c388L4-R10) [[4]](diffhunk://#diff-0c54b7e5fffd735ddc73954bc9525e60f7603189a64c4c252f8a541a4915c388L20-R20) [[5]](diffhunk://#diff-ff9d9874d316e79fd50ee2208f84f86f4b810a3831adf7fdbac5089c47994e00L5-R5)
* Updated references from "contributed" to "custom" for utilities and editors in documentation, comments, and summaries in files including `IDocumentContentProvider.cs`, `IGetUtilitiesStateCommand.cs`, `IShowUtilityCommand.cs`, `IMcpToolBridge.cs`, and `IDocumentWebViewToolBridge.cs`. [[1]](diffhunk://#diff-3c55aba4920474ace02a51991dbe09a2fd556fd8ffa740f64f5938534aac6426L5-R5) [[2]](diffhunk://#diff-3c55aba4920474ace02a51991dbe09a2fd556fd8ffa740f64f5938534aac6426L17-R17) [[3]](diffhunk://#diff-6e8e33c8f075ea0cc9652cba137f83030e461eb41472608269d553599ec600f5L19-R25) [[4]](diffhunk://#diff-eca1a4d842d1aa261a2a2967e6c0299077a1aa4557496990fe6fb5257ba2fd21L8-R14) [[5]](diffhunk://#diff-765ad299d6d4cd2df5b7114be5e6710e2789b54e917a4a4be1bf0e83967bb2b3L31-R31) [[6]](diffhunk://#diff-bd57eac782a0ac9e95a35fe8524c0ec7e25bc2d5edc7d408dae041b36e75b632L143-R143) [[7]](diffhunk://#diff-bd57eac782a0ac9e95a35fe8524c0ec7e25bc2d5edc7d408dae041b36e75b632L161-R161)

**API and Type Renaming:**

* Renamed types and methods to use "Custom" instead of "Contributed" for utility-related APIs, including changing `ContributedUtility` to `CustomUtility` and updating method names like `BuildContributedUtilities` to `BuildCustomUtilities` in `IUtilityPanel.cs` and related interfaces. [[1]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL24-R28) [[2]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL37-R37) [[3]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL53-R77) [[4]](diffhunk://#diff-0754556c715b188323f7d9b17e523f8dec8632e49874379841d2f9a4aef7ed8aL17-R17)
* Updated enum and message names to use "CustomUtility" instead of "Utility" for clarity in workspace panel and messaging code. [[1]](diffhunk://#diff-629da6d5b2e2007e3b8418d2a0ed57e61948e9ea1e8dad93238e0a777329ffdeL39-R41) [[2]](diffhunk://#diff-6230d4b6eb07ddb329c10b33eefee42a5f58bd2537e409f634894ab7bf841da1L46-R46)
* Adjusted comments and method summaries to consistently use "custom" for user-defined utilities and editors, and "package" for package-defined components, including in `UtilityId.cs` and `CodeDocumentEditorContribution.cs`. [[1]](diffhunk://#diff-1a4d848aaae2c59876af8e11bbd5d46db4e144adc4bb067886f91158e5792d9dL4-R6) [[2]](diffhunk://#diff-1a4d848aaae2c59876af8e11bbd5d46db4e144adc4bb067886f91158e5792d9dL30-R30) [[3]](diffhunk://#diff-7767f764a6f9e81adfb5562fed6c602245aaab49675c21a1ab71688e2ea5e62cL4-R17) [[4]](diffhunk://#diff-7767f764a6f9e81adfb5562fed6c602245aaab49675c21a1ab71688e2ea5e62cL37-R37) [[5]](diffhunk://#diff-e9cbe9d04ccb0d90f8b9ef9ae6189608ae0fcd761338e7241bd9c1556380283aL13-R18) [[6]](diffhunk://#diff-6d401abd0bceeb664f8a3ebfadbc3bc145ea38da02979a1e933391086e8ec972L69-R69)

These changes improve clarity and consistency in the codebase by standardizing terminology, making it easier for developers to distinguish between built-in and custom/package-provided features.Replace 'contribution/contributed' terminology with 'custom/custom editor' across the codebase. Renamed interfaces, classes and members (e.g. IContributionEditorLoader→ICustomEditorLoader, ContributionEditorController→CustomEditorController, ContributionDocumentView→CustomDocumentView, ContributedUtility→CustomUtility), updated DI registrations, RPC/context strings, tool docs, workspace APIs (BuildContributedUtilities→BuildCustomUtilities), and tests. Also renamed ContributionToolsHandler→PackageToolsHandler and related guards. This is a mechanical rename to align terminology; no functional behavior intended to change.