### PR TITLE
Fix close tab tooltip shortcut text for macOS and Windows

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -758,6 +758,9 @@ Do you wish to continue?</value>
   <data name="DocumentTab_CloseAllShortcutControl" xml:space="preserve">
     <value>Ctrl+Shift+W</value>
   </data>
+  <data name="DocumentTab_CloseTabTooltip" xml:space="preserve">
+    <value>Close tab ({0})</value>
+  </data>
   <data name="DocumentTab_MoveLeft" xml:space="preserve">
     <value>Move Left</value>
   </data>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -121,17 +121,46 @@ public partial class DocumentTab : TabViewItem
     }
 
     // Displays the close shortcut hints next to the Close and Close All menu items. These are display-only
-    // labels matching the shortcuts handled in KeyboardShortcutService. The platform command modifier selects
-    // between the Command-glyph form shown on macOS and the "Ctrl" form shown on Windows.
+    // labels matching the shortcuts handled in KeyboardShortcutService.
     private void ApplyCloseShortcutHints()
     {
         bool usesCommandModifier = _platformInfo.CommandModifier == CommandModifierKey.Command;
-
-        string closeHintKey = usesCommandModifier ? "DocumentTab_CloseShortcutCommand" : "DocumentTab_CloseShortcutControl";
         string closeAllHintKey = usesCommandModifier ? "DocumentTab_CloseAllShortcutCommand" : "DocumentTab_CloseAllShortcutControl";
 
-        CloseMenuItem.KeyboardAcceleratorTextOverride = _stringLocalizer.GetString(closeHintKey);
+        CloseMenuItem.KeyboardAcceleratorTextOverride = GetCloseShortcutHint();
         CloseAllMenuItem.KeyboardAcceleratorTextOverride = _stringLocalizer.GetString(closeAllHintKey);
+    }
+
+    // The display form of the close-document shortcut for the current platform: the Command-glyph form on macOS,
+    // the "Ctrl" form on Windows. Matches the shortcut handled in KeyboardShortcutService.
+    private string GetCloseShortcutHint()
+    {
+        bool usesCommandModifier = _platformInfo.CommandModifier == CommandModifierKey.Command;
+        string closeHintKey = usesCommandModifier ? "DocumentTab_CloseShortcutCommand" : "DocumentTab_CloseShortcutControl";
+
+        return _stringLocalizer.GetString(closeHintKey);
+    }
+
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        OverrideCloseButtonTooltip();
+    }
+
+    // Uno's TabViewItem seeds the close button with a hardcoded "Close tab (Ctrl+F4)" tooltip that ignores the
+    // platform and the app's actual binding. Replace it with the close shortcut the app binds, so macOS shows the
+    // Command glyph and both platforms match the close hint on the tab context menu.
+    private void OverrideCloseButtonTooltip()
+    {
+        if (GetTemplateChild("CloseButton") is not Button closeButton)
+        {
+            return;
+        }
+
+        string shortcutHint = GetCloseShortcutHint();
+        string tooltipText = _stringLocalizer.GetString("DocumentTab_CloseTabTooltip", shortcutHint);
+        ToolTipService.SetToolTip(closeButton, tooltipText);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #795.

This pull request improves the user experience for closing document tabs by ensuring that the close button tooltip and shortcut hints accurately reflect the current platform's key bindings. The changes update both the UI text resources and the logic for displaying shortcut information, especially addressing inconsistencies between platforms.

**UI improvements for close tab shortcuts:**

* Added a new localized string `DocumentTab_CloseTabTooltip` to `Resources.resw` to provide a consistent tooltip for the close tab button, including the correct shortcut key for the current platform.

**Code changes to support dynamic tooltips and shortcut hints:**

* Refactored the shortcut hint logic by extracting it into a new `GetCloseShortcutHint()` method, which selects the correct shortcut display based on platform.
* Implemented `OverrideCloseButtonTooltip()` to replace the default close button tooltip with the correct, localized shortcut for the platform, ensuring consistency with the context menu. This is called from the new override of `OnApplyTemplate()`.
* Simplified `ApplyCloseShortcutHints()` to use the new shortcut hint method for the close menu item, further ensuring consistency in displayed shortcuts.Adds a localized `DocumentTab_CloseTabTooltip` string and updates `DocumentTab` to compute the close shortcut hint once per platform. The tab now overrides `OnApplyTemplate` to replace Uno’s hardcoded close-button tooltip (`Ctrl+F4`) with the app’s actual close shortcut, keeping tooltip and context-menu hints consistent on both macOS and Windows.