### PR TITLE
Add Recent Projects menu and redesign workspace navigation button

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -1106,6 +1106,9 @@ Do you wish to continue?</value>
   <data name="TitleBar_MainMenuTooltip" xml:space="preserve">
     <value>Main menu</value>
   </data>
+  <data name="TitleBar_RecentProjectsHeader" xml:space="preserve">
+    <value>Recent Projects</value>
+  </data>
   <data name="MainMenu_CloseProject" xml:space="preserve">
     <value>Close Project</value>
   </data>

--- a/Source/Core/Celbridge.UserInterface/Helpers/RecentProjectsMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/RecentProjectsMenu.cs
@@ -1,0 +1,52 @@
+using Celbridge.Projects;
+using Celbridge.UserInterface.Views.Controls;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Builds the shared recent-projects menu used by both the main menu's Open Recent submenu and the Current
+/// Project switcher, so the two surfaces present the project list and the clear action identically.
+/// </summary>
+public static class RecentProjectsMenu
+{
+    /// <summary>
+    /// Populates the target collection with one item per recent project (the name plus a right-aligned path
+    /// column) followed by a separator and a Clear Recent Projects item. Call only when there is at least one
+    /// recent project. onOpenProject receives the clicked project's file path; onClearRecent clears the list.
+    /// </summary>
+    public static void Populate(
+        IList<MenuFlyoutItemBase> items,
+        IReadOnlyList<RecentProject> recentProjects,
+        Action<string> onOpenProject,
+        string clearRecentLabel,
+        Action onClearRecent)
+    {
+        foreach (var recentProject in recentProjects)
+        {
+            var projectFilePath = recentProject.ProjectFilePath;
+
+            var projectItem = new MenuFlyoutItem
+            {
+                Text = recentProject.ProjectName,
+                // Display-only secondary text (it registers no keyboard accelerator), reused as a right-aligned
+                // path column so the list scans by name with the on-disk location shown at a glance.
+                KeyboardAcceleratorTextOverride = projectFilePath
+            };
+            ToolTipService.SetToolTip(projectItem, projectFilePath);
+            projectItem.Click += (sender, e) => onOpenProject(projectFilePath);
+
+            items.Add(projectItem);
+        }
+
+        items.Add(new MenuFlyoutSeparator());
+
+        var clearRecentItem = new MenuFlyoutItem
+        {
+            Text = clearRecentLabel,
+            Icon = new Icon { Symbol = IconSymbol.Delete }
+        };
+        clearRecentItem.Click += (sender, e) => onClearRecent();
+
+        items.Add(clearRecentItem);
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
@@ -165,30 +165,12 @@ public class MainMenu
             return openRecentSubItem;
         }
 
-        foreach (var recentProject in recentProjects)
-        {
-            var projectFilePath = recentProject.ProjectFilePath;
-
-            var projectItem = new MenuFlyoutItem
-            {
-                Text = recentProject.ProjectName
-            };
-            ToolTipService.SetToolTip(projectItem, projectFilePath);
-            projectItem.Click += (sender, e) => OpenRecentProject(projectFilePath);
-
-            openRecentSubItem.Items.Add(projectItem);
-        }
-
-        openRecentSubItem.Items.Add(new MenuFlyoutSeparator());
-
-        var clearRecentItem = new MenuFlyoutItem
-        {
-            Text = _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
-            Icon = new Icon { Symbol = IconSymbol.Delete }
-        };
-        clearRecentItem.Click += (sender, e) => ViewModel.ClearRecentProjects();
-
-        openRecentSubItem.Items.Add(clearRecentItem);
+        RecentProjectsMenu.Populate(
+            openRecentSubItem.Items,
+            recentProjects,
+            OpenRecentProject,
+            _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
+            ViewModel.ClearRecentProjects);
 
         return openRecentSubItem;
     }

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml
@@ -69,21 +69,36 @@
                                FontSize="{StaticResource IconSizeMedium}"/>
             </NavigationViewItem>
 
-            <!-- Separator before Workspace -->
-            <NavigationViewItemSeparator x:Name="WorkspaceSeparator"
-                                         Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+        </NavigationView.MenuItems>
 
-            <!-- Workspace - the Current Project control: the folder glyph, project name and recent-projects
-                 chevron sit in one nav item so they highlight together as a unit. The chevron is a nested button
-                 whose Tapped is handled in code-behind, so opening the switcher never triggers the item's
-                 navigation. -->
-            <NavigationViewItem x:Name="WorkspaceNavItem"
-                                AutomationProperties.AutomationId="workspace-button"
-                                Tag="Workspace"
-                                Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="6"
-                            VerticalAlignment="Center">
+        <!-- Content after Home and Community: the Workspace button, then the shortcut buttons. -->
+        <NavigationView.PaneCustomContent>
+            <StackPanel Orientation="Horizontal"
+                        VerticalAlignment="Stretch">
+
+              <!-- Workspace button: a custom button styled as a prominent, distinct control rather than a nav tab.
+                   Clicking it navigates to the workspace; the nested chevron button opens the recent-projects
+                   switcher, its Tapped handled so it never triggers the navigation click. -->
+              <Button x:Name="WorkspaceButton"
+                      AutomationProperties.AutomationId="workspace-button"
+                      Click="WorkspaceButton_Click"
+                      Background="{ThemeResource NavigationViewItemBackgroundPointerOver}"
+                      BorderThickness="0"
+                      CornerRadius="4"
+                      Padding="8,0"
+                      VerticalAlignment="Stretch"
+                      VerticalContentAlignment="Stretch"
+                      Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+
+                <!-- Attached to the whole button (not the chevron) so it drops down aligned to the button's left edge. -->
+                <FlyoutBase.AttachedFlyout>
+                  <MenuFlyout x:Name="RecentProjectsFlyout"
+                              Placement="BottomEdgeAlignedLeft"/>
+                </FlyoutBase.AttachedFlyout>
+                <Grid>
+                  <StackPanel Orientation="Horizontal"
+                              Spacing="6"
+                              VerticalAlignment="Center">
                     <controls:Icon Symbol="Folder"
                                    FontSize="{StaticResource IconSizeMedium}"/>
                     <TextBlock Text="{x:Bind ViewModel.ProjectTitle, Mode=OneWay}"
@@ -95,32 +110,38 @@
                             Padding="2"
                             VerticalAlignment="Center"
                             Tapped="RecentProjectsButton_Tapped">
-                        <controls:Icon Symbol="ChevronDown"
-                                       FontSize="12"/>
-                        <FlyoutBase.AttachedFlyout>
-                            <MenuFlyout x:Name="RecentProjectsFlyout"
-                                        Placement="BottomEdgeAlignedLeft"/>
-                        </FlyoutBase.AttachedFlyout>
+                      <controls:Icon Symbol="ChevronDown"
+                                     FontSize="12"/>
                     </Button>
-                </StackPanel>
-            </NavigationViewItem>
-        </NavigationView.MenuItems>
+                  </StackPanel>
 
-        <!-- Shortcut buttons to the right of the project button -->
-        <NavigationView.PaneCustomContent>
-            <StackPanel x:Name="PaneButtonsContainer"
-                        Orientation="Horizontal"
-                        VerticalAlignment="Center"
-                        Visibility="Collapsed">
+                  <!-- Accent underline shown while the workspace is the current page, echoing the nav tabs'
+                       selection indicator. The bottom margin lifts it to match the inset the NavigationView gives
+                       its own top-mode indicator. Toggled from code-behind. -->
+                  <Border x:Name="WorkspaceActiveIndicator"
+                          Height="3"
+                          VerticalAlignment="Bottom"
+                          Margin="0,0,0,5"
+                          CornerRadius="1.5"
+                          Background="{ThemeResource NavigationViewSelectionIndicatorForeground}"
+                          Visibility="Collapsed"/>
+                </Grid>
+              </Button>
 
               <!-- Shortcut buttons (added programmatically) -->
-              <Border x:Name="ShortcutLeadingSeparator"
-                      Style="{StaticResource TitleBarSeparatorStyle}"
-                      Visibility="Collapsed"/>
+              <StackPanel x:Name="PaneButtonsContainer"
+                          Orientation="Horizontal"
+                          VerticalAlignment="Center"
+                          Visibility="Collapsed">
 
-              <StackPanel x:Name="ShortcutButtonsPanel"
-                          Orientation="Horizontal"/>
+                <Border x:Name="ShortcutLeadingSeparator"
+                        Style="{StaticResource TitleBarSeparatorStyle}"
+                        Visibility="Collapsed"/>
 
+                <StackPanel x:Name="ShortcutButtonsPanel"
+                            Orientation="Horizontal"/>
+
+              </StackPanel>
             </StackPanel>
         </NavigationView.PaneCustomContent>
     </NavigationView>

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml
@@ -73,18 +73,35 @@
             <NavigationViewItemSeparator x:Name="WorkspaceSeparator"
                                          Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-            <!-- Workspace - shows project name when loaded -->
+            <!-- Workspace - the Current Project control: the folder glyph, project name and recent-projects
+                 chevron sit in one nav item so they highlight together as a unit. The chevron is a nested button
+                 whose Tapped is handled in code-behind, so opening the switcher never triggers the item's
+                 navigation. -->
             <NavigationViewItem x:Name="WorkspaceNavItem"
                                 AutomationProperties.AutomationId="workspace-button"
                                 Tag="Workspace"
                                 Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                 <StackPanel Orientation="Horizontal"
-                            Spacing="8"
+                            Spacing="6"
                             VerticalAlignment="Center">
                     <controls:Icon Symbol="Folder"
                                    FontSize="{StaticResource IconSizeMedium}"/>
                     <TextBlock Text="{x:Bind ViewModel.ProjectTitle, Mode=OneWay}"
                                VerticalAlignment="Center"/>
+                    <Button x:Name="RecentProjectsButton"
+                            AutomationProperties.AutomationId="recent-projects-button"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Tapped="RecentProjectsButton_Tapped">
+                        <controls:Icon Symbol="ChevronDown"
+                                       FontSize="12"/>
+                        <FlyoutBase.AttachedFlyout>
+                            <MenuFlyout x:Name="RecentProjectsFlyout"
+                                        Placement="BottomEdgeAlignedLeft"/>
+                        </FlyoutBase.AttachedFlyout>
+                    </Button>
                 </StackPanel>
             </NavigationViewItem>
         </NavigationView.MenuItems>

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml.cs
@@ -135,7 +135,7 @@ public sealed partial class PageNavigationToolbar : UserControl
             MainMenuButton.Visibility = Visibility.Visible;
         }
 
-        // The Current Project switcher reuses the main menu view model for the recent-projects list and open
+        // The Workspace button's switcher reuses the main menu view model for the recent-projects list and open
         // logic. It is available on every platform, not only those without a native menu bar.
         _recentProjectsViewModel = ServiceLocator.AcquireService<MainMenuViewModel>();
         RecentProjectsFlyout.Opening += OnRecentProjectsFlyoutOpening;
@@ -179,6 +179,16 @@ public sealed partial class PageNavigationToolbar : UserControl
             return;
         }
 
+        // The switcher is opened from a bare chevron, so a disabled header names the list for anyone who opens
+        // it without reading the tooltip. The main menu's Open Recent submenu is already labelled, so it has none.
+        var headerItem = new MenuFlyoutItem
+        {
+            Text = _stringLocalizer.GetString("TitleBar_RecentProjectsHeader"),
+            IsEnabled = false
+        };
+        RecentProjectsFlyout.Items.Add(headerItem);
+        RecentProjectsFlyout.Items.Add(new MenuFlyoutSeparator());
+
         RecentProjectsMenu.Populate(
             RecentProjectsFlyout.Items,
             recentProjects,
@@ -189,9 +199,9 @@ public sealed partial class PageNavigationToolbar : UserControl
 
     private void RecentProjectsButton_Tapped(object sender, TappedRoutedEventArgs e)
     {
-        // Open the switcher and mark the tap handled so it does not reach the workspace nav item; opening the
-        // switcher must never also trigger navigation to the workspace.
-        FlyoutBase.ShowAttachedFlyout(RecentProjectsButton);
+        // Open the switcher (anchored to the whole button so it aligns to the button's left edge) and mark the
+        // tap handled so it does not reach the button's own click; opening it must never also navigate.
+        FlyoutBase.ShowAttachedFlyout(WorkspaceButton);
         e.Handled = true;
     }
 
@@ -248,8 +258,8 @@ public sealed partial class PageNavigationToolbar : UserControl
             ? ViewModel.ProjectFilePath
             : _stringLocalizer.GetString("TitleBar_WorkspaceTooltip");
 
-        ToolTipService.SetToolTip(WorkspaceNavItem, tooltip);
-        ToolTipService.SetPlacement(WorkspaceNavItem, PlacementMode.Bottom);
+        ToolTipService.SetToolTip(WorkspaceButton, tooltip);
+        ToolTipService.SetPlacement(WorkspaceButton, PlacementMode.Bottom);
     }
 
     private void OnWorkspaceLoaded(object recipient, WorkspaceLoadedMessage message)
@@ -270,6 +280,11 @@ public sealed partial class PageNavigationToolbar : UserControl
     {
         PageNavigation.SelectionChanged -= PageNavigation_SelectionChanged;
 
+        // The Workspace button is custom, so drive its active underline directly from the active page.
+        WorkspaceActiveIndicator.Visibility = activePage == ApplicationPage.Workspace
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         try
         {
             switch (activePage)
@@ -281,7 +296,8 @@ public sealed partial class PageNavigationToolbar : UserControl
                     PageNavigation.SelectedItem = CommunityNavItem;
                     break;
                 case ApplicationPage.Workspace:
-                    PageNavigation.SelectedItem = WorkspaceNavItem;
+                    // The Workspace button is custom, not a nav item, so no menu item is selected here.
+                    PageNavigation.SelectedItem = null;
                     break;
                 case ApplicationPage.Settings:
                     PageNavigation.SelectedItem = null;
@@ -309,5 +325,10 @@ public sealed partial class PageNavigationToolbar : UserControl
 
             ViewModel.NavigateToPage(tag);
         }
+    }
+
+    private void WorkspaceButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.NavigateToPage("Workspace");
     }
 }

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/PageNavigationToolbar.xaml.cs
@@ -13,6 +13,7 @@ public sealed partial class PageNavigationToolbar : UserControl
     private MainMenu? _mainMenu;
     private bool _hasShortcuts;
     private ShortcutMenuBuilder? _shortcutMenuBuilder;
+    private MainMenuViewModel? _recentProjectsViewModel;
 
     public PageNavigationToolbarViewModel ViewModel { get; }
 
@@ -134,6 +135,11 @@ public sealed partial class PageNavigationToolbar : UserControl
             MainMenuButton.Visibility = Visibility.Visible;
         }
 
+        // The Current Project switcher reuses the main menu view model for the recent-projects list and open
+        // logic. It is available on every platform, not only those without a native menu bar.
+        _recentProjectsViewModel = ServiceLocator.AcquireService<MainMenuViewModel>();
+        RecentProjectsFlyout.Opening += OnRecentProjectsFlyoutOpening;
+
         ApplyTooltips();
 
         _messengerService.Register<ActivePageChangedMessage>(this, OnActivePageChanged);
@@ -146,10 +152,67 @@ public sealed partial class PageNavigationToolbar : UserControl
 
         _mainMenu?.OnUnloaded();
 
+        RecentProjectsFlyout.Opening -= OnRecentProjectsFlyoutOpening;
+
         Loaded -= OnPageNavigationToolbar_Loaded;
         Unloaded -= OnPageNavigationToolbar_Unloaded;
 
         _messengerService.UnregisterAll(this);
+    }
+
+    private void OnRecentProjectsFlyoutOpening(object? sender, object e)
+    {
+        RecentProjectsFlyout.Items.Clear();
+
+        var viewModel = _recentProjectsViewModel;
+        var recentProjects = viewModel?.GetRecentProjects();
+        if (viewModel is null ||
+            recentProjects is null ||
+            recentProjects.Count == 0)
+        {
+            var emptyItem = new MenuFlyoutItem
+            {
+                Text = _stringLocalizer.GetString("Menu_NoRecentProjects"),
+                IsEnabled = false
+            };
+            RecentProjectsFlyout.Items.Add(emptyItem);
+            return;
+        }
+
+        RecentProjectsMenu.Populate(
+            RecentProjectsFlyout.Items,
+            recentProjects,
+            OpenRecentProjectFromSwitcher,
+            _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
+            viewModel.ClearRecentProjects);
+    }
+
+    private void RecentProjectsButton_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        // Open the switcher and mark the tap handled so it does not reach the workspace nav item; opening the
+        // switcher must never also trigger navigation to the workspace.
+        FlyoutBase.ShowAttachedFlyout(RecentProjectsButton);
+        e.Handled = true;
+    }
+
+    private async void OpenRecentProjectFromSwitcher(string projectFilePath)
+    {
+        if (_recentProjectsViewModel is null)
+        {
+            return;
+        }
+
+        // async void: observe exceptions so a failed open (e.g. the project moved or was deleted) cannot crash
+        // on the UI thread.
+        try
+        {
+            await _recentProjectsViewModel.OpenRecentProjectAsync(projectFilePath);
+        }
+        catch (Exception ex)
+        {
+            var logger = ServiceLocator.AcquireService<Logging.ILogger<PageNavigationToolbar>>();
+            logger.LogError(ex, "Failed to open recent project from the switcher");
+        }
     }
 
     private void ApplyTooltips()
@@ -158,6 +221,12 @@ public sealed partial class PageNavigationToolbar : UserControl
         ToolTipService.SetToolTip(MainMenuButton, mainMenuTooltip);
         ToolTipService.SetPlacement(MainMenuButton, PlacementMode.Bottom);
         AutomationProperties.SetName(MainMenuButton, mainMenuTooltip);
+
+        // The switcher chevron carries only an icon, so give it a tooltip and an accessible name.
+        var recentProjectsTooltip = _stringLocalizer.GetString("MainMenu_OpenRecent");
+        ToolTipService.SetToolTip(RecentProjectsButton, recentProjectsTooltip);
+        ToolTipService.SetPlacement(RecentProjectsButton, PlacementMode.Bottom);
+        AutomationProperties.SetName(RecentProjectsButton, recentProjectsTooltip);
 
         // Home and Community carry only an icon in their Content, so give assistive technology an explicit name.
         var homeTooltip = _stringLocalizer.GetString("TitleBar_HomeTooltip");


### PR DESCRIPTION
This pull request introduces a shared recent-projects menu component and refactors the UI to provide a more consistent and accessible experience for switching and opening recent projects. The main menu and the workspace switcher now use the same logic and display, with improved tooltips and accessibility. The workspace navigation is also redesigned for better clarity and usability.

**Recent Projects Menu Refactor and Workspace Navigation Redesign:**

**Recent Projects Menu Unification**
- Added a new static helper class `RecentProjectsMenu` to centralize the construction and behavior of the recent-projects menu, ensuring both the main menu and workspace switcher present the project list and clear action identically.
- Refactored `MainMenu.cs` to use `RecentProjectsMenu.Populate`, removing duplicated code for building the recent-projects menu.
- Updated resource strings to add a header label for the recent projects list (`TitleBar_RecentProjectsHeader`).

**Workspace Navigation Redesign**
- Redesigned the workspace navigation in `PageNavigationToolbar.xaml` to use a custom prominent button (with chevron for recent projects flyout), replacing the previous nav item and separator. Added a custom underline indicator for the active workspace. [[1]](diffhunk://#diff-4e6bf64c135265f3bdb7202d4685f7b9fda592803609fb2304364260416eeaecL72-L99) [[2]](diffhunk://#diff-4e6bf64c135265f3bdb7202d4685f7b9fda592803609fb2304364260416eeaecR145)
- Updated code-behind (`PageNavigationToolbar.xaml.cs`) to manage the new workspace button, including flyout population, active indicator, and navigation logic. [[1]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084R16) [[2]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084R138-R142) [[3]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084R155-R240) [[4]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084L182-R262) [[5]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084R283-R287) [[6]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084L215-R300) [[7]](diffhunk://#diff-403689d6afe07aa654a183ab6dff37700abf8ecb92df4b1ed964c6fa01aa2084R329-R333)

**Accessibility and User Experience Improvements**
- Improved tooltips and accessibility names for the workspace button and recent-projects chevron, ensuring assistive technologies can correctly identify and interact with these controls.
- Added an explicit disabled header to the recent-projects flyout for clarity when opened from the workspace button.

These changes make the recent-projects experience more consistent across the application and enhance accessibility and usability for all users.