### PR TITLE
Restore tree focus after Explorer rebuilds and add drag-move fallback

### DIFF
--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.DragDrop.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.DragDrop.cs
@@ -20,6 +20,11 @@ public sealed partial class ResourceTree
     // cross-control consumer (DocumentSection) can recognise the drag on Windows, where it round-trips.
     private List<IResource>? _internalDragResources;
 
+    // Forces the post-rebuild focus restore after a built-in-drag move, in case the OS drag loop dropped
+    // tree focus before the pre-rebuild focus snapshot ran (which would otherwise miss it). The pointer-driven
+    // drag (macOS) keeps focus on the tree, so its move path does not set this.
+    private bool _restoreTreeFocusAfterMove;
+
     private void ListView_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
     {
         // Store the dragged items for later use, excluding the project folder
@@ -244,6 +249,10 @@ public sealed partial class ResourceTree
                 command.DestResource = destResource;
                 command.TransferMode = DataTransferMode.Move;
             });
+
+            // The move triggers a tree rebuild that destroys the dragged row; restore focus to the tree once
+            // the rebuild completes so the Explorer panel keeps focus and the utility rail button stays lit.
+            _restoreTreeFocusAfterMove = true;
         }
     }
 

--- a/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml.cs
+++ b/Source/Workspace/Celbridge.Explorer/Views/ResourceTree.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class ResourceTree : UserControl
     private readonly IPlatformInfo _platformInfo;
     private readonly IStringLocalizer _stringLocalizer;
     private double _savedScrollOffset;
+    private bool _treeHadFocusBeforeRebuild;
 
     public ResourceTreeViewModel ViewModel { get; }
 
@@ -77,12 +78,48 @@ public sealed partial class ResourceTree : UserControl
     private void OnPreBuildResourceTree()
     {
         _savedScrollOffset = GetScrollOffset();
+
+        // Snapshot before TreeItems is replaced, while focus is still on the row the rebuild will destroy.
+        _treeHadFocusBeforeRebuild = IsResourceListFocused();
     }
 
     private void OnPostBuildResourceTree()
     {
         ResourceListView.UpdateLayout();
         SetScrollOffset(_savedScrollOffset);
+
+        // A rebuild destroys the focused row, and the built-in-drag heads (Windows) rescue focus to chrome
+        // outside the Explorer panel, dropping the panel's focused state and unlighting the utility rail
+        // button. Re-focus the tree so the central focus tracker re-reports the Explorer panel. This covers
+        // any rebuild while the tree was focused (undo/redo, rename, delete) plus a move whose OS drag loop
+        // dropped tree focus before the snapshot above ran.
+        if (_treeHadFocusBeforeRebuild || _restoreTreeFocusAfterMove)
+        {
+            _restoreTreeFocusAfterMove = false;
+            FocusTree();
+        }
+    }
+
+    // Whether keyboard focus currently rests on the resource list or one of its rows.
+    private bool IsResourceListFocused()
+    {
+        if (XamlRoot is null)
+        {
+            return false;
+        }
+
+        var focusedElement = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(XamlRoot) as DependencyObject;
+        while (focusedElement is not null)
+        {
+            if (ReferenceEquals(focusedElement, ResourceListView))
+            {
+                return true;
+            }
+
+            focusedElement = VisualTreeHelper.GetParent(focusedElement);
+        }
+
+        return false;
     }
 
     private void OnSelectionRequested(List<ResourceKey> resourceKeys)


### PR DESCRIPTION
This pull request improves the focus management of the `ResourceTree` in the Explorer panel, ensuring that keyboard focus is correctly restored after operations that rebuild the tree, such as drag-and-drop moves, undo/redo, rename, or delete. This prevents the Explorer panel from losing focus and keeps the utility rail button highlighted as expected, especially on Windows where the OS drag loop can cause focus loss.

**Focus Management Improvements:**

* Added a `_restoreTreeFocusAfterMove` flag in `ResourceTree.DragDrop.cs` to signal when focus should be restored to the tree after a move operation that triggers a rebuild.
* Set `_restoreTreeFocusAfterMove` to `true` after moving resources, ensuring the tree regains focus once the rebuild completes.
* Added a `_treeHadFocusBeforeRebuild` field in `ResourceTree.xaml.cs` to remember if the tree was focused prior to a rebuild.
* Updated `OnPreBuildResourceTree` and `OnPostBuildResourceTree` to snapshot and restore focus as needed, covering all rebuild scenarios that might disrupt focus.
* Implemented the `IsResourceListFocused()` helper method to accurately detect if the resource list or one of its rows currently has keyboard focus.Track whether the resource tree had focus before a rebuild and restore focus afterward so Explorer remains the active panel. Also add a drag-move fallback flag for built-in drag paths where the OS drag loop can drop focus before the snapshot, ensuring post-move rebuilds still return focus to the tree and keep the utility rail state correct.