### PR TITLE
Guide macOS agents to Reload Project menu

### DIFF
--- a/Source/Core/Celbridge.Tools/Guides/Concepts/agent_instructions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/agent_instructions.md
@@ -6,7 +6,7 @@ You are reading this because the auto-attach response filter prepended it to the
 
 The first non-proxy tool call this session also delivered two state snapshots ahead of these instructions:
 
-- **App state** — the running app `version`, whether a project is loaded, the `featureFlags` map (consult before invoking a feature-gated tool such as `webview_eval`), the `focusedPanel`, and the `layoutMode` visibility flags.
+- **App state** — the running app `version`, whether a project is loaded, the `featureFlags` map (consult before invoking a feature-gated tool such as `webview_eval`), the `focusedPanel`, whether `usesNativeMenuBar` is enabled, and the `layoutMode` visibility flags.
 - **Open documents** — the active document and the full list of open editor tabs with their `resource`, `sectionIndex`, `tabOrder`, `isActive`, and `editorId`.
 
 These are **snapshots taken at session start**. The user can switch tabs, open new files, or change focus at any time, and your snapshot will not update with them. Whenever current state matters — resolving an ambiguous file reference, deciding whether a feature flag is enabled, checking which document is active before a `webview_*` call — call `app_get_state` or `document_get_state` to refresh.

--- a/Source/Core/Celbridge.Tools/Guides/Namespaces/app.md
+++ b/Source/Core/Celbridge.Tools/Guides/Namespaces/app.md
@@ -4,7 +4,8 @@ The `app` namespace covers application-level concerns that are not tied to a spe
 
 ## Must-knows
 
-- **Call `app_get_state` first.** It reports the running app `version`, whether a project is loaded, the feature-flag map (consult before invoking a feature-gated tool such as `webview_eval`), the focused panel, and the layout-mode visibility flags.
+- **Call `app_get_state` first.** It reports the running app `version`, whether a project is loaded, the feature-flag map (consult before invoking a feature-gated tool such as `webview_eval`), the focused panel, whether `usesNativeMenuBar` is enabled, and the layout-mode visibility flags.
+- **Use the native menu bar when it is available.** When `usesNativeMenuBar` is true, tell the user to choose menu commands by their menu path rather than spotlighting the in-window control. For example, tell them to choose **File > Reload Project** to reload a project.
 - **Point at the UI rather than describing it.** When the user asks where something is, or you are orienting a new user, `app_spotlight` highlights a named landmark (a panel or button) with a callout; an empty target clears it. The `workspace_panels` guide maps the UI and `app_spotlight` lists the landmark names.
 - **Logging tools are user-visible.** `app_log`, `app_log_warning`, and `app_log_error` write to the console panel the user can see. Use them for status the user should notice; do not use them for internal trace output.
 - **`app_show_alert` is interactive.** It blocks until the user dismisses the dialog. Use it for genuinely modal confirmations, not status updates.

--- a/Source/Core/Celbridge.Tools/Tools/App/AppStateProvider.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppStateProvider.cs
@@ -20,8 +20,9 @@ public record class LayoutModeInfo(
 /// <summary>
 /// Result returned by app_get_state, reporting the running version, project load
 /// state, feature flag states, the focused panel ("None" when unfocused), the utility
-/// currently shown in the Utility Panel rail ("" when no project is loaded), the current
-/// panel layout, and the spotlightable landmark ids app_spotlight accepts.
+/// currently shown in the Utility Panel rail ("" when no project is loaded), whether the
+/// platform supplies a native menu bar, the current panel layout, and the spotlightable landmark ids
+/// app_spotlight accepts.
 /// </summary>
 public record class AppStateResult(
     string Version,
@@ -31,7 +32,8 @@ public record class AppStateResult(
     string FocusedPanel,
     string ActiveUtility,
     LayoutModeInfo LayoutMode,
-    IReadOnlyList<string> SpotlightLandmarks);
+    IReadOnlyList<string> SpotlightLandmarks,
+    bool UsesNativeMenuBar = false);
 
 /// <summary>
 /// Builds the AppStateResult snapshot describing current app and workspace state.
@@ -49,6 +51,7 @@ internal sealed class AppStateProvider : IAppStateProvider
     private static readonly IReadOnlyList<string> KnownFeatureFlagNames = ReadFeatureFlagNames();
 
     private readonly IAppEnvironment _environmentService;
+    private readonly IPlatformInfo _platformInfo;
     private readonly IProjectService _projectService;
     private readonly IFeatureFlags _featureFlags;
     private readonly IFocusService _focusService;
@@ -62,6 +65,7 @@ internal sealed class AppStateProvider : IAppStateProvider
 
     public AppStateProvider(
         IAppEnvironment environmentService,
+        IPlatformInfo platformInfo,
         IProjectService projectService,
         IFeatureFlags featureFlags,
         IFocusService focusService,
@@ -70,6 +74,7 @@ internal sealed class AppStateProvider : IAppStateProvider
         IMessengerService messengerService)
     {
         _environmentService = environmentService;
+        _platformInfo = platformInfo;
         _projectService = projectService;
         _featureFlags = featureFlags;
         _focusService = focusService;
@@ -122,7 +127,8 @@ internal sealed class AppStateProvider : IAppStateProvider
             FocusedPanel: focusedPanel,
             ActiveUtility: activeUtility,
             LayoutMode: layoutMode,
-            SpotlightLandmarks: spotlightLandmarks);
+            SpotlightLandmarks: spotlightLandmarks,
+            UsesNativeMenuBar: _platformInfo.UsesNativeMenuBar);
     }
 
     private static IReadOnlyList<string> ReadFeatureFlagNames()

--- a/Source/Tests/Tools/AppToolTests.cs
+++ b/Source/Tests/Tools/AppToolTests.cs
@@ -88,6 +88,20 @@ public class AppToolTests
     }
 
     [Test]
+    public void GetState_IncludesWhetherThePlatformUsesNativeMenuBar()
+    {
+        WireAppStateDependencies(usesNativeMenuBar: true);
+        var projectService = Substitute.For<IProjectService>();
+        projectService.CurrentProject.Returns((IProject?)null);
+        _services.GetRequiredService<IProjectService>().Returns(projectService);
+
+        var tools = new AppTools(_services);
+        var root = ParseResult(tools.GetState());
+
+        root.GetProperty("usesNativeMenuBar").GetBoolean().Should().BeTrue();
+    }
+
+    [Test]
     public void GetState_IncludesFocusedPanelAndLayoutMode()
     {
         WireAppStateDependencies(
@@ -143,6 +157,7 @@ public class AppToolTests
 
     private IFeatureFlags WireAppStateDependencies(
         WorkspacePanel focusedPanel = WorkspacePanel.None,
+        bool usesNativeMenuBar = false,
         bool contextVisible = false,
         bool inspectorVisible = false,
         bool consoleVisible = false,
@@ -156,6 +171,9 @@ public class AppToolTests
         var environmentInfo = new EnvironmentInfo(appVersion, "Windows", "Debug");
         environmentService.GetEnvironmentInfo().Returns(environmentInfo);
 
+        var platformInfo = Substitute.For<IPlatformInfo>();
+        platformInfo.UsesNativeMenuBar.Returns(usesNativeMenuBar);
+
         var focusService = Substitute.For<IFocusService>();
         focusService.FocusedPanel.Returns(focusedPanel);
 
@@ -167,6 +185,7 @@ public class AppToolTests
 
         _services.GetRequiredService<IFeatureFlags>().Returns(featureFlags);
         _services.GetRequiredService<IAppEnvironment>().Returns(environmentService);
+        _services.GetRequiredService<IPlatformInfo>().Returns(platformInfo);
         _services.GetRequiredService<IFocusService>().Returns(focusService);
         _services.GetRequiredService<ILayoutService>().Returns(layoutService);
 
@@ -182,6 +201,7 @@ public class AppToolTests
         _services.GetRequiredService<IAppStateProvider>().Returns(
             _ => new AppStateProvider(
                 environmentService,
+                platformInfo,
                 _services.GetRequiredService<IProjectService>(),
                 featureFlags,
                 focusService,


### PR DESCRIPTION
# Guide macOS agents to Reload Project menu

## Summary

On macOS, agents could spotlight the Windows-style in-window navigation control when asking users to reload a project. `app_get_state` now exposes whether the running platform has a native menu bar, and the app guide tells agents to use native menu paths in that case. This directs macOS users to **File > Reload Project** instead.

Fixes #788

## Changes

- Expose `usesNativeMenuBar` in the application-state response.
- Guide agents to describe native menu commands rather than spotlighting in-window controls when that capability is enabled.
- Cover the native-menu-bar state value with an `app_get_state` unit test.

## Testing

- `sandbox-run "dotnet test Source/Tests/Celbridge.Tests.csproj --filter FullyQualifiedName~AppToolTests"` — could not run because the sandbox image does not provide `dotnet` (`bash: line 1: dotnet: command not found`).
- `git diff --check` — passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
