### PR TITLE
Handle empty TOML manifests

### DIFF
--- a/Source/Core/Celbridge.Projects/Services/ProjectConfigParser.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectConfigParser.cs
@@ -58,6 +58,11 @@ public static class ProjectConfigParser
             }
 
             var root = TomlSerializer.Deserialize<TomlTable>(text);
+            if (root is null)
+            {
+                return Result<ProjectConfig>.Fail($"Failed to deserialize TOML file: {configFilePath}");
+            }
+
             var config = MapRootToModel(root);
 
             return Result<ProjectConfig>.Ok(config);

--- a/Source/Core/Celbridge.Projects/Services/ProjectConfigReader.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectConfigReader.cs
@@ -89,6 +89,18 @@ public class ProjectConfigReader
             }
 
             var root = TomlSerializer.Deserialize<TomlTable>(text);
+            if (root is null)
+            {
+                _logger.LogWarning($"Failed to deserialize TOML in '{projectFilePath}'");
+
+                return Result<ProjectMetadata>.Ok(new ProjectMetadata(
+                    projectFilePath,
+                    projectName,
+                    projectFolderPath,
+                    CelbridgeVersion: null,
+                    IsConfigValid: false));
+            }
+
             isConfigValid = true;
 
             // Try to extract version from [celbridge] section

--- a/Source/Core/Celbridge.Projects/Services/ProjectMigrationService.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectMigrationService.cs
@@ -130,6 +130,12 @@ public class ProjectMigrationService : IProjectMigrationService
             }
 
             var root = TomlSerializer.Deserialize<TomlTable>(text);
+            if (root is null)
+            {
+                return ParseResult.Failure(
+                    ParseFailureReason.InvalidToml,
+                    Result.Fail("Failed to deserialize project TOML file"));
+            }
 
             // Get project version from [celbridge].celbridge-version property
             var projectVersion = string.Empty;
@@ -538,6 +544,11 @@ public class ProjectMigrationService : IProjectMigrationService
         }
 
         var root = TomlSerializer.Deserialize<TomlTable>(text);
+        if (root is null)
+        {
+            return Result<TomlTable>.Fail("Failed to deserialize project TOML file");
+        }
+
         return Result<TomlTable>.Ok(root);
     }
 }

--- a/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Publish.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Package/PackageTools.Publish.cs
@@ -338,7 +338,7 @@ public partial class PackageTools
         }
         var tomlContent = readResult.Value;
 
-        TomlTable tomlTable;
+        TomlTable? tomlTable;
         try
         {
             tomlTable = TomlSerializer.Deserialize<TomlTable>(tomlContent);
@@ -346,6 +346,11 @@ public partial class PackageTools
         catch (TomlException exception)
         {
             return Result.Fail($"Invalid TOML in package manifest: {exception.Message}");
+        }
+
+        if (tomlTable is null)
+        {
+            return Result.Fail("Package manifest is empty or not a valid TOML table.");
         }
 
         if (!tomlTable.TryGetValue("package", out var packageSection)

--- a/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
@@ -204,7 +204,7 @@ public partial class PageTools
         }
         var tomlContent = readResult.Value;
 
-        TomlTable tomlTable;
+        TomlTable? tomlTable;
         try
         {
             tomlTable = TomlSerializer.Deserialize<TomlTable>(tomlContent);
@@ -212,6 +212,11 @@ public partial class PageTools
         catch (TomlException exception)
         {
             return Result.Fail($"Invalid TOML in page manifest: {exception.Message}");
+        }
+
+        if (tomlTable is null)
+        {
+            return Result.Fail($"Page manifest '{PageConstants.ManifestFileName}' is empty or not a valid TOML table.");
         }
 
         if (!tomlTable.TryGetValue("publish", out var publishSection)

--- a/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/SidecarHelper.cs
@@ -208,6 +208,12 @@ public static class SidecarHelper
             }
 
             var table = TomlSerializer.Deserialize<TomlTable>(tomlText);
+            if (table is null)
+            {
+                return Result<IReadOnlyDictionary<string, object>>.Ok(
+                    new Dictionary<string, object>());
+            }
+
             var dictionary = new Dictionary<string, object>();
             foreach (var (key, value) in table)
             {


### PR DESCRIPTION
Treat `TomlSerializer.Deserialize<TomlTable>` returning null as an invalid/empty manifest across project, package, page, and sidecar parsing paths. This avoids null dereferences and returns clearer failures or safe empty results when TOML content cannot be mapped to a table.