### PR TITLE
Implement platform-specific minimum window size constraints

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Helpers/IWindowSizeConstraints.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/IWindowSizeConstraints.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Constrains how small the user can resize the application window. The mechanism differs per head: the
+/// packaged WinAppSDK head constrains the overlapped presenter, while the Skia desktop heads constrain the
+/// native window on macOS and have no equivalent elsewhere.
+/// </summary>
+public interface IWindowSizeConstraints
+{
+    /// <summary>
+    /// Applies the smallest size the user may resize the window to. Does nothing on heads that cannot
+    /// express the constraint, leaving the window unconstrained.
+    /// </summary>
+    void ApplyMinimumSize(AppWindow appWindow, SizeInt32 minimumSize);
+}

--- a/Source/Core/Celbridge.UserInterface/Helpers/WindowStateHelper.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WindowStateHelper.cs
@@ -11,11 +11,17 @@ namespace Celbridge.UserInterface.Helpers;
 /// </summary>
 public sealed class WindowStateHelper
 {
+    // The smallest window that keeps the application toolbar and a usable editor pane on screen, chosen to
+    // sit well inside the work area of a 1280x800 display.
+    private const int MinimumWindowWidth = 800;
+    private const int MinimumWindowHeight = 600;
+
     private readonly ILogger<WindowStateHelper> _logger;
     private readonly IMessengerService _messengerService;
     private readonly ISettingsService _settingsService;
     private readonly IFullScreenController _fullScreenController;
     private readonly IWindowBoundsValidator _windowBoundsValidator;
+    private readonly IWindowSizeConstraints _windowSizeConstraints;
     private AppWindow? _appWindow;
     private OverlappedPresenter? _overlappedPresenter;
     private bool _isApplyingWindowMode;
@@ -27,13 +33,15 @@ public sealed class WindowStateHelper
         IMessengerService messengerService,
         ISettingsService settingsService,
         IFullScreenController fullScreenController,
-        IWindowBoundsValidator windowBoundsValidator)
+        IWindowBoundsValidator windowBoundsValidator,
+        IWindowSizeConstraints windowSizeConstraints)
     {
         _logger = logger;
         _messengerService = messengerService;
         _settingsService = settingsService;
         _fullScreenController = fullScreenController;
         _windowBoundsValidator = windowBoundsValidator;
+        _windowSizeConstraints = windowSizeConstraints;
     }
 
     /// <summary>
@@ -64,6 +72,8 @@ public sealed class WindowStateHelper
 
             // Bind the platform-specific fullscreen controller to this window.
             _fullScreenController.Initialize(_appWindow);
+
+            ApplyMinimumWindowSize();
 
             // This is a "best-effort" restore. If it doesn't work, the default window state will be applied automatically.
             TryRestoreWindowState();
@@ -169,6 +179,9 @@ public sealed class WindowStateHelper
             // refresh the cached reference and the tracked kind for window-state tracking.
             _overlappedPresenter = _appWindow.Presenter as OverlappedPresenter;
             _previousPresenterKind = _appWindow.Presenter.Kind;
+
+            // A replacement presenter does not carry over the size constraint.
+            ApplyMinimumWindowSize();
         }
         catch (Exception ex)
         {
@@ -178,6 +191,22 @@ public sealed class WindowStateHelper
         {
             _isApplyingWindowMode = false;
         }
+    }
+
+    private void ApplyMinimumWindowSize()
+    {
+        if (_appWindow == null)
+        {
+            return;
+        }
+
+        var minimumSize = new SizeInt32
+        {
+            Width = MinimumWindowWidth,
+            Height = MinimumWindowHeight
+        };
+
+        _windowSizeConstraints.ApplyMinimumSize(_appWindow, minimumSize);
     }
 
     private void TryRestoreWindowState()
@@ -196,8 +225,13 @@ public sealed class WindowStateHelper
 
         int x = _settingsService.Get(SettingCatalog.Window.PreferredX);
         int y = _settingsService.Get(SettingCatalog.Window.PreferredY);
-        int width = _settingsService.Get(SettingCatalog.Window.PreferredWidth);
-        int height = _settingsService.Get(SettingCatalog.Window.PreferredHeight);
+        int savedWidth = _settingsService.Get(SettingCatalog.Window.PreferredWidth);
+        int savedHeight = _settingsService.Get(SettingCatalog.Window.PreferredHeight);
+
+        // The platform constraint only applies to user resizing, and geometry saved before the minimum was
+        // introduced may be smaller than it, so clamp the restored size here too.
+        int width = Math.Max(savedWidth, MinimumWindowWidth);
+        int height = Math.Max(savedHeight, MinimumWindowHeight);
 
         // Object-initializer syntax is used for the Windows.Graphics structs because the Skia desktop
         // head's projection does not expose their positional constructors.

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSWindowInterop.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSWindowInterop.cs
@@ -17,8 +17,8 @@ internal readonly record struct MacScreen(
 /// <summary>
 /// Objective-C interop for the native AppKit window and screens behind Uno's macOS Skia head, which
 /// surfaces neither the NSWindow nor (on the Skia head) the DisplayArea APIs. Reads display geometry and
-/// native-fullscreen state, and updates the window's first responder. macOS-only. Call on the main (UI)
-/// thread, where AppKit is safe.
+/// native-fullscreen state, constrains the window's minimum size, and updates the window's first responder.
+/// macOS-only. Call on the main (UI) thread, where AppKit is safe.
 /// </summary>
 internal static class MacOSWindowInterop
 {
@@ -53,6 +53,11 @@ internal static class MacOSWindowInterop
     // declaration local rather than in the shared runtime.
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
     private static extern CGRect SendMessageReturnCGRect(IntPtr receiver, IntPtr selector);
+
+    // NSSize is a pair of doubles, so the ARM64 ABI passes it in the floating point registers and the
+    // CGSize struct marshals directly.
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendMessageVoidCGSize(IntPtr receiver, IntPtr selector, CGSize argument);
 
     /// <summary>
     /// Reads the geometry of every attached display from NSScreen. Returns false off macOS or when the
@@ -117,6 +122,33 @@ internal static class MacOSWindowInterop
 
         screens = result;
         return true;
+    }
+
+    /// <summary>
+    /// Sets the smallest content size the window can be resized to, in macOS points. AppKit enforces this
+    /// for every user-driven resize, including the title-bar zoom button. No-op off macOS or when the
+    /// window cannot be resolved.
+    /// </summary>
+    public static void SetMinimumContentSize(double width, double height)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        var window = GetMainWindow();
+        if (window == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var minimumSize = new CGSize
+        {
+            Width = width,
+            Height = height
+        };
+
+        SendMessageVoidCGSize(window, GetSelector("setContentMinSize:"), minimumSize);
     }
 
     /// <summary>

--- a/Source/Core/Celbridge.UserInterface/Platform/PlatformServiceConfiguration.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/PlatformServiceConfiguration.cs
@@ -36,6 +36,14 @@ public static class PlatformServiceConfiguration
         services.AddSingleton<IWindowBoundsValidator, SkiaWindowBoundsValidator>();
 #endif
 
+        // The minimum window size is applied to the overlapped presenter on the packaged WinAppSDK head and
+        // to the native window on the macOS Skia head. The remaining Skia heads leave it unconstrained.
+#if WINDOWS
+        services.AddSingleton<IWindowSizeConstraints, WinAppSdkWindowSizeConstraints>();
+#else
+        services.AddSingleton<IWindowSizeConstraints, SkiaWindowSizeConstraints>();
+#endif
+
         // Window activation tinting is only meaningful on the head that draws the custom title bar. The
         // Skia heads draw a native title bar that the OS tints, so they use the no-op monitor.
 #if WINDOWS

--- a/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowSizeConstraints.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowSizeConstraints.cs
@@ -1,0 +1,23 @@
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Minimum window size for the Skia desktop heads. On macOS the constraint is set on the native window,
+/// where AppKit enforces it. The other Skia heads expose no equivalent mechanism, so the window is left
+/// unconstrained there.
+/// </summary>
+public sealed class SkiaWindowSizeConstraints : IWindowSizeConstraints
+{
+    public void ApplyMinimumSize(AppWindow appWindow, SizeInt32 minimumSize)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        // macOS points match the size units used elsewhere in the window state, so no scaling is needed.
+        MacOSWindowInterop.SetMinimumContentSize(minimumSize.Width, minimumSize.Height);
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Platform/WinAppSdkWindowSizeConstraints.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/WinAppSdkWindowSizeConstraints.cs
@@ -1,0 +1,25 @@
+#if WINDOWS
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Minimum window size for the packaged WinAppSDK head, applied to the overlapped presenter. The
+/// PreferredMinimum properties are absent from the Uno presenter, so this implementation is Windows-only.
+/// </summary>
+internal sealed class WinAppSdkWindowSizeConstraints : IWindowSizeConstraints
+{
+    public void ApplyMinimumSize(AppWindow appWindow, SizeInt32 minimumSize)
+    {
+        var presenter = appWindow.Presenter as OverlappedPresenter;
+        if (presenter is null)
+        {
+            return;
+        }
+
+        presenter.PreferredMinimumWidth = minimumSize.Width;
+        presenter.PreferredMinimumHeight = minimumSize.Height;
+    }
+}
+#endif


### PR DESCRIPTION
This pull request introduces a cross-platform minimum window size constraint to the application, ensuring the window cannot be resized below a usable size. The implementation is platform-specific: on Windows, it uses the WinAppSDK overlapped presenter, while on macOS it constrains the native window; other platforms remain unconstrained. The changes also ensure that restored window sizes and window mode transitions respect these constraints.

**Minimum window size enforcement:**

* Introduced the `IWindowSizeConstraints` interface to abstract applying minimum window size constraints across platforms (`IWindowSizeConstraints.cs`).
* Added platform-specific implementations: `WinAppSdkWindowSizeConstraints` for Windows (uses the overlapped presenter) (`WinAppSdkWindowSizeConstraints.cs`) and `SkiaWindowSizeConstraints` for Skia heads (calls into native AppKit on macOS, no-op elsewhere) (`SkiaWindowSizeConstraints.cs`). [[1]](diffhunk://#diff-52ff0f770c7f62be4e5c30e2f4cc6a4b57d337cbcdb0be69432a3c581dad8a71R1-R25) [[2]](diffhunk://#diff-1c4476a6f62796bed2da65143a78bfe8495c4da9339b9494da7bcf7fbb5dfcb7R1-R23)
* Registered the appropriate implementation in the dependency injection container based on platform (`PlatformServiceConfiguration.cs`).

**Window state management updates:**

* Updated `WindowStateHelper` to use the new minimum size constraint: applies the constraint on initialization and when toggling fullscreen, and clamps restored window sizes to the minimum if previously saved sizes are too small (`WindowStateHelper.cs`). [[1]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23R14-R24) [[2]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23L30-R44) [[3]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23R76-R77) [[4]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23R182-R184) [[5]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23R196-R211) [[6]](diffhunk://#diff-7cc9b70ec4a4b1d123ea87d15725f8279f7ce31ecc674ea9167fde1526a9ef23L199-R234)

**macOS interop enhancements:**

* Added a native interop method to set the minimum content size for the window on macOS via AppKit (`MacOSWindowInterop.cs`). [[1]](diffhunk://#diff-d01462599f8974fc9642df23126e515a8eeb8c74410a4c0b55967c0e86e537f4L20-R21) [[2]](diffhunk://#diff-d01462599f8974fc9642df23126e515a8eeb8c74410a4c0b55967c0e86e537f4R57-R61) [[3]](diffhunk://#diff-d01462599f8974fc9642df23126e515a8eeb8c74410a4c0b55967c0e86e537f4R127-R153)

These changes ensure a consistent, user-friendly minimum window size across supported platforms.Introduces an `IWindowSizeConstraints` abstraction and platform implementations to enforce a minimum 800x600 window size where supported: WinAppSDK via `OverlappedPresenter` and macOS Skia via AppKit interop. `WindowStateHelper` now applies constraints during initialization and after presenter changes, and clamps restored persisted window sizes to the same minimum so older saved geometry cannot reopen below the new floor. DI registration was updated to select the correct implementation per head.