### PR TITLE
Enable Cmd+Backspace for delete in resource tree

### DIFF
--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.Keyboard.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.Keyboard.cs
@@ -104,13 +104,15 @@ public sealed partial class ResourceTree : IEditTarget
 
     private static EditIntent? ResolveEditIntent(VirtualKey key)
     {
+        // Delete is modifier-agnostic so the macOS native Cmd+Backspace shortcut deletes the selection
+        // just as plain Backspace and Delete do.
+        if (EditKeyboard.IsDeleteKey(key))
+        {
+            return EditIntent.Delete;
+        }
+
         if (!EditKeyboard.IsCommandModifierDown())
         {
-            if (EditKeyboard.IsDeleteKey(key))
-            {
-                return EditIntent.Delete;
-            }
-
             if (key == VirtualKey.F2)
             {
                 return EditIntent.Rename;


### PR DESCRIPTION
Fixes #789.

This pull request makes a targeted update to the edit intent resolution logic in `ResourceTree.Keyboard.cs`. The main change clarifies the handling of the Delete key, ensuring that the macOS-native Cmd+Backspace shortcut is treated the same as plain Backspace and Delete, regardless of modifier keys.

Edit intent handling improvements:

* Modified `ResolveEditIntent` so that Delete actions (including Cmd+Backspace on macOS) are now recognized without requiring command modifiers, aligning with native platform behavior.Treat delete keys as modifier-agnostic when resolving edit intents, so macOS native Cmd+Backspace now triggers delete in the resource tree alongside Backspace/Delete.