### PR TITLE
Add shared stylesheet with design tokens for WebView editors

### DIFF
--- a/Source/Core/Celbridge.Tools/Guides/Concepts/agent_instructions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/agent_instructions.md
@@ -79,7 +79,7 @@ tools = ["document.*", "file.*", "app.get_state"]
 The manifest uses the **alias form** — `namespace.snake_case_method`. The JS proxy converts the method portion to camelCase at the call site; the manifest does **not**.
 
 ```javascript
-import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
+import celbridge from '/assets/celbridge-client/celbridge.js';
 await celbridge.initialize();
 const tree = await cel.file.getTree("");
 ```

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -1,6 +1,6 @@
 # Document editor contributions
 
-A package contribution that takes over a file extension in the documents panel. The editor runs in a WebView2 and talks to the host through `https://shared.celbridge/celbridge-client/celbridge.js`. Read `packages_overview` first.
+A package contribution that takes over a file extension in the documents panel. The editor runs in a WebView and talks to the host through the shared client at `/assets/celbridge-client/celbridge.js`, addressed root-relative against the page's own loopback origin. Read `packages_overview` first.
 
 ## Manifest
 
@@ -44,8 +44,8 @@ default = true
 ## JS handlers
 
 ```javascript
-import celbridge from 'https://shared.celbridge/celbridge-client/celbridge.js';
-import { ContentLoadedReason } from 'https://shared.celbridge/celbridge-client/api/document-api.js';
+import celbridge from '/assets/celbridge-client/celbridge.js';
+import { ContentLoadedReason } from '/assets/celbridge-client/api/document-api.js';
 
 const client = celbridge;
 
@@ -67,6 +67,35 @@ client.viewState.onChanged((viewState) => {
 - **`onRequestSave()`** — auto-save, tab close, programmatic flush. `await client.document.save(content)`. May fire while the tab is hidden.
 - **`onExternalChange(args)`** — file changed on disk. `client.document.load()`, apply with the spurious-update guard, then `client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload)`. Forward `args.preserveViewState`.
 - **`onRequestState()` / `onRestoreState(stateJson)`** — opaque string round-trip for scroll, selection, pending view state. Survives external reloads and session restore. Return `null` if nothing to preserve.
+
+## Styling
+
+Link the shared stylesheet to inherit the host's fonts and colors, so a WebView editor reads as part of the native app rather than a foreign web page:
+
+```html
+<link rel="stylesheet" href="/assets/celbridge-client/celbridge.css">
+```
+
+It defines design tokens as CSS custom properties whose color values mirror the native app's theme (`Celbridge.UserInterface/Resources/Colors.xaml`). Theme switching is automatic: the client mirrors the host theme onto `html[data-theme]` on every state snapshot, so tokens re-resolve with no editor JS — do not subscribe to `appState.theme` to swap a stylesheet or toggle a class. Build surfaces from the tokens, or key your own rules on `[data-theme="dark"]` for anything a token does not cover.
+
+An editor that hand-styles its own chrome (the CodeEditor is the precedent) can link `/assets/celbridge-client/celbridge-tokens.css` instead — the same tokens with none of the bare-element control rules — so it gets the host palette without the generic button/input styling leaking into its surface.
+
+Core tokens:
+
+| Token | Purpose |
+|---|---|
+| `--cel-font-ui` | UI and prose text. A system font stack, matching the host chrome per platform. |
+| `--cel-font-mono` | Code and monospace text. The bundled Cascadia Mono, consistent across platforms. |
+| `--cel-app-bg`, `--cel-panel-bg`, `--cel-panel-bg-alt` | Window, panel, and inner-content backgrounds. |
+| `--cel-text-primary`, `--cel-text-secondary` | Primary and muted foreground text. |
+| `--cel-divider` | Separator and control-border color. |
+| `--cel-accent` | Accent color (hardcoded per theme; the CSS `AccentColor` keyword renders transparent in WebView2). |
+| `--cel-error-text`, `--cel-warning-text`, `--cel-search-highlight` | Semantic status colors. |
+| `--cel-radius-control`, `--cel-radius-card` | Corner radii for controls and larger cards. |
+
+The stylesheet also imports the Cascadia Mono face and applies the UI font, base text color, and window background to `body`. It gives common form controls — `<button>`, `<select>`, `<textarea>`, text `<input>`, checkboxes/radios, and range sliders — an approximate native Fluent look with no markup beyond the plain element; add `class="cel-accent"` to a button for the filled accent (primary) variant. Text-level elements are themed too: `<a>` links take the accent color, `<code>`/`<pre>`/`<kbd>` use the mono font, and placeholders, `::selection`, and `<hr>` follow the theme. These are bare-element rules with the lowest specificity, so an editor overrides any of them by id or class. Larger components (tables, dialogs, cards) are intentionally not pre-styled — build them from the tokens. Icons are opt-in: link `/assets/bootstrap-icons/bootstrap-icons.css` and use the `bi` classes (the same icon font the native chrome uses).
+
+The Notepad and Process utilities are the minimal reference for consuming these tokens — Notepad for a bare monospace surface, Process for the UI font, host-styled controls, and a bordered input.
 
 ## Edit verbs (optional)
 

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
@@ -1,0 +1,64 @@
+/* Celbridge design tokens, served at /assets/celbridge-client/celbridge-tokens.css.
+
+   This is the tokens-only sheet: the `--cel-*` custom properties and nothing else. Link it directly when an
+   editor wants the host's colors and fonts but brings its own chrome and does not want the bare-element control
+   styling in celbridge.css (the CodeEditor is the precedent — its toolbar and Monaco surface are styled by hand
+   and should not inherit generic button/input rules). Utilities that want the full package link celbridge.css
+   instead, which imports this file and adds the base and control layers on top.
+
+   The color values mirror the native app's theme dictionaries in Celbridge.UserInterface/Resources/Colors.xaml;
+   keep the two in sync when either changes. Theme follows html[data-theme], which the client mirrors from the
+   host on every state snapshot (see core/state-store.js). The accent color is hardcoded per theme because the
+   CSS AccentColor keyword renders as transparent in WebView2. The monospace font is the bundled Cascadia Mono,
+   imported below; the UI font is a system stack, matching the host chrome per platform. */
+
+@import url('/assets/cascadia-mono/cascadia-mono.css');
+
+:root {
+    --cel-font-ui: system-ui, -apple-system, "Segoe UI Variable Text", "Segoe UI", sans-serif;
+    --cel-font-mono: "Cascadia Mono", ui-monospace, Consolas, Menlo, monospace;
+    --cel-font-size-base: 14px;
+
+    --cel-radius-control: 4px;
+    --cel-radius-card: 8px;
+
+    color-scheme: light;
+
+    --cel-app-bg: #F3F3F3;
+    --cel-panel-bg: #F3F3F3;
+    --cel-panel-bg-alt: #F7F8FA;
+    --cel-divider: #D0D0D0;
+    --cel-accent: #0078D4;
+    --cel-accent-text: #FFFFFF;
+    --cel-text-primary: #1F1F1F;
+    --cel-text-secondary: rgba(0, 0, 0, 0.6);
+    --cel-error-text: #D32F2F;
+    --cel-warning-text: #FFA000;
+    --cel-search-highlight: #C66300;
+    --cel-list-selected-bg: rgba(0, 120, 212, 0.235);
+
+    /* Button fill and hover. The native app uses WinUI's system control brushes here rather than a token in
+       Colors.xaml; these approximate that Fluent look. */
+    --cel-control-bg: #FBFBFB;
+    --cel-control-hover-bg: #F0F0F0;
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+
+    --cel-app-bg: #2B2D30;
+    --cel-panel-bg: #2B2D30;
+    --cel-panel-bg-alt: #1E1F22;
+    --cel-divider: #1E1F22;
+    --cel-accent: #60CDFF;
+    --cel-accent-text: #000000;
+    --cel-text-primary: #FFFFFF;
+    --cel-text-secondary: rgba(255, 255, 255, 0.6);
+    --cel-error-text: #FF5252;
+    --cel-warning-text: #FFCA28;
+    --cel-search-highlight: #FFD966;
+    --cel-list-selected-bg: rgba(0, 120, 212, 0.235);
+
+    --cel-control-bg: #383A3E;
+    --cel-control-hover-bg: #43464A;
+}

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
@@ -1,0 +1,121 @@
+/* Celbridge shared stylesheet for WebView utilities and editors.
+   Served over the loopback file server at /assets/celbridge-client/celbridge.css. Link it alongside the
+   client script to inherit the host's fonts and colors, plus base and control styling:
+
+       <link rel="stylesheet" href="/assets/celbridge-client/celbridge.css">
+
+   This imports the design tokens from celbridge-tokens.css and layers a box-sizing reset, body defaults, and
+   an approximate-Fluent set of form-control and text-element styles on top. An editor that wants the tokens
+   but brings its own chrome should link celbridge-tokens.css directly instead, to avoid the bare-element
+   control rules below (the CodeEditor does this). */
+
+@import url('/assets/celbridge-client/celbridge-tokens.css');
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--cel-font-ui);
+    font-size: var(--cel-font-size-base);
+    color: var(--cel-text-primary);
+    background: var(--cel-app-bg);
+}
+
+/* Common form controls, approximating the native Fluent look so a utility's inputs and buttons read as part
+   of the host. These bare-element rules apply only to pages that link this stylesheet; an editor with its own
+   control styling can override them by id or class, since element selectors have the lowest specificity. */
+
+:root {
+    accent-color: var(--cel-accent);
+}
+
+button,
+select,
+textarea,
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]) {
+    font-family: var(--cel-font-ui);
+    font-size: var(--cel-font-size-base);
+    color: var(--cel-text-primary);
+    border: 1px solid var(--cel-divider);
+    border-radius: var(--cel-radius-control);
+}
+
+select,
+textarea,
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]) {
+    padding: 5px 8px;
+    background: var(--cel-panel-bg-alt);
+}
+
+button:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+input:focus-visible {
+    outline: none;
+    border-color: var(--cel-accent);
+}
+
+button {
+    padding: 5px 14px;
+    background: var(--cel-control-bg);
+    cursor: pointer;
+}
+
+button:hover {
+    background: var(--cel-control-hover-bg);
+}
+
+button:disabled,
+select:disabled,
+textarea:disabled,
+input:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+/* Primary/call-to-action button, filled with the accent color. */
+button.cel-accent {
+    background: var(--cel-accent);
+    border-color: var(--cel-accent);
+    color: var(--cel-accent-text);
+}
+
+button.cel-accent:hover {
+    filter: brightness(1.08);
+}
+
+/* Text-level defaults. Links, code, placeholders, and selection pick up the theme so real content reads as
+   part of the host rather than falling back to the browser's blue links and UA monospace. */
+
+a {
+    color: var(--cel-accent);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+code,
+pre,
+kbd,
+samp {
+    font-family: var(--cel-font-mono);
+}
+
+::placeholder {
+    color: var(--cel-text-secondary);
+}
+
+::selection {
+    background: var(--cel-list-selected-bg);
+}
+
+hr {
+    border: none;
+    border-top: 1px solid var(--cel-divider);
+}

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/ui/find-bar.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/ui/find-bar.js
@@ -20,6 +20,10 @@ const ACTIVE_MATCH_HIGHLIGHT = 'celbridge-find-active';
 const STYLE_ELEMENT_ID = 'celbridge-find-styles';
 const ICON_FONT_LINK_ID = 'celbridge-find-icon-font';
 
+// Colors read from the shared stylesheet's --cel-* tokens where the host page links it (celbridge.css), with
+// the previous GitHub-style palette kept as the fallback so the bar is unchanged in a host that does not. The
+// per-theme fallbacks stay split across the base and html[data-theme="dark"] blocks; when the tokens are
+// present they are theme-aware, so both blocks resolve to the same host color.
 const STYLES = `
 .celbridge-find-bar {
     position: fixed;
@@ -31,10 +35,10 @@ const STYLES = `
     gap: 4px;
     padding: 6px 8px;
     font-size: 13px;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
-    background-color: #f6f8fa;
-    color: #24292f;
-    border: 1px solid #d0d7de;
+    font-family: var(--cel-font-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif);
+    background-color: var(--cel-panel-bg-alt, #f6f8fa);
+    color: var(--cel-text-primary, #24292f);
+    border: 1px solid var(--cel-divider, #d0d7de);
     border-top: none;
     border-right: none;
     border-radius: 0 0 0 6px;
@@ -45,10 +49,10 @@ const STYLES = `
     width: 240px;
     padding: 6px 8px;
     font-size: 14px;
-    border: 1px solid #d0d7de;
+    border: 1px solid var(--cel-divider, #d0d7de);
     border-radius: 4px;
-    background-color: #ffffff;
-    color: #24292f;
+    background-color: var(--cel-app-bg, #ffffff);
+    color: var(--cel-text-primary, #24292f);
     outline: none;
 }
 .celbridge-find-count {
@@ -56,7 +60,7 @@ const STYLES = `
     min-width: 88px;
     text-align: center;
     white-space: nowrap;
-    color: #656d76;
+    color: var(--cel-text-secondary, #656d76);
 }
 .celbridge-find-bar button {
     display: inline-flex;
@@ -74,21 +78,21 @@ const STYLES = `
 .celbridge-find-bar button:hover { background-color: rgba(0, 0, 0, 0.08); }
 .celbridge-find-bar .bi { font-size: 15px; }
 .celbridge-find-toggle { font-size: 13px; font-weight: 600; }
-.celbridge-find-toggle[aria-pressed="true"] { background-color: #0969da; color: #ffffff; }
+.celbridge-find-toggle[aria-pressed="true"] { background-color: var(--cel-accent, #0969da); color: var(--cel-accent-text, #ffffff); }
 
 html[data-theme="dark"] .celbridge-find-bar {
-    background-color: #282828;
-    color: #d4d4d4;
-    border-color: #444;
+    background-color: var(--cel-panel-bg-alt, #282828);
+    color: var(--cel-text-primary, #d4d4d4);
+    border-color: var(--cel-divider, #444);
 }
 html[data-theme="dark"] .celbridge-find-input {
-    background-color: #1e1e1e;
-    color: #d4d4d4;
-    border-color: #444;
+    background-color: var(--cel-app-bg, #1e1e1e);
+    color: var(--cel-text-primary, #d4d4d4);
+    border-color: var(--cel-divider, #444);
 }
-html[data-theme="dark"] .celbridge-find-count { color: #9e9e9e; }
+html[data-theme="dark"] .celbridge-find-count { color: var(--cel-text-secondary, #9e9e9e); }
 html[data-theme="dark"] .celbridge-find-bar button:hover { background-color: rgba(255, 255, 255, 0.1); }
-html[data-theme="dark"] .celbridge-find-toggle[aria-pressed="true"] { background-color: #58a6ff; color: #1e1e1e; }
+html[data-theme="dark"] .celbridge-find-toggle[aria-pressed="true"] { background-color: var(--cel-accent, #58a6ff); color: var(--cel-accent-text, #1e1e1e); }
 
 /* Yellow for all matches, orange for the active one, mirroring the familiar browser find colours. */
 ::highlight(celbridge-find) { background-color: #ffd54f; color: #000000; }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/css/editor.css
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/css/editor.css
@@ -4,26 +4,26 @@ html, body {
     overflow: hidden;
 }
 
-/* Theme via [data-theme] attribute (WebView2 doesn't reliably
-   re-evaluate prefers-color-scheme). Accent color is hardcoded
-   because the CSS AccentColor keyword renders as transparent. */
+/* Theme via [data-theme] attribute (WebView2 doesn't reliably re-evaluate prefers-color-scheme). The accent
+   and toolbar-foreground colors derive from the shared tokens (celbridge-tokens.css, linked before this file),
+   so they are single-sourced from Colors.xaml and need no per-theme override here. The remaining tokens are
+   the editor's own translucent divider, toolbar surface, and button-overlay colors, which have no shared
+   equivalent and stay defined per theme below. */
 :root {
-    --accent-color: #0078D4;
+    --accent-color: var(--cel-accent);
+    --toolbar-btn-fg: var(--cel-text-primary);
     --divider-base-color: rgba(0, 0, 0, 0.0803);
     --toolbar-bg: #F3F3F3;
     --toolbar-border: rgba(0, 0, 0, 0.0803);
-    --toolbar-btn-fg: #1F1F1F;
     --toolbar-btn-hover-bg: rgba(0, 0, 0, 0.0402);
     --toolbar-btn-active-bg: rgba(0, 120, 212, 0.12);
     --toolbar-btn-disabled-fg: rgba(0, 0, 0, 0.36);
 }
 
 [data-theme="dark"] {
-    --accent-color: #60CDFF;
     --divider-base-color: rgba(255, 255, 255, 0.0837);
     --toolbar-bg: #202020;
     --toolbar-border: rgba(255, 255, 255, 0.0837);
-    --toolbar-btn-fg: #FFFFFF;
     --toolbar-btn-hover-bg: rgba(255, 255, 255, 0.0605);
     --toolbar-btn-active-bg: rgba(96, 205, 255, 0.18);
     --toolbar-btn-disabled-fg: rgba(255, 255, 255, 0.3628);

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/index.html
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/index.html
@@ -7,6 +7,7 @@
           data-name="vs/editor/editor.main"
           href="./min/vs/editor/editor.main.css" />
     <link rel="stylesheet" href="/assets/bootstrap-icons/bootstrap-icons.css" />
+    <link rel="stylesheet" href="/assets/celbridge-client/celbridge-tokens.css" />
     <link rel="stylesheet" href="./css/editor.css" />
     <link rel="stylesheet" href="./css/toolbar.css" />
 </head>

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -33,7 +33,11 @@ export class EditorController {
             automaticLayout: true,
             theme: initialTheme,
             minimap: { autohide: true },
-            wordWrap: 'on'
+            wordWrap: 'on',
+            // Render hovers, suggestions, and the find widget's toggle tooltips on a fixed layer attached to
+            // the body rather than inside the editor, so they are not clipped by the container's overflow:hidden
+            // when the find widget sits at the top edge.
+            fixedOverflowWidgets: true
         });
 
         this.#setupLineEndings();

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/css/notepad.css
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/css/notepad.css
@@ -1,33 +1,25 @@
+/* Colors and fonts come from the shared stylesheet (/assets/celbridge-client/celbridge.css), which follows
+   the host theme via html[data-theme]. Only Notepad's own layout lives here. */
+
 html, body {
-    margin: 0;
     height: 100%;
 }
 
 #notepad-container {
-    box-sizing: border-box;
     height: 100vh;
     padding: 8px;
 }
 
 #notepad-input {
-    box-sizing: border-box;
     width: 100%;
     height: 100%;
     padding: 8px;
     border: none;
     outline: none;
     resize: none;
-    font-family: Consolas, "Courier New", monospace;
+    font-family: var(--cel-font-mono);
     font-size: 14px;
     line-height: 1.5;
-}
-
-body.theme-light #notepad-input {
-    background-color: #ffffff;
-    color: #1e1e1e;
-}
-
-body.theme-dark #notepad-input {
-    background-color: #1e1e1e;
-    color: #e0e0e0;
+    background: var(--cel-panel-bg-alt);
+    color: var(--cel-text-primary);
 }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/index.html
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/index.html
@@ -6,10 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Celbridge Notepad</title>
     <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/assets/celbridge-client/celbridge.css">
     <link rel="stylesheet" href="css/notepad.css">
 </head>
 
-<body class="theme-light">
+<body>
     <div id="notepad-container">
         <textarea id="notepad-input" spellcheck="false"></textarea>
     </div>

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/js/notepad.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notepad/js/notepad.js
@@ -15,10 +15,6 @@ const inputEl = document.getElementById('notepad-input');
 let suppressChangeNotifications = false;
 let notifyTimer = null;
 
-function applyTheme(theme) {
-    document.body.className = theme === 'Dark' ? 'theme-dark' : 'theme-light';
-}
-
 function applyReadOnlyState(readOnly) {
     suppressChangeNotifications = readOnly;
     inputEl.readOnly = readOnly;
@@ -51,12 +47,6 @@ function scheduleNotifyChanged() {
 }
 
 inputEl.addEventListener('input', scheduleNotifyChanged);
-
-client.appState.onChanged((appState) => {
-    if (appState.theme) {
-        applyTheme(appState.theme);
-    }
-});
 
 client.viewState.onChanged((viewState) => {
     if (viewState.writable) {

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Process/css/process.css
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Process/css/process.css
@@ -1,10 +1,7 @@
-:root {
-    color-scheme: light dark;
-}
+/* Colors and fonts come from the shared stylesheet (/assets/celbridge-client/celbridge.css), which follows
+   the host theme via html[data-theme]. Only Process's own layout lives here. */
 
-html,
-body {
-    margin: 0;
+html, body {
     height: 100%;
 }
 
@@ -12,9 +9,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100%;
-    box-sizing: border-box;
     padding: 12px;
-    font-family: "Segoe UI", system-ui, sans-serif;
 }
 
 #process-title {
@@ -26,27 +21,38 @@ body {
 #process-blurb {
     margin: 0 0 12px 0;
     font-size: 12px;
-    opacity: 0.7;
+    color: var(--cel-text-secondary);
+}
+
+#process-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+#process-controls label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+}
+
+#process-footer {
+    margin: 8px 0 0 0;
+    font-size: 12px;
+    color: var(--cel-text-secondary);
 }
 
 #process-input {
     flex: 1;
     resize: none;
-    border: 1px solid rgba(128, 128, 128, 0.4);
-    border-radius: 4px;
+    border: 1px solid var(--cel-divider);
+    border-radius: var(--cel-radius-control);
     padding: 8px;
-    font-family: "Cascadia Mono", Consolas, monospace;
+    font-family: var(--cel-font-mono);
     font-size: 13px;
-    background: transparent;
-    color: inherit;
-}
-
-body.theme-light {
-    background: #ffffff;
-    color: #1a1a1a;
-}
-
-body.theme-dark {
-    background: #1e1e1e;
-    color: #e6e6e6;
+    background: var(--cel-panel-bg-alt);
+    color: var(--cel-text-primary);
 }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Process/index.html
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Process/index.html
@@ -6,17 +6,43 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Celbridge Process</title>
     <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/assets/celbridge-client/celbridge.css">
     <link rel="stylesheet" href="css/process.css">
 </head>
 
-<body class="theme-light">
+<body>
     <div id="process-container">
         <h1 id="process-title">Process</h1>
         <p id="process-blurb">
             A utility surface: live in the Utility Panel, or dock it into a document tab.
-            Its notes persist per project under the utils: root.
+            Its notes persist per project under the utils: root. The controls below are
+            styled entirely by the shared stylesheet.
         </p>
+        <div id="process-controls">
+            <input id="process-name" type="text" placeholder="Name" aria-label="Name">
+            <select id="process-mode" aria-label="Mode">
+                <option>Watch</option>
+                <option>Build</option>
+                <option>Test</option>
+            </select>
+            <label>
+                <input id="process-verbose" type="checkbox">
+                Verbose
+            </label>
+            <label>
+                Level
+                <input id="process-level" type="range" min="0" max="100" value="50">
+            </label>
+            <button id="process-add" type="button">Add</button>
+            <button id="process-run" class="cel-accent" type="button">Run</button>
+            <button id="process-stop" type="button" disabled>Stop</button>
+        </div>
         <textarea id="process-input" spellcheck="false"></textarea>
+        <hr>
+        <p id="process-footer">
+            Every control here is styled by <code>celbridge.css</code>.
+            <a href="#">Learn more</a>.
+        </p>
     </div>
 
     <script type="module" src="js/process.js"></script>

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Process/js/process.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Process/js/process.js
@@ -16,10 +16,6 @@ const inputEl = document.getElementById('process-input');
 let suppressChangeNotifications = false;
 let notifyTimer = null;
 
-function applyTheme(theme) {
-    document.body.className = theme === 'Dark' ? 'theme-dark' : 'theme-light';
-}
-
 function applyReadOnlyState(readOnly) {
     suppressChangeNotifications = readOnly;
     inputEl.readOnly = readOnly;
@@ -52,12 +48,6 @@ function scheduleNotifyChanged() {
 }
 
 inputEl.addEventListener('input', scheduleNotifyChanged);
-
-client.appState.onChanged((appState) => {
-    if (appState.theme) {
-        applyTheme(appState.theme);
-    }
-});
 
 client.viewState.onChanged((viewState) => {
     if (viewState.writable) {


### PR DESCRIPTION
Introduce celbridge.css and celbridge-tokens.css, providing a centralized design-token system and form-control styling for WebView editors and utilities. Tokens mirror the native app's theme (Colors.xaml) and update automatically via html[data-theme]. Editors now link the shared stylesheet instead of implementing individual theme listeners, reducing duplication and ensuring consistency. Updated Notepad, Process, CodeEditor, and find-bar to consume the tokens. Documentation updated to reflect the new import paths and styling conventions.