### PR TITLE
Update NewProjectDialog.xaml

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/NewProjectDialog.xaml
@@ -53,7 +53,8 @@
       </GridView.ItemTemplate>
       <GridView.ItemsPanel>
         <ItemsPanelTemplate>
-          <ItemsWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="4"/>
+          <!-- Non-virtualizing panel: a virtualizing items panel realizes no containers on the Uno Skia head. -->
+          <StackPanel Orientation="Horizontal"/>
         </ItemsPanelTemplate>
       </GridView.ItemsPanel>
     </GridView>


### PR DESCRIPTION
This pull request makes a small but important change to the `NewProjectDialog.xaml` file. The `GridView`'s items panel has been updated to use a non-virtualizing `StackPanel` instead of an `ItemsWrapGrid`. This change addresses an issue where a virtualizing items panel would not realize any containers on the Uno Skia head, ensuring that items are properly displayed.

- Updated the `GridView.ItemsPanel` to use a non-virtualizing `StackPanel` with horizontal orientation, replacing the `ItemsWrapGrid`, to ensure item containers are realized correctly on Uno Skia.