### PR TITLE
Harden macOS WebView background RPC handling

### DIFF
--- a/Source/Core/Celbridge.Server/Services/WebSocketHostChannel.cs
+++ b/Source/Core/Celbridge.Server/Services/WebSocketHostChannel.cs
@@ -73,6 +73,10 @@ public sealed class WebSocketHostChannel : IHostChannel, IDisposable
             {
                 if (_webSocket.State != WebSocketState.Open)
                 {
+                    // Dropping it silently would leave the caller waiting out its timeout with no trace of
+                    // why the page never answered.
+                    _logger.LogWarning(
+                        "Dropped a host to page message because the WebSocket is {State}", _webSocket.State);
                     continue;
                 }
 

--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -89,6 +89,13 @@ public static class MacOSWebViewInterop
     // one retain each.
     private static readonly HashSet<IntPtr> _pinnedWebViews = new();
 
+    // WKPreferences SPI that keeps a hidden page's process schedulable.
+    private static readonly string[] BackgroundPageActivitySelectors =
+    [
+        "_setAppNapEnabled:",
+        "_setPageVisibilityBasedProcessSuppressionEnabled:"
+    ];
+
     /// <summary>
     /// Walks CoreWebView2._nativeWebView and its _webview field to recover the native WKWebView
     /// pointer. Returns false with the type name walked through in 'detail' when the shape does not
@@ -145,11 +152,11 @@ public static class MacOSWebViewInterop
     }
 
     /// <summary>
-    /// Retains the native WKWebView for the lifetime of the process. Uno's MacOSNativeElement calls
-    /// uno_native_dispose on every Unloaded event, which drops the native side's owning reference while
-    /// managed code keeps the raw handle; a later reattach or message then crashes on the freed view.
-    /// Pinning the view turns those touches into calls on a live object. The WebContent renderer is
-    /// still reclaimed by CloseNativeWebView, so what leaks is the view shell only.
+    /// Retains the native WKWebView for the lifetime of the process and keeps it schedulable while hidden.
+    /// Uno's MacOSNativeElement calls uno_native_dispose on every Unloaded event, which drops the native
+    /// side's owning reference while managed code keeps the raw handle; a later reattach or message then
+    /// crashes on the freed view. Pinning the view turns those touches into calls on a live object. The
+    /// WebContent renderer is still reclaimed by CloseNativeWebView, so what leaks is the view shell only.
     /// </summary>
     public static void RetainNativeWebView(IntPtr webView)
     {
@@ -167,6 +174,68 @@ public static class MacOSWebViewInterop
         }
 
         SendMessage(webView, GetSelector("retain"));
+
+        EnableBackgroundPageActivity(webView);
+    }
+
+    /// <summary>
+    /// The WKPreferences object backing a WKWebView, or zero when it cannot be resolved. The throttling
+    /// controls for hidden pages live here rather than on the view.
+    /// </summary>
+    public static IntPtr GetPreferences(IntPtr webView)
+    {
+        if (webView == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        var configuration = SendMessage(webView, GetSelector("configuration"));
+        if (configuration == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        return SendMessage(configuration, GetSelector("preferences"));
+    }
+
+    /// <summary>
+    /// The number of preferences EnableBackgroundPageActivity applies when WebKit exposes all of them. A
+    /// lower count means this OS version dropped one and background documents may stall again.
+    /// </summary>
+    public static int BackgroundPageActivityPreferenceCount => BackgroundPageActivitySelectors.Length;
+
+    /// <summary>
+    /// Keeps a hidden page's process schedulable so it still services host-to-editor RPC. WebKit treats a
+    /// background document tab as a hidden page and both throttles its timers and suppresses its process;
+    /// the suppression is what leaves RPC unanswered for tens of seconds. Only the process-level suppression
+    /// is turned off, so timers stay throttled and an idle background document stays cheap. Returns the
+    /// preferences that were applied, for diagnostics. Private SPI, each guarded by respondsToSelector: so an
+    /// OS that drops one degrades rather than crashing.
+    /// </summary>
+    public static IReadOnlyList<string> EnableBackgroundPageActivity(IntPtr webView)
+    {
+        var applied = new List<string>();
+
+        var preferences = GetPreferences(webView);
+        if (preferences == IntPtr.Zero)
+        {
+            return applied;
+        }
+
+        var respondsToSelector = GetSelector("respondsToSelector:");
+        foreach (var selectorName in BackgroundPageActivitySelectors)
+        {
+            var selector = GetSelector(selectorName);
+            if (SendMessage(preferences, respondsToSelector, selector) == IntPtr.Zero)
+            {
+                continue;
+            }
+
+            SendMessageVoidBool(preferences, selector, false);
+            applied.Add(selectorName);
+        }
+
+        return applied;
     }
 
     /// <summary>

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -18,6 +18,8 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     // completes for a control that has not been parented to a window.
     private Panel? _initHost;
 
+    private bool _checkedBackgroundActivity;
+
     // The find methods receive only a CoreWebView2, so sessions are keyed by it to recover per-find state.
     private readonly Dictionary<CoreWebView2, FindSession> _findSessions = new();
 
@@ -60,15 +62,16 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
 
             await webView.EnsureCoreWebView2Async();
 
-            // Pin the native WKWebView for the process lifetime. Uno's native element disposes the
-            // view on every Unloaded and later touches the stale handle, which is a use-after-free
-            // (see RetainNativeWebView). The handle may not be resolvable yet at this point, so the
-            // other adapter entry points that resolve it also pin (RetainNativeWebView is idempotent).
+            // Pin the native WKWebView for the process lifetime and keep it schedulable while hidden. Uno's
+            // native element disposes the view on every Unloaded and later touches the stale handle, which is
+            // a use-after-free (see RetainNativeWebView). The handle may not be resolvable yet at this point,
+            // so the other adapter entry points that resolve it also pin (RetainNativeWebView is idempotent).
             if (OperatingSystem.IsMacOS() && webView.CoreWebView2 is not null)
             {
                 if (MacOSWebViewInterop.TryGetNativeWebViewHandle(webView.CoreWebView2, out var nativeWebViewHandle, out var detail))
                 {
                     MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
+                    CheckBackgroundPageActivityOnce(nativeWebViewHandle);
                 }
                 else
                 {
@@ -80,6 +83,30 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         {
             host.Children.Remove(webView);
         }
+    }
+
+    // WebKit suspends a hidden page's process, which stalls host-to-editor RPC for a background document
+    // tab until the tab is shown again. RetainNativeWebView turns that suppression off through private SPI,
+    // so this reports once per session whether the SPI still exists: losing it silently brings the stall back.
+    private void CheckBackgroundPageActivityOnce(IntPtr nativeWebViewHandle)
+    {
+        if (_checkedBackgroundActivity)
+        {
+            return;
+        }
+
+        _checkedBackgroundActivity = true;
+
+        var applied = MacOSWebViewInterop.EnableBackgroundPageActivity(nativeWebViewHandle);
+        if (applied.Count == MacOSWebViewInterop.BackgroundPageActivityPreferenceCount)
+        {
+            _logger.LogDebug("Background page activity preferences applied: {Applied}", string.Join(", ", applied));
+            return;
+        }
+
+        _logger.LogWarning(
+            "WebKit no longer exposes every background page activity preference, so background documents may stop servicing host RPC. Applied: {Applied}",
+            applied.Count == 0 ? "none" : string.Join(", ", applied));
     }
 
     public void CloseWebView(WebView2 webView, Panel container)


### PR DESCRIPTION
This pull request introduces important improvements to how the application handles background activity for macOS WebViews, ensuring that host-to-editor RPC remains responsive even when a document tab is hidden. The changes add private APIs for disabling process suppression, diagnostics for when these APIs are unavailable, and improved logging for dropped WebSocket messages.

**macOS WebView background activity management:**

* Added logic to retain the native `WKWebView` and keep its process schedulable while hidden by invoking private WebKit SPI methods. This prevents host-to-editor RPC from stalling when a tab is backgrounded. (`MacOSWebViewInterop.cs`, `SkiaWebViewAdapter.cs`) [[1]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dR92-R98) [[2]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL148-R159) [[3]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dR177-R238) [[4]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0L63-R74)
* Implemented `EnableBackgroundPageActivity` and related helpers to apply and track which background activity preferences are set, with graceful degradation if the OS removes any of them. (`MacOSWebViewInterop.cs`)
* Added a diagnostic check (`CheckBackgroundPageActivityOnce`) to log whether all required preferences were successfully applied, warning if not, to aid in future debugging as WebKit evolves. (`SkiaWebViewAdapter.cs`) [[1]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R21-R22) [[2]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R88-R111)

**Logging improvements:**

* Enhanced logging to warn when a host-to-page WebSocket message is dropped due to the socket not being open, improving traceability of RPC failures. (`WebSocketHostChannel.cs`)Adds observability and safeguards for stalled host-to-editor messaging on macOS. The WebView interop now applies private WKPreferences selectors to keep hidden pages schedulable, exposes diagnostic helpers, and SkiaWebViewAdapter logs once per session if those selectors are missing so regressions are visible. WebSocketHostChannel also logs when outbound messages are dropped because the socket is no longer open, instead of failing silently.