### PR TITLE
Remove chrome project-title platform flag

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -46,12 +46,6 @@ public interface IPlatformInfo
     bool PickersRequireWindowHandle { get; }
 
     /// <summary>
-    /// Whether the host chrome (the custom title bar) shows the open project's name, so the explorer banner
-    /// shows a generic title instead of duplicating it. True on the packaged Windows head only.
-    /// </summary>
-    bool HostShowsProjectTitleInChrome { get; }
-
-    /// <summary>
     /// The keyboard modifier that issues application commands. Command on macOS. Control on Windows and Linux.
     /// </summary>
     CommandModifierKey CommandModifier { get; }

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -36,18 +36,6 @@ public sealed class PlatformInfo : IPlatformInfo
         }
     }
 
-    public bool HostShowsProjectTitleInChrome
-    {
-        get
-        {
-#if WINDOWS
-            return true;
-#else
-            return false;
-#endif
-        }
-    }
-
     public CommandModifierKey CommandModifier => OperatingSystem.IsMacOS()
         ? CommandModifierKey.Command
         : CommandModifierKey.Control;

--- a/Source/Workspace/Celbridge.Explorer/ViewModels/ExplorerPanelViewModel.cs
+++ b/Source/Workspace/Celbridge.Explorer/ViewModels/ExplorerPanelViewModel.cs
@@ -1,6 +1,4 @@
 using Celbridge.Commands;
-using Celbridge.Platform;
-using Celbridge.Projects;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.Localization;
 
@@ -15,26 +13,13 @@ public partial class ExplorerPanelViewModel : ObservableObject
     private string _titleText = string.Empty;
 
     public ExplorerPanelViewModel(
-        IProjectService projectService,
-        ICommandService commandService,
-        IPlatformInfo platformInfo)
+        ICommandService commandService)
     {
         _commandService = commandService;
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
-        // The project data is guaranteed to have been loaded at this point, so it's safe to just
-        // acquire a reference via the ProjectService.
-        var project = projectService.CurrentProject!;
-
-        // When the host chrome (the custom title bar) shows the project name, the banner shows a generic
-        // title instead of duplicating it. Otherwise the banner carries the project name.
-        if (platformInfo.HostShowsProjectTitleInChrome)
-        {
-            TitleText = _stringLocalizer.GetString("ExplorerPanel_Title");
-        }
-        else
-        {
-            TitleText = project.ProjectName;
-        }
+        // The open project's name is shown in the page navigation toolbar, so the panel header carries the
+        // generic utility title to match the other workspace panels.
+        TitleText = _stringLocalizer.GetString("ExplorerPanel_Title");
     }
 }


### PR DESCRIPTION
Drops `HostShowsProjectTitleInChrome` from `IPlatformInfo` and `PlatformInfo`, removing the Windows-only chrome check. `ExplorerPanelViewModel` no longer depends on `IProjectService` or `IPlatformInfo` for its title and now always uses the localized `ExplorerPanel_Title`, since the project name is already shown in the workspace navigation toolbar.