### PR TITLE
Add macOS tab wheel scrolling workaround

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -93,6 +93,12 @@ public interface IPlatformInfo
     bool RequiresMacOSTabScrollIntoView { get; }
 
     /// <summary>
+    /// Whether the mouse wheel must be translated into horizontal tab-strip scrolling manually because the
+    /// platform does not scroll the overflowing strip in response to the wheel. True on macOS.
+    /// </summary>
+    bool RequiresMacOSTabWheelScroll { get; }
+
+    /// <summary>
     /// Whether document tabs are dragged by the pointer-driven drag controller because the platform's
     /// built-in tab drag-and-drop is unreliable. True on the Skia desktop head (all operating systems).
     /// </summary>

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -64,6 +64,8 @@ public sealed class PlatformInfo : IPlatformInfo
 
     public bool RequiresMacOSTabScrollIntoView => OperatingSystem.IsMacOS();
 
+    public bool RequiresMacOSTabWheelScroll => OperatingSystem.IsMacOS();
+
     public bool UsesPointerDrivenTabDrag
     {
         get

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSection.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class DocumentSection : UserControl
     private readonly IDocumentSectionLogger _logger;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly IPlatformInfo _platformInfo;
+    private readonly PointerEventHandler _tabStripWheelHandler;
     private bool _isShuttingDown = false;
 
     /// <summary>
@@ -79,6 +80,7 @@ public sealed partial class DocumentSection : UserControl
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
         _tabPointerPressedHandler = OnTabPointerPressed;
+        _tabStripWheelHandler = OnTabStripPointerWheelChanged;
         DisableBuiltInTabDrag();
 
         // Disable tab add/remove animations so tabs snap into place immediately
@@ -90,6 +92,14 @@ public sealed partial class DocumentSection : UserControl
         if (_platformInfo.RequiresMacOSTabScrollIntoView)
         {
             TabView.SizeChanged += OnTabViewSizeChanged;
+        }
+
+        // On macOS the overflowing strip does not scroll in response to the mouse wheel, so translate the
+        // wheel into horizontal scrolling ourselves. Subscribe for handled events too because the strip's
+        // internal ScrollViewer can mark the wheel handled without scrolling.
+        if (_platformInfo.RequiresMacOSTabWheelScroll)
+        {
+            TabView.AddHandler(PointerWheelChangedEvent, _tabStripWheelHandler, handledEventsToo: true);
         }
     }
 
@@ -572,6 +582,49 @@ public sealed partial class DocumentSection : UserControl
         var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
 
         return tabListView is null ? null : VisualTree.FindDescendant<ScrollViewer>(tabListView);
+    }
+
+    /// <summary>
+    /// Scrolls the overflowing tab strip horizontally in response to the mouse wheel. macOS only: the Uno
+    /// TabView does not translate vertical wheel input into horizontal strip scrolling the way the packaged
+    /// Windows TabView does, so the strip's scroll offset is driven directly.
+    /// </summary>
+    private void OnTabStripPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is null ||
+            scrollViewer.ScrollableWidth <= 0)
+        {
+            return;
+        }
+
+        // Only the tab strip should react. A wheel over the document content below it falls outside the
+        // strip's ScrollViewer, so leave it unhandled to scroll that content.
+        var pointerPoint = e.GetCurrentPoint(scrollViewer);
+        var position = pointerPoint.Position;
+        bool isOverTabStrip = position.X >= 0 &&
+            position.X <= scrollViewer.ViewportWidth &&
+            position.Y >= 0 &&
+            position.Y <= scrollViewer.ActualHeight;
+        if (!isOverTabStrip)
+        {
+            return;
+        }
+
+        int wheelDelta = pointerPoint.Properties.MouseWheelDelta;
+        if (wheelDelta == 0)
+        {
+            return;
+        }
+
+        // A forward wheel notch (positive delta) reveals earlier tabs, matching the packaged Windows TabView.
+        ScrollTabStripBy(-wheelDelta);
+        e.Handled = true;
     }
 
     private void TabView_CloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)


### PR DESCRIPTION
Introduces `RequiresMacOSTabWheelScroll` on `IPlatformInfo`/`PlatformInfo` and uses it in `DocumentSection` to wire a pointer-wheel handler for the tab strip. On macOS, wheel input is now translated into horizontal scrolling for overflowing tabs (including handled wheel events), while only activating when the pointer is over the tab strip to avoid interfering with document content scrolling.