### PR TITLE
Unify asset path resolution across all platform heads

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IAppEnvironment.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IAppEnvironment.cs
@@ -39,8 +39,7 @@ public interface IAppEnvironment
 
     /// <summary>
     /// Returns the on-disk path to a bundled asset (file or folder) shipped by the given library module,
-    /// at the forward-slashed relative path within that module's bundled files. The relative path must
-    /// start with the module's Assets folder; other content roots are not addressable this way.
+    /// at the forward-slashed relative path within that module's bundled files.
     /// </summary>
     string GetBundledAssetPath(string moduleFolderName, string relativePath);
 }

--- a/Source/Core/Celbridge.Projects/Services/ProjectTemplateService.cs
+++ b/Source/Core/Celbridge.Projects/Services/ProjectTemplateService.cs
@@ -90,8 +90,7 @@ public class ProjectTemplateService : IProjectTemplateService
             var appVersion = _appEnvironment.GetEnvironmentInfo().AppVersion;
 
             // Extract the bundled template zip to the staging location. The zip is read as a real file
-            // from the install location: the package root on the packaged Windows head, the
-            // Celbridge.Projects content folder beside the app on the Skia heads.
+            // from the Celbridge.Projects module folder beside the app.
             var sourceZipPath = _appEnvironment.GetBundledAssetPath(
                 ProjectsModuleFolder, $"Assets/Templates/{template.Id}.zip");
 

--- a/Source/Core/Celbridge.Utilities/Platform/AppEnvironment.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/AppEnvironment.cs
@@ -5,13 +5,14 @@ namespace Celbridge.Utilities.Platform;
 
 /// <summary>
 /// Resolves application-environment facts from the packaging model and the build head, keeping the
-/// packaged-versus-unpackaged branching in one place. On the packaged Windows head the version, folders, and
-/// bundled assets come from the app package. On the Skia heads they come from the entry assembly and the
-/// app's library-layout folders.
+/// packaged-versus-unpackaged branching in one place. On the packaged Windows head the version and data
+/// folders come from the app package. On the Skia heads they come from the entry assembly and the
+/// operating system's per-user folders. Bundled assets resolve the same way on every head.
 /// </summary>
 public sealed class AppEnvironment : IAppEnvironment
 {
     private const string ApplicationDataFolderName = "Celbridge";
+    private const string WebHostModuleFolderName = "Celbridge.WebHost";
 
     // The process working folder captured at startup, before any loaded project changes it.
     private static readonly string LaunchWorkingFolder;
@@ -71,27 +72,17 @@ public sealed class AppEnvironment : IAppEnvironment
 
     public string LaunchWorkingFolderPath => LaunchWorkingFolder;
 
-    // Every head lays the shared web assets out the same way, under the WebHost module folder, so this
-    // needs no packaging fork.
-    public string SharedWebAssetsFolderPath => Path.Combine(AppContext.BaseDirectory, "Celbridge.WebHost", "Web");
+    public string SharedWebAssetsFolderPath => GetBundledAssetPath(WebHostModuleFolderName, "Web");
 
     public string GetBundledAssetPath(string moduleFolderName, string relativePath)
     {
         // Callers pass forward-slashed relative paths. Normalize to this platform's separator.
         var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar);
 
-#if WINDOWS
-        // The packaged head copies each library's Assets folder to the package root as well as to its
-        // module folder, so an Assets-rooted path resolves without the module folder. Content outside
-        // Assets is not duplicated that way and cannot be addressed here. InstalledLocation is a real
-        // on-disk folder.
-        var root = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
-        return Path.Combine(root, normalizedRelativePath);
-#else
-        // The Skia heads place each library's assets next to the app under the Uno library layout
-        // "<base>/<moduleFolderName>/...".
+        // Every head lays a library's bundled content out the same way, in the library's module folder
+        // beside the app. The packaged head also flattens each library's Assets folder to the package
+        // root, but that copy covers Assets alone, so no caller depends on it.
         return Path.Combine(AppContext.BaseDirectory, moduleFolderName, normalizedRelativePath);
-#endif
     }
 
     private static string ResolveAppVersion()

--- a/Source/Workspace/Celbridge.Python/Services/PythonInstaller.cs
+++ b/Source/Workspace/Celbridge.Python/Services/PythonInstaller.cs
@@ -147,9 +147,8 @@ public class PythonInstaller : IPythonInstaller
 
         await _fileSystem.CreateFolderAsync(pythonFolderPath);
 
-        // Bundled assets are read as real files from the install location: the package root on the
-        // packaged Windows head, the library-layout folder next to the app on the Skia heads. uv handles
-        // installing the required python & package versions for the loaded project.
+        // Bundled assets are read as real files from the Celbridge.Python module folder beside the app.
+        // uv handles installing the required python & package versions for the loaded project.
         var uvArchivePath = _appEnvironment.GetBundledAssetPath(
             PythonModuleFolder, $"Assets/UV/{GetUvArchiveFileName()}");
         await ExtractUvArchiveAsync(uvArchivePath, pythonFolderPath);


### PR DESCRIPTION
This pull request updates how bundled assets are located and accessed across different platforms, simplifying and unifying the logic so that all heads (platforms) resolve assets in the same way. Documentation and comments are updated to reflect this consistent approach, and platform-specific branching for asset paths is removed.

**Unified asset resolution logic:**

* [`AppEnvironment.cs`](diffhunk://#diff-d9292a9a5604b129f13b2cf17434e741544a3fb6054149809692279d7c2b8339L74-L94): The `GetBundledAssetPath` method now always resolves bundled assets to the library's module folder beside the app, regardless of platform, removing previous platform-specific logic.
* [`AppEnvironment.cs`](diffhunk://#diff-d9292a9a5604b129f13b2cf17434e741544a3fb6054149809692279d7c2b8339L74-L94): The `SharedWebAssetsFolderPath` property now uses `GetBundledAssetPath` with the `WebHostModuleFolderName` for consistency.

**Documentation and comment updates:**

* [`IAppEnvironment.cs`](diffhunk://#diff-20e859e21f282ae5568f5c799223dbe9eda615bc1b503f03487e57c38518850cL42-R42): The XML doc for `GetBundledAssetPath` is updated to remove references to specific content roots and clarify usage.
* [`AppEnvironment.cs`](diffhunk://#diff-d9292a9a5604b129f13b2cf17434e741544a3fb6054149809692279d7c2b8339L8-R15): The class-level summary is revised to clarify the new, unified asset resolution behavior.
* `ProjectTemplateService.cs` and `PythonInstaller.cs`: Comments are updated to accurately describe the new asset location logic, removing references to platform-specific paths. [[1]](diffhunk://#diff-9d880b123138d3b7edef9c2dd7b7d90f1db9da5511ed2bf6d7fb015c234df716L93-R93) [[2]](diffhunk://#diff-5069ff54433c0289ca504bdf7b372b68c42ff61f25117a9146926065ced66b63L150-R151)Simplifies `AppEnvironment.GetBundledAssetPath` to always resolve assets from `<base>/<module>/<relativePath>` across all heads, removing the Windows-only package-root special case. `SharedWebAssetsFolderPath` now uses the same helper, and related docs/comments in `IAppEnvironment`, `ProjectTemplateService`, and `PythonInstaller` were updated to reflect the unified module-folder layout.