### PR TITLE
Fix macOS tab strip visibility for active document tab

### DIFF
--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
@@ -84,6 +84,27 @@ public sealed partial class DocumentSection : UserControl
 
         // Disable tab add/remove animations so tabs snap into place immediately
         TabView.Loaded += (s, e) => DisableTabViewAnimations();
+
+        // On macOS the strip does not re-reveal the selected tab when it gets narrower, so a window resize
+        // or a change in the number of sections can leave the active tab clipped off-screen. Re-scroll it
+        // into view whenever the strip's width changes.
+        if (_platformInfo.RequiresMacOSTabScrollIntoView)
+        {
+            TabView.SizeChanged += OnTabViewSizeChanged;
+        }
+    }
+
+    private void OnTabViewSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        if (TabView.SelectedItem is DocumentTab selectedTab)
+        {
+            ScrollTabIntoView(selectedTab);
+        }
     }
 
     /// <summary>
@@ -308,7 +329,9 @@ public sealed partial class DocumentSection : UserControl
     }
 
     /// <summary>
-    /// Scrolls the tab strip so the given tab is visible when it lies outside the visible area.
+    /// Scrolls the tab strip so the given tab is visible when it lies outside the visible area. macOS only:
+    /// the Uno TabView does not bring the selected tab into view on its own, so the strip's scroll offset is
+    /// driven directly once its layout has settled.
     /// </summary>
     private void ScrollTabIntoView(DocumentTab tab)
     {
@@ -320,12 +343,71 @@ public sealed partial class DocumentSection : UserControl
 
         // Defer to the next dispatcher cycle so the tab strip has completed layout. A tab that was just
         // added, or a selection that changes the strip's extent, has no scroll geometry to act on until
-        // the layout pass runs, so scrolling synchronously here would be a no-op.
+        // the layout pass runs, so measuring synchronously here would read stale bounds.
         DispatcherQueue.TryEnqueue(() =>
         {
             var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
-            tabListView?.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
+            if (tabListView is null)
+            {
+                return;
+            }
+
+            var scrollViewer = VisualTree.FindDescendant<ScrollViewer>(tabListView);
+            if (scrollViewer is null)
+            {
+                return;
+            }
+
+            // Realize the container for an off-screen (virtualized) tab and force the strip to lay out, so
+            // the measurements below reflect the settled geometry rather than a transient resize state.
+            tabListView.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
+            tabListView.UpdateLayout();
+
+            var container = tabListView.ContainerFromItem(tab) as FrameworkElement;
+            if (container is null ||
+                container.ActualWidth == 0)
+            {
+                // Uno can realize a tab many positions off-screen without arranging it (zero bounds). Its
+                // ScrollIntoView above is the best available fallback; driving the scroll from zero geometry
+                // would only push the strip to the wrong place.
+                return;
+            }
+
+            // Position of the tab relative to the visible viewport. A negative value means the tab is clipped
+            // off the leading edge; a right edge past the viewport width means it is clipped off the trailing
+            // edge. The minimum scroll that clears the offending edge keeps the rest of the strip stable.
+            double tabViewportX = TabViewportLeft(container, scrollViewer);
+            double tabWidth = container.ActualWidth;
+            double viewportWidth = scrollViewer.ViewportWidth;
+            double currentOffset = scrollViewer.HorizontalOffset;
+
+            double? targetOffset = null;
+            if (tabViewportX < 0)
+            {
+                targetOffset = currentOffset + tabViewportX;
+            }
+            else if (tabViewportX + tabWidth > viewportWidth)
+            {
+                targetOffset = currentOffset + (tabViewportX + tabWidth - viewportWidth);
+            }
+
+            if (targetOffset is null)
+            {
+                return;
+            }
+
+            double clampedOffset = Math.Clamp(targetOffset.Value, 0, scrollViewer.ScrollableWidth);
+            scrollViewer.ChangeView(clampedOffset, null, null, disableAnimation: true);
         });
+    }
+
+    /// <summary>
+    /// The x offset of a tab container relative to the tab strip's scroll viewport.
+    /// </summary>
+    private static double TabViewportLeft(FrameworkElement container, ScrollViewer scrollViewer)
+    {
+        var origin = new Windows.Foundation.Point(0, 0);
+        return container.TransformToVisual(scrollViewer).TransformPoint(origin).X;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #731

This pull request improves the tab strip behavior on macOS to ensure the selected tab is always visible, especially after window resizes or changes in the number of sections. The update adds logic to detect when the tab strip's width changes and programmatically scrolls the selected tab into view, working around a limitation in Uno's TabView on macOS. It also enhances the scrolling logic to handle virtualized tabs and transient layout states more robustly.

**macOS Tab Visibility Improvements:**

* Added a `SizeChanged` event handler to `TabView` on macOS platforms to automatically scroll the selected tab into view whenever the tab strip's width changes, preventing the active tab from being clipped off-screen.
* Enhanced the `ScrollTabIntoView` method to realize off-screen (virtualized) tabs, force layout updates, and accurately compute the scroll offset needed to bring the selected tab fully into view, clamping the scroll position to valid bounds.
* Added a helper method `TabViewportLeft` to calculate a tab's position relative to the scroll viewport, enabling precise scroll adjustments.
* Updated the XML documentation for `ScrollTabIntoView` to clarify its macOS-specific behavior and rationale.Ensure the active document tab stays visible on macOS when the tab strip width changes. The change hooks `TabView.SizeChanged` behind `RequiresMacOSTabScrollIntoView` and updates `ScrollTabIntoView` to measure the realized tab container, compute the minimal horizontal offset needed, clamp it, and call `ScrollViewer.ChangeView` without animation. This avoids cases where the selected tab remained clipped after resize or section-count changes.