### PR TITLE
Restrict drop highlight to panels and propagate tab drop slots

### DIFF
--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.TabDrag.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.TabDrag.cs
@@ -84,7 +84,7 @@ public sealed partial class DocumentSection
             return;
         }
 
-        bool wasSelected = TabView.SelectedItem == tab;
+        bool wasSelected = ReferenceEquals(TabView.SelectedItem, tab);
         TabView.TabItems.RemoveAt(currentIndex);
         DetachStrandedContainer(tab);
         TabView.TabItems.Insert(targetIndex, tab);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
@@ -67,9 +67,10 @@ public sealed partial class DocumentSection : UserControl
     public event Action<DocumentSection, DocumentTab>? TabDroppedInside;
 
     /// <summary>
-    /// Event raised when resource files are dropped into this section from the ResourceTree.
+    /// Event raised when resource files are dropped into this section from the ResourceTree, with the
+    /// insertion slot in the tab order the drop point maps to.
     /// </summary>
-    public event Action<DocumentSection, List<IResource>>? FilesDropped;
+    public event Action<DocumentSection, List<IResource>, int>? FilesDropped;
 
     public DocumentSection()
     {
@@ -596,7 +597,8 @@ public sealed partial class DocumentSection : UserControl
         var draggedResources = TakeResourceDragPayload(e);
         if (draggedResources != null)
         {
-            FilesDropped?.Invoke(this, draggedResources);
+            int insertionSlot = GetInsertionSlot(e.GetPosition(this).X, this);
+            FilesDropped?.Invoke(this, draggedResources, insertionSlot);
             e.Handled = true;
         }
     }
@@ -648,7 +650,8 @@ public sealed partial class DocumentSection : UserControl
         var draggedResources = TakeResourceDragPayload(e);
         if (draggedResources != null)
         {
-            FilesDropped?.Invoke(this, draggedResources);
+            int insertionSlot = GetInsertionSlot(e.GetPosition(this).X, this);
+            FilesDropped?.Invoke(this, draggedResources, insertionSlot);
             e.Handled = true;
         }
     }

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
@@ -65,9 +65,10 @@ public sealed partial class DocumentSectionContainer : UserControl
     public event Action<List<double>>? SectionRatiosChanged;
 
     /// <summary>
-    /// Event raised when resource files are dropped into a section from the ResourceTree.
+    /// Event raised when resource files are dropped into a section from the ResourceTree, with the
+    /// insertion slot in the tab order the drop point maps to.
     /// </summary>
-    public event Action<DocumentSection, List<IResource>>? FilesDropped;
+    public event Action<DocumentSection, List<IResource>, int>? FilesDropped;
 
     /// <summary>
     /// Gets the current number of sections.
@@ -921,9 +922,9 @@ public sealed partial class DocumentSectionContainer : UserControl
         }
     }
 
-    private void OnSectionFilesDropped(DocumentSection targetSection, List<IResource> resources)
+    private void OnSectionFilesDropped(DocumentSection targetSection, List<IResource> resources, int insertionSlot)
     {
-        FilesDropped?.Invoke(targetSection, resources);
+        FilesDropped?.Invoke(targetSection, resources, insertionSlot);
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -149,18 +149,17 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
         ViewModel.OnSectionRatiosChanged(ratios);
     }
 
-    private void OnSectionFilesDropped(DocumentSection targetSection, List<IResource> resources)
+    private void OnSectionFilesDropped(DocumentSection targetSection, List<IResource> resources, int insertionSlot)
     {
-        // The built-in drag-and-drop path shows no divider, so the drop appends. The pointer-driven
-        // path arrives through TryDrop instead, which carries the divider's insertion slot.
-        _ = HandleDroppedFiles(targetSection, resources, insertionSlot: null);
+        // The built-in drag-and-drop path: the section maps the drop point to an insertion slot. The
+        // pointer-driven path arrives through TryDrop instead, which carries the divider's insertion slot.
+        _ = HandleDroppedFiles(targetSection, resources, insertionSlot);
     }
 
-    // The insertion slot is where the drop's divider landed in the target section's tab order, or null
-    // to append (the built-in drag-and-drop heads show no divider and always append). The open is awaited
+    // The insertion slot is where the drop landed in the target section's tab order. The open is awaited
     // so focus can transfer to the resulting document once its view exists; the command queue serializes
     // the opens either way, so this does not change the order documents open in.
-    private async Task HandleDroppedFiles(DocumentSection targetSection, List<IResource> resources, int? insertionSlot)
+    private async Task HandleDroppedFiles(DocumentSection targetSection, List<IResource> resources, int insertionSlot)
     {
         if (_isShuttingDown)
         {
@@ -180,8 +179,8 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
 
             var fileResourceKey = ViewModel.GetResourceKey(fileResource);
 
-            // Several files dropped at one divider insert consecutively from that slot.
-            int? slot = insertionSlot is int start ? start + droppedFileOffset : null;
+            // Several files dropped at one slot insert consecutively from it.
+            int slot = insertionSlot + droppedFileOffset;
             droppedFileOffset++;
 
             // Check if the file is already open in any section
@@ -198,10 +197,7 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
                 }
                 else
                 {
-                    if (slot is int reorderSlot)
-                    {
-                        existingSection.ReorderTab(existingTab, reorderSlot);
-                    }
+                    existingSection.ReorderTab(existingTab, slot);
                     existingSection.SelectTab(existingTab);
                     SectionContainer.ActivateDocument(fileResourceKey, targetSectionIndex);
                 }

--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.PointerDrag.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.PointerDrag.cs
@@ -24,7 +24,7 @@ public sealed partial class ResourceTree : IResourceDropTarget
 {
     private IResourceDragCoordinator? _resourceDragCoordinator;
     private readonly PointerEventHandler _listPointerPressedHandler;
-    private FrameworkElement? _dropHighlightElement;
+    private Panel? _dropHighlightElement;
 
     /// <summary>
     /// Disables the built-in ListView drag source on heads that use the pointer-driven coordinator, and
@@ -200,7 +200,7 @@ public sealed partial class ResourceTree : IResourceDropTarget
     private void HighlightDropTarget(ResourceViewItem targetItem)
     {
         var container = ResourceListView.ContainerFromItem(targetItem) as ListViewItem;
-        var contentGrid = container is null ? null : VisualTree.FindDescendantByName(container, "ContentGrid") as FrameworkElement;
+        var contentGrid = container is null ? null : VisualTree.FindDescendantByName(container, "ContentGrid") as Panel;
         if (contentGrid is null)
         {
             ClearDragFeedback();


### PR DESCRIPTION
This pull request updates the drag-and-drop handling for resource files in the document workspace, ensuring that the exact insertion slot in the tab order is tracked and used throughout the system. The changes improve the precision of where dropped files are inserted and simplify the related event signatures and logic. Additionally, there are minor type corrections for drag feedback visuals in the resource tree.

**Drag-and-drop insertion slot tracking:**

* The `FilesDropped` event in both `DocumentSection` and `DocumentSectionContainer` now includes an `int insertionSlot` parameter, indicating the exact tab order position for dropped files. All relevant event handlers and invocations have been updated to pass and use this slot. [[1]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00L70-R73) [[2]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00L599-R601) [[3]](diffhunk://#diff-821acb4e61e8aebea20df31fe66c3734f35ff49237a7207b4ac85559cbb3ef00L651-R654) [[4]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L68-R71) [[5]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L924-R927) [[6]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decL152-R162)
* The logic for handling dropped files now always expects a non-null insertion slot, and files dropped together are inserted consecutively starting at that slot.
* When a dropped file is already open, its tab is reordered to the correct slot using the updated logic.

**Tab reordering correctness:**

* In `ReorderTab`, tab selection is now checked using `ReferenceEquals` to avoid issues with value equality.

**Drag feedback type correction:**

* The type of `_dropHighlightElement` and related variables in the resource tree drag-and-drop code has been changed from `FrameworkElement` to `Panel` for improved type accuracy. [[1]](diffhunk://#diff-47ad12d4cdc7d080171a5e5fc9ebf44fe9d3b4a85e8971afc6350fb421cf6584L27-R27) [[2]](diffhunk://#diff-47ad12d4cdc7d080171a5e5fc9ebf44fe9d3b4a85e8971afc6350fb421cf6584L203-R203)