### PR TITLE
Refactor console startup for invisible POSIX markers and fix tab drag

### DIFF
--- a/Source/Tests/Console/ShellCommandComposerTests.cs
+++ b/Source/Tests/Console/ShellCommandComposerTests.cs
@@ -6,6 +6,9 @@ namespace Celbridge.Tests.Console;
 [TestFixture]
 public class ShellCommandComposerTests
 {
+    private const char Escape = (char)27;
+    private const char Bell = (char)7;
+
     private static ConsoleStartupInvocation Command(string executable, params string[] arguments)
     {
         return new ConsoleStartupInvocation(executable, arguments);
@@ -16,7 +19,8 @@ public class ShellCommandComposerTests
     {
         var composed = ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, ConsoleStartupInvocation.None);
 
-        composed.Should().BeEmpty();
+        composed.Line.Should().BeEmpty();
+        composed.ScanMarker.Should().BeNull();
     }
 
     [Test]
@@ -24,11 +28,11 @@ public class ShellCommandComposerTests
     {
         var command = Command("celbridge-py", "--python", "3.13", "--with", "numpy", "--offline");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be("celbridge-py --python 3.13 --with numpy --offline");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command).Line
             .Should().Be("celbridge-py --python 3.13 --with numpy --offline");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command).Line
             .Should().Be("celbridge-py --python 3.13 --with numpy --offline");
     }
 
@@ -38,11 +42,11 @@ public class ShellCommandComposerTests
         // An unquoted '>' would redirect in every shell family.
         var command = Command("celbridge-py", "--with", "pandas>=2");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be("celbridge-py --with 'pandas>=2'");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command).Line
             .Should().Be("celbridge-py --with 'pandas>=2'");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command).Line
             .Should().Be("celbridge-py --with \"pandas>=2\"");
     }
 
@@ -51,7 +55,7 @@ public class ShellCommandComposerTests
     {
         var command = Command(@"C:\Program Files\App\tool.exe", "-x");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be(@"& 'C:\Program Files\App\tool.exe' -x");
     }
 
@@ -60,7 +64,7 @@ public class ShellCommandComposerTests
     {
         var command = Command(@"C:\Tools\tool.exe", "-x");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be(@"C:\Tools\tool.exe -x");
     }
 
@@ -69,7 +73,7 @@ public class ShellCommandComposerTests
     {
         var command = Command("/bin/echo", "it's");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command).Line
             .Should().Be("/bin/echo 'it'\\''s'");
     }
 
@@ -78,7 +82,7 @@ public class ShellCommandComposerTests
     {
         var command = Command("echo", "it's");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be("echo 'it''s'");
     }
 
@@ -88,9 +92,9 @@ public class ShellCommandComposerTests
         // Single quotes keep $ literal in PowerShell and POSIX shells alike.
         var command = Command("echo", "$HOME");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be("echo '$HOME'");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command).Line
             .Should().Be("echo '$HOME'");
     }
 
@@ -99,35 +103,46 @@ public class ShellCommandComposerTests
     {
         var command = Command("tool", "");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command).Line
             .Should().Be("tool ''");
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command)
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command).Line
             .Should().Be("tool \"\"");
     }
 
     [Test]
-    public void Compose_ReadyMarker_ClearsThenEchoesTheMarker()
+    public void Compose_ReadyMarker_ClearsThenEmitsTheMarker()
     {
         var command = Command("celbridge-py");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command, "READY-1234")
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command, "READY-1234").Line
             .Should().Be("Clear-Host; Write-Host -NoNewline ('READY' + '-1234'); celbridge-py");
-        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command, "READY-1234")
-            .Should().Be("clear; printf '%s' 'READY''-1234'; celbridge-py");
+
+        // POSIX emits an invisible OSC via printf octal escapes rather than visible text.
+        ShellCommandComposer.Compose(ConsoleShellFamily.Posix, command, "READY-1234").Line
+            .Should().Be("clear; printf '\\033]7000;READY-1234\\007'; celbridge-py");
     }
 
     [Test]
-    public void Compose_ReadyMarker_IsSplitSoTheEchoedLineDoesNotContainIt()
+    public void Compose_ReadyMarker_PosixScanMarkerIsTheInvisibleOscBytes()
     {
-        // The shell echoes this line as it reads it, before executing the write. If the echo contained
-        // the marker the document would reveal the terminal before the clear had run.
+        var composed = ShellCommandComposer.Compose(ConsoleShellFamily.Posix, Command("celbridge-py"), "READY-1234");
+
+        composed.ScanMarker.Should().Be($"{Escape}]7000;READY-1234{Bell}");
+    }
+
+    [Test]
+    public void Compose_ReadyMarker_ComposedLineNeverContainsTheScanMarker()
+    {
+        // The shell echoes this line as it reads it, before executing the write. If the echo contained the
+        // scan marker the document would reveal the terminal before the clear had run.
         const string marker = "CELBRIDGE-CONSOLE-READY-a1b2c3d4";
         var command = Command("celbridge-py");
 
         foreach (var family in new[] { ConsoleShellFamily.PowerShell, ConsoleShellFamily.Posix })
         {
-            var line = ShellCommandComposer.Compose(family, command, marker);
-            line.Should().NotContain(marker);
+            var composed = ShellCommandComposer.Compose(family, command, marker);
+            composed.ScanMarker.Should().NotBeNull();
+            composed.Line.Should().NotContain(composed.ScanMarker!);
         }
     }
 
@@ -137,8 +152,10 @@ public class ShellCommandComposerTests
         var command = Command("celbridge-py");
 
         ShellCommandComposer.SupportsReadyMarker(ConsoleShellFamily.Cmd).Should().BeFalse();
-        ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command, "READY-1234")
-            .Should().Be("cls & celbridge-py");
+
+        var composed = ShellCommandComposer.Compose(ConsoleShellFamily.Cmd, command, "READY-1234");
+        composed.Line.Should().Be("cls & celbridge-py");
+        composed.ScanMarker.Should().BeNull();
     }
 
     [Test]
@@ -146,14 +163,25 @@ public class ShellCommandComposerTests
     {
         var command = Command(@"C:\Program Files\App\tool.exe");
 
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command, "READY-1234")
+        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, command, "READY-1234").Line
             .Should().Be(@"Clear-Host; Write-Host -NoNewline ('READY' + '-1234'); & 'C:\Program Files\App\tool.exe'");
     }
 
     [Test]
-    public void Compose_ReadyMarker_EmptyCommandStaysEmpty()
+    public void Compose_ReadyMarker_PosixPlainShellRevealsWithoutACommand()
     {
-        ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, ConsoleStartupInvocation.None, "READY-1234")
-            .Should().BeEmpty();
+        var composed = ShellCommandComposer.Compose(ConsoleShellFamily.Posix, ConsoleStartupInvocation.None, "READY-1234");
+
+        composed.Line.Should().Be("clear; printf '\\033]7000;READY-1234\\007';");
+        composed.ScanMarker.Should().Be($"{Escape}]7000;READY-1234{Bell}");
+    }
+
+    [Test]
+    public void Compose_ReadyMarker_PowerShellPlainShellStaysEmpty()
+    {
+        var composed = ShellCommandComposer.Compose(ConsoleShellFamily.PowerShell, ConsoleStartupInvocation.None, "READY-1234");
+
+        composed.Line.Should().BeEmpty();
+        composed.ScanMarker.Should().BeNull();
     }
 }

--- a/Source/Workspace/Celbridge.Console/Helpers/ShellCommandComposer.cs
+++ b/Source/Workspace/Celbridge.Console/Helpers/ShellCommandComposer.cs
@@ -1,15 +1,25 @@
-using System.Text;
-
 namespace Celbridge.Console.Helpers;
 
 /// <summary>
+/// A composed shell startup line and the exact marker bytes the host scans the output stream for. A null
+/// ScanMarker means the line emits no marker, so the session reveals on its timer instead.
+/// </summary>
+public sealed record ComposedStartup(string Line, string? ScanMarker);
+
+/// <summary>
 /// Composes a startup command into a single line safe to inject at a shell prompt, quoting each token for
-/// the target shell's dialect. Given a ready marker the line also clears the screen and echoes the marker
+/// the target shell's dialect. Given a ready marker the line also clears the screen and emits the marker
 /// before running the command, so the shell wipes its own startup noise (banner, prompt, the echoed line)
-/// and the document knows the exact moment the screen is ready to reveal.
+/// and the document knows the exact moment the screen is ready to reveal. A shell whose marker is invisible
+/// still gets the clear-and-mark reveal with no command, so a plain shell also starts on a clean screen.
 /// </summary>
 public static class ShellCommandComposer
 {
+    // Private OSC identifier carrying the POSIX ready marker. Any number the terminal does not itself
+    // handle works: the host consumes the sequence before xterm.js sees it, and a leaked marker renders as
+    // nothing rather than visible text.
+    private const string PosixReadyMarkerOscCode = "7000";
+
     /// <summary>
     /// Whether a shell family can emit a ready marker. Cmd has no concise way to write a string whose
     /// source text differs from its output, so a cmd console reveals on the document's timer instead.
@@ -19,11 +29,23 @@ public static class ShellCommandComposer
         return family != ConsoleShellFamily.Cmd;
     }
 
-    public static string Compose(ConsoleShellFamily family, ConsoleStartupInvocation command, string? readyMarker = null)
+    public static ComposedStartup Compose(ConsoleShellFamily family, ConsoleStartupInvocation command, string? readyMarker = null)
     {
-        if (string.IsNullOrWhiteSpace(command.Executable))
+        var hasExecutable = !string.IsNullOrWhiteSpace(command.Executable);
+
+        // A plain shell injects no command, but a shell whose marker is invisible still clears the startup
+        // noise and marks the ready point so the buffer begins on a clean prompt. A visible-marker shell
+        // cannot reveal here without leaving the cursor mid-line, so it reveals nothing.
+        if (!hasExecutable)
         {
-            return string.Empty;
+            if (readyMarker is not null &&
+                family == ConsoleShellFamily.Posix)
+            {
+                var revealOnly = BuildReveal(family, readyMarker);
+                return new ComposedStartup(revealOnly.Prefix.TrimEnd(), revealOnly.ScanMarker);
+            }
+
+            return new ComposedStartup(string.Empty, null);
         }
 
         var tokens = new List<string>
@@ -51,34 +73,61 @@ public static class ShellCommandComposer
             line = "& " + line;
         }
 
+        string? scanMarker = null;
         if (readyMarker is not null)
         {
-            line = StartupPrefix(family, readyMarker) + line;
+            var reveal = BuildReveal(family, readyMarker);
+            line = reveal.Prefix + line;
+            scanMarker = reveal.ScanMarker;
         }
 
-        return line;
+        return new ComposedStartup(line, scanMarker);
     }
 
-    // Clears the screen, then writes the ready marker. The marker is split across two adjacent string
-    // literals, which the shell concatenates on execution: the line the shell echoes as it reads the
-    // input therefore never contains the marker, so only the executed write matches it.
-    private static string StartupPrefix(ConsoleShellFamily family, string readyMarker)
+    // The reveal injected before the command: clears the screen and emits the marker. The prefix's source
+    // text never contains the scan marker, so the shell's echo of the injected line cannot match it. POSIX
+    // emits an invisible escape sequence whose printf source differs from its output; PowerShell splits the
+    // marker across two concatenated literals.
+    private static (string Prefix, string? ScanMarker) BuildReveal(ConsoleShellFamily family, string readyMarker)
     {
-        var splitIndex = readyMarker.Length / 2;
-        var head = readyMarker.Substring(0, splitIndex);
-        var tail = readyMarker.Substring(splitIndex);
-
         switch (family)
         {
             case ConsoleShellFamily.PowerShell:
-                return $"Clear-Host; Write-Host -NoNewline ('{head}' + '{tail}'); ";
+            {
+                var splitIndex = readyMarker.Length / 2;
+                var head = readyMarker.Substring(0, splitIndex);
+                var tail = readyMarker.Substring(splitIndex);
+                var prefix = $"Clear-Host; Write-Host -NoNewline ('{head}' + '{tail}'); ";
+                return (prefix, readyMarker);
+            }
 
             case ConsoleShellFamily.Cmd:
-                return "cls & ";
+                return ("cls & ", null);
 
             default:
-                return $"clear; printf '%s' '{head}''{tail}'; ";
+            {
+                // Invisible, cursor-neutral OSC carrying the marker: leaves the shell at column 0 so a
+                // reveal with no following command does not trip zsh's partial-line indicator.
+                var prefix = $"clear; printf '{PosixMarkerPrintfSource(readyMarker)}'; ";
+                return (prefix, PosixMarkerStreamBytes(readyMarker));
+            }
         }
+    }
+
+    // The OSC marker as printf source text: backslash-escaped ESC and BEL, so its literal form differs from
+    // the bytes printf writes.
+    private static string PosixMarkerPrintfSource(string readyMarker)
+    {
+        return $"\\033]{PosixReadyMarkerOscCode};{readyMarker}\\007";
+    }
+
+    // The OSC marker as it appears in the output stream: real ESC and BEL bytes, which is what the host
+    // scans for.
+    private static string PosixMarkerStreamBytes(string readyMarker)
+    {
+        var escape = (char)27;
+        var bell = (char)7;
+        return $"{escape}]{PosixReadyMarkerOscCode};{readyMarker}{bell}";
     }
 
     private static string QuoteToken(ConsoleShellFamily family, string token)

--- a/Source/Workspace/Celbridge.Console/Services/ConsoleLiveSession.cs
+++ b/Source/Workspace/Celbridge.Console/Services/ConsoleLiveSession.cs
@@ -12,10 +12,11 @@ namespace Celbridge.Console.Services;
 /// </summary>
 internal sealed class ConsoleLiveSession : IDisposable
 {
-    // Prefixes the ready marker the injected command echoes once it has cleared the screen. The random
+    // Prefixes the ready marker the injected command emits once it has cleared the screen. The random
     // per-launch suffix guards against a stale marker from a previous launch arriving late on the old
-    // pty's stream. What stops the shell's own echo of the injected line matching is the literal split in
-    // ShellCommandComposer, not this suffix.
+    // pty's stream. What stops the shell's own echo of the injected line matching is that the marker's
+    // source text differs from its output (an escape sequence on POSIX, a split literal on PowerShell),
+    // not this suffix.
     private const string ReadyMarkerPrefix = "CELBRIDGE-CONSOLE-READY-";
 
     // How long after injection the marker scan keeps going before giving up and buffering raw output.
@@ -36,6 +37,7 @@ internal sealed class ConsoleLiveSession : IDisposable
 
     private ITerminal? _terminal;
     private StartupInjector? _startupInjector;
+    private List<string>? _deferredInjectionLines;
     private Timer? _markerTimeout;
     private int? _trackedProcessId;
     private bool _disposed;
@@ -193,7 +195,7 @@ internal sealed class ConsoleLiveSession : IDisposable
         var startupInvocation = invocationResult.Value;
 
         // Every session runs the platform shell; the session type only decides what is injected into it.
-        // The injected line clears the shell-startup noise and echoes the ready marker, so the buffer
+        // The injected line clears the shell-startup noise and emits the ready marker, so the buffer
         // begins on a clean screen.
         var shell = ConsoleShell.Resolve();
         var shellCommandLine = new CommandLineBuilder(shell.Executable).ToString();
@@ -204,11 +206,12 @@ internal sealed class ConsoleLiveSession : IDisposable
             readyMarker = ReadyMarkerPrefix + Guid.NewGuid().ToString("N").Substring(0, 8);
         }
 
-        var injectedCommandLine = ShellCommandComposer.Compose(shell.Family, startupInvocation, readyMarker);
-        var hasStartupInvocation = !string.IsNullOrEmpty(injectedCommandLine);
+        var composedStartup = ShellCommandComposer.Compose(shell.Family, startupInvocation, readyMarker);
+        var injectedCommandLine = composedStartup.Line;
+        var hasInjectedLine = !string.IsNullOrEmpty(injectedCommandLine);
 
         var injectedLines = new List<string>();
-        if (hasStartupInvocation)
+        if (hasInjectedLine)
         {
             injectedLines.Add(injectedCommandLine);
         }
@@ -254,9 +257,9 @@ internal sealed class ConsoleLiveSession : IDisposable
         // Gate input before the pty starts, so nothing typed can reach the shell prompt ahead of the
         // injected lines. The marker scanner keeps the buffer clean of the shell-startup noise.
         _startupInjectionPending = injectedLines.Count > 0;
-        if (readyMarker is not null && hasStartupInvocation)
+        if (composedStartup.ScanMarker is not null)
         {
-            _markerScanner = new StartupMarkerScanner(readyMarker);
+            _markerScanner = new StartupMarkerScanner(composedStartup.ScanMarker);
         }
 
         try
@@ -281,7 +284,25 @@ internal sealed class ConsoleLiveSession : IDisposable
 
         if (injectedLines.Count > 0)
         {
-            _startupInjector = StartupInjector.Begin(terminal, injectedLines, CompleteStartup);
+            // A plain shell's reveal is held until the terminal has a real size, which arrives on the
+            // first resize (at attach). Injecting at the headless guess would draw the revealed prompt at
+            // the wrong width, and zsh's PROMPT_SP fill would leave a stray marker glyph when the view
+            // renders at its own width. A command console injects immediately: its own output takes over
+            // after the marker, so no shell prompt is drawn at the guessed width.
+            var deferUntilSized = string.IsNullOrWhiteSpace(startupInvocation.Executable) &&
+                composedStartup.ScanMarker is not null;
+
+            if (deferUntilSized)
+            {
+                lock (_gateLock)
+                {
+                    _deferredInjectionLines = injectedLines;
+                }
+            }
+            else
+            {
+                _startupInjector = StartupInjector.Begin(terminal, injectedLines, CompleteStartup);
+            }
         }
 
         // Track the child so the workspace-scoped owner tears it down on project close or app crash.
@@ -331,6 +352,22 @@ internal sealed class ConsoleLiveSession : IDisposable
     public void Resize(int cols, int rows)
     {
         _terminal?.SetSize(cols, rows);
+
+        // A deferred reveal waits for this first real size before injecting, so the revealed prompt is
+        // drawn at the width it will be shown at. The resize itself redraws the pre-reveal prompt, which
+        // the marker scan still discards.
+        List<string>? deferredInjectionLines;
+        lock (_gateLock)
+        {
+            deferredInjectionLines = _deferredInjectionLines;
+            _deferredInjectionLines = null;
+        }
+
+        if (deferredInjectionLines is not null &&
+            _terminal is not null)
+        {
+            _startupInjector = StartupInjector.Begin(_terminal, deferredInjectionLines, CompleteStartup);
+        }
     }
 
     public void InjectCommand(string text)
@@ -543,6 +580,7 @@ internal sealed class ConsoleLiveSession : IDisposable
         {
             _startupInjectionPending = false;
             _bufferedInjections.Clear();
+            _deferredInjectionLines = null;
         }
 
         lock (_streamLock)

--- a/Source/Workspace/Celbridge.Documents/Views/TabDragController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/TabDragController.cs
@@ -102,10 +102,20 @@ internal sealed class TabDragController
             return;
         }
 
-        var position = e.GetCurrentPoint(_overlay).Position;
+        var pointerPoint = e.GetCurrentPoint(_overlay);
+        var position = pointerPoint.Position;
 
         if (!_isDragging)
         {
+            // A double-tap's second release is not delivered to this handler, so a press can outlive
+            // the button. A move with the button up is that missed release: drop the stale press
+            // rather than starting a phantom drag that follows the pointer with no button held.
+            if (!pointerPoint.Properties.IsLeftButtonPressed)
+            {
+                EndTracking();
+                return;
+            }
+
             if (Math.Abs(position.X - _pressPosition.X) < DragThreshold &&
                 Math.Abs(position.Y - _pressPosition.Y) < DragThreshold)
             {


### PR DESCRIPTION
This pull request refactors how shell startup commands are composed and tested, introducing a new `ComposedStartup` record to carry both the shell command line and an optional scan marker. The main goal is to ensure that when a ready marker is injected into the shell, it is emitted in a way that avoids accidental matching with the shell's echoed input, especially for POSIX shells where the marker is now an invisible OSC sequence. The changes also update tests and session startup logic to use the new structure.

**Core refactoring and feature improvements:**

* Introduced the `ComposedStartup` record to encapsulate both the composed shell command line and the scan marker, replacing the previous approach of returning just a string (`ShellCommandComposer.cs`).
* Refactored `ShellCommandComposer.Compose` to return a `ComposedStartup` and to emit invisible OSC sequences for ready markers in POSIX shells, ensuring that the marker is not visible and cannot be accidentally echoed or matched. [[1]](diffhunk://#diff-ce2eb232ce8f4fab9162ba7aa8d801528d41c354146817e44ec2c656b24253c0L22-R48) [[2]](diffhunk://#diff-ce2eb232ce8f4fab9162ba7aa8d801528d41c354146817e44ec2c656b24253c0R76-R132)
* Updated all relevant tests in `ShellCommandComposerTests.cs` to validate both the command line and the scan marker, and to check for correct behavior when no executable is provided or when using different shell families. [[1]](diffhunk://#diff-eb25c3f1276180cd5413173ee43944ce4094cd62f3b947ddbd2a9ef4e0314fa5L19-R35) [[2]](diffhunk://#diff-eb25c3f1276180cd5413173ee43944ce4094cd62f3b947ddbd2a9ef4e0314fa5L102-R145) [[3]](diffhunk://#diff-eb25c3f1276180cd5413173ee43944ce4094cd62f3b947ddbd2a9ef4e0314fa5L140-R185)

**Session startup and marker scanning:**

* Updated `ConsoleLiveSession` to use the new `ComposedStartup` structure, ensuring that the marker scanner is initialized with the correct scan marker and that injected lines are handled appropriately. [[1]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L207-R214) [[2]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L257-R262)
* Improved comments and logic to clarify the distinction between emitting and echoing ready markers, and to document why the marker cannot be accidentally matched by shell echo. [[1]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L15-R19) [[2]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L196-R198)

These changes collectively make the startup and ready-marker logic more robust and less error-prone, especially in POSIX environments where invisible markers are now used.