### PR TITLE
Add macOS exit action for Presentation mode and improve UX

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -1010,6 +1010,9 @@ Do you wish to continue?</value>
   <data name="FullScreenToolbar_ExitPresentation" xml:space="preserve">
     <value>Exit Presentation</value>
   </data>
+  <data name="FullScreenToolbar_ExitPresentationHint" xml:space="preserve">
+    <value>To exit Presentation mode, choose Window &gt; Exit Presentation</value>
+  </data>
   <data name="TitleBar_SettingsTooltip" xml:space="preserve">
     <value>Open Application Settings</value>
   </data>
@@ -1099,6 +1102,9 @@ Do you wish to continue?</value>
   </data>
   <data name="Menu_BringAllToFront" xml:space="preserve">
     <value>Bring All to Front</value>
+  </data>
+  <data name="Menu_ExitPresentation" xml:space="preserve">
+    <value>Exit Presentation</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>Help</value>

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
@@ -27,6 +27,7 @@ internal static class MacOSMainMenu
     private const long TagNewFolder = 12;
     private const long TagShowLogs = 13;
     private const long TagFind = 14;
+    private const long TagExitPresentation = 15;
 
     // Recent project items are generated on demand, so their tags start above the fixed tags and index into
     // _recentProjectPaths, which the Open Recent submenu provider rebuilds each time the menu opens.
@@ -115,6 +116,10 @@ internal static class MacOSMainMenu
             {
                 MacMenuItem.Selector(Text("Menu_Minimize"), "performMiniaturize:", "m"),
                 MacMenuItem.Selector(Text("Menu_Zoom"), "performZoom:"),
+                MacMenuItem.Separator(),
+                // The only way out of Presentation mode on macOS. The in-window reveal strip cannot be
+                // used there because the menu bar and title bar auto-reveal over it in native fullscreen.
+                MacMenuItem.Command(Text("Menu_ExitPresentation"), TagExitPresentation),
                 MacMenuItem.Separator(),
                 MacMenuItem.Selector(Text("Menu_BringAllToFront"), "arrangeInFront:")
             }
@@ -208,6 +213,9 @@ internal static class MacOSMainMenu
             case TagFind:
                 return GetActiveFindableDocument()?.CanFind ?? false;
 
+            case TagExitPresentation:
+                return ServiceLocator.AcquireService<IWindowModeService>().LayoutMode == LayoutMode.Presentation;
+
             case TagNoRecentProjects:
                 return false;
 
@@ -286,6 +294,15 @@ internal static class MacOSMainMenu
 
             case TagFind:
                 GetActiveFindableDocument()?.TryBeginFind();
+                break;
+
+            case TagExitPresentation:
+                // Focus keeps the side panels hidden while restoring the application toolbar, so the user
+                // can pick their next layout from there.
+                ServiceLocator.AcquireService<ICommandService>().Execute<ISetLayoutCommand>(command =>
+                {
+                    command.Transition = LayoutTransition.Focus;
+                });
                 break;
 
             case TagClearRecentProjects:

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml
@@ -9,6 +9,7 @@
   <!--
   Minimal strip that appears at the top of the screen in Presentation mode (application toolbar hidden) when the mouse moves near the top edge.
   Clicking anywhere on it reveals the application toolbar. The TriggerZone is an invisible area at the top that detects mouse hover.
+  Where the platform supplies a native menu bar, the strip is instead a non-interactive hint pointing at the menu item that exits Presentation mode.
   -->
   <Grid x:Name="RootContainer">
     <!-- Invisible trigger zone that sits above all other UI elements -->

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml.cs
@@ -1,17 +1,21 @@
 using Celbridge.Commands;
+using Celbridge.Platform;
 using Microsoft.UI.Xaml.Media.Animation;
 
 namespace Celbridge.UserInterface.Views;
 
 /// <summary>
-/// A minimal strip that appears at the top of the screen in Presentation mode (where the application
-/// toolbar is hidden) when the mouse moves near the top edge. Clicking it reveals the toolbar by
-/// switching to the Focus layout.
+/// A minimal strip shown at the top of the screen in Presentation mode, where the application toolbar is
+/// hidden. On platforms without a native menu bar it is revealed whenever the mouse moves near the top
+/// edge, and clicking it switches to the Focus layout. On platforms with a native menu bar the exit lives
+/// in the Window menu instead, so the strip is a non-interactive hint that points there and is shown only
+/// when Presentation mode is entered.
 /// </summary>
 public sealed partial class FullscreenToolbar : UserControl
 {
     private const double TriggerZoneHeight = 4; // pixels from top to trigger showing the toolbar
     private const double AutoHideDelay = 1.5; // seconds
+    private const double HintAutoHideDelay = 5; // seconds; the hint is read rather than clicked, so it lingers
     private const double AnimationDuration = 150; // ms
 
     private readonly IMessengerService _messengerService;
@@ -19,13 +23,27 @@ public sealed partial class FullscreenToolbar : UserControl
     private readonly IWindowModeService _windowModeService;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly DispatcherTimer _hideTimer;
-    
+    private readonly TimeSpan _autoHideDelay;
+
+    // The strip only tells the user where the exit is, rather than acting as the exit itself.
+    private readonly bool _isHintOnly;
+
     private bool _isToolbarHidden;
     private bool _isToolbarVisible;
     private bool _isMouseOverToolbar;
     private Storyboard? _currentAnimation;
-    
-    public string ExitPresentationString => _stringLocalizer.GetString("FullScreenToolbar_ExitPresentation");
+
+    public string ExitPresentationString
+    {
+        get
+        {
+            var stringKey = _isHintOnly
+                ? "FullScreenToolbar_ExitPresentationHint"
+                : "FullScreenToolbar_ExitPresentation";
+
+            return _stringLocalizer.GetString(stringKey);
+        }
+    }
 
     public FullscreenToolbar()
     {
@@ -36,12 +54,26 @@ public sealed partial class FullscreenToolbar : UserControl
         _windowModeService = ServiceLocator.AcquireService<IWindowModeService>();
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
 
+        var platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
+        _isHintOnly = platformInfo.UsesNativeMenuBar;
+
+        if (_isHintOnly)
+        {
+            // A display-only overlay never has to win pointer input from the native views it covers.
+            IsHitTestVisible = false;
+        }
+
         this.DataContext = this;
+
+        var autoHideSeconds = _isHintOnly
+            ? HintAutoHideDelay
+            : AutoHideDelay;
+        _autoHideDelay = TimeSpan.FromSeconds(autoHideSeconds);
 
         // Setup auto-hide timer
         _hideTimer = new DispatcherTimer
         {
-            Interval = TimeSpan.FromSeconds(AutoHideDelay)
+            Interval = _autoHideDelay
         };
         _hideTimer.Tick += HideTimer_Tick;
 
@@ -108,6 +140,13 @@ public sealed partial class FullscreenToolbar : UserControl
 
     private void UpdateTriggerZoneVisibility()
     {
+        if (_isHintOnly)
+        {
+            // The hint is shown only when Presentation mode is entered, so there is nothing to trigger.
+            TriggerZone.Visibility = Visibility.Collapsed;
+            return;
+        }
+
         // Show the trigger zone only when the application toolbar is hidden and the reveal strip is not
         // already showing.
         TriggerZone.Visibility = _isToolbarHidden && !_isToolbarVisible
@@ -128,7 +167,8 @@ public sealed partial class FullscreenToolbar : UserControl
     /// </summary>
     public void OnPointerMoved(double yPosition)
     {
-        if (!_isToolbarHidden)
+        if (_isHintOnly ||
+            !_isToolbarHidden)
         {
             return;
         }
@@ -164,7 +204,7 @@ public sealed partial class FullscreenToolbar : UserControl
     {
         _hideTimer.Stop();
         // Reset interval to normal
-        _hideTimer.Interval = TimeSpan.FromSeconds(AutoHideDelay);
+        _hideTimer.Interval = _autoHideDelay;
 
         // Only hide if not hovering over toolbar and still in fullscreen mode
         if (_isToolbarHidden && !_isMouseOverToolbar)
@@ -179,7 +219,7 @@ public sealed partial class FullscreenToolbar : UserControl
         {
             // Reset hide timer
             _hideTimer.Stop();
-            _hideTimer.Interval = TimeSpan.FromSeconds(AutoHideDelay);
+            _hideTimer.Interval = _autoHideDelay;
             _hideTimer.Start();
             return;
         }
@@ -224,7 +264,7 @@ public sealed partial class FullscreenToolbar : UserControl
         storyboard.Begin();
 
         // Start hide timer
-        _hideTimer.Interval = TimeSpan.FromSeconds(AutoHideDelay);
+        _hideTimer.Interval = _autoHideDelay;
         _hideTimer.Start();
     }
 

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
@@ -293,6 +293,7 @@ public sealed partial class LayoutToolbar : UserControl
         {
             command.Transition = transition;
         });
+        PanelLayoutFlyout.Hide();
     }
 
     private void FullScreenToggle_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This pull request introduces support for exiting Presentation mode on macOS via the native Window menu, and updates the fullscreen toolbar to provide a platform-appropriate exit experience. On macOS, the toolbar now displays a non-interactive hint pointing users to the new menu item, while on other platforms it remains interactive. The changes also improve localization and user guidance for exiting Presentation mode.

**Platform-specific Presentation mode exit:**

* Added a new "Exit Presentation" command to the macOS Window menu, including logic to enable/disable it based on the current layout and to trigger a transition out of Presentation mode (`MacOSMainMenu.cs`, `Resources.resw`). [[1]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R30) [[2]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R120-R123) [[3]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R216-R218) [[4]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R299-R307) [[5]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R1106-R1108)
* Updated the fullscreen toolbar to detect platforms with a native menu bar (like macOS) and show a non-interactive hint instead of an interactive strip. The hint appears when entering Presentation mode and auto-hides after a short delay (`FullscreenToolbar.xaml.cs`, `FullscreenToolbar.xaml`). [[1]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66R2-R46) [[2]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66R57-R76) [[3]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66R143-R149) [[4]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66L131-R171) [[5]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66L167-R207) [[6]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66L182-R222) [[7]](diffhunk://#diff-4ab26d53263a206e93fdab08b02dbf1536e61167ff8bc913f9e57769b260eb66L227-R267) [[8]](diffhunk://#diff-81b6ec61eee07ce36943e2116d23dbb564c0cd411123a92180a7315fcdf29d86R12)

**Localization and user guidance:**

* Added new localized strings for the Presentation mode exit hint and menu item, improving clarity for users on how to exit Presentation mode (`Resources.resw`). [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R1013-R1015) [[2]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R1106-R1108)

**UI polish:**

* Ensured the layout toolbar flyout is hidden after changing layout mode, preventing UI overlap issues (`LayoutToolbar.xaml.cs`).Adds a dedicated Window > Exit Presentation action on macOS, enabled only while in Presentation mode, and routes it through the existing layout command flow back to Focus mode. The fullscreen top strip now adapts by platform: on native menu-bar platforms it becomes a non-interactive hint with its own localized text and longer auto-hide timing, while keeping existing reveal/click behavior elsewhere. Also hides the panel layout flyout after layout changes for cleaner UX.