### PR TITLE
Enforce minimum title bar visibility for window bounds validation

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
+++ b/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
@@ -45,5 +45,9 @@
     <EmbeddedResource Include="Assets\Fonts\**\*.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Celbridge.Tests" />
+  </ItemGroup>
+
 </Project>
 

--- a/Source/Core/Celbridge.UserInterface/Helpers/RectInt32Extensions.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/RectInt32Extensions.cs
@@ -8,14 +8,20 @@ namespace Celbridge.UserInterface.Helpers;
 internal static class RectInt32Extensions
 {
     /// <summary>
-    /// Whether two rectangles overlap. Rectangles that only touch along an edge do not count as
-    /// overlapping.
+    /// Whether two rectangles overlap by at least the given width and height. Rectangles that only touch
+    /// along an edge do not count as overlapping.
     /// </summary>
-    public static bool IntersectsWith(this RectInt32 rect, RectInt32 other)
+    public static bool OverlapsAtLeast(this RectInt32 rect, RectInt32 other, int minimumWidth, int minimumHeight)
     {
-        return rect.X < other.X + other.Width &&
-               rect.X + rect.Width > other.X &&
-               rect.Y < other.Y + other.Height &&
-               rect.Y + rect.Height > other.Y;
+        int left = Math.Max(rect.X, other.X);
+        int top = Math.Max(rect.Y, other.Y);
+        int right = Math.Min(rect.X + rect.Width, other.X + other.Width);
+        int bottom = Math.Min(rect.Y + rect.Height, other.Y + other.Height);
+
+        int overlapWidth = right - left;
+        int overlapHeight = bottom - top;
+
+        return overlapWidth >= minimumWidth &&
+               overlapHeight >= minimumHeight;
     }
 }

--- a/Source/Core/Celbridge.UserInterface/Helpers/WindowPlacementPolicy.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WindowPlacementPolicy.cs
@@ -1,0 +1,44 @@
+using Windows.Graphics;
+
+namespace Celbridge.UserInterface.Helpers;
+
+/// <summary>
+/// Shared rules for deciding whether a saved window placement is usable, applied by the per-platform
+/// window bounds validators.
+/// </summary>
+internal static class WindowPlacementPolicy
+{
+    private const int TitleBarHeight = 40;
+
+    // Enough of the title bar must land on a screen for the user to see the window and drag it back. A
+    // window nudged just past a screen edge still intersects that screen by a few pixels, which reads as
+    // visible to a bare intersection test but leaves nothing on screen to grab.
+    private const int MinimumVisibleTitleBarWidth = 120;
+    private const int MinimumVisibleTitleBarHeight = 20;
+
+    /// <summary>
+    /// The title bar strip along the top of the given window bounds.
+    /// </summary>
+    public static RectInt32 GetTitleBarStrip(RectInt32 windowBounds)
+    {
+        return new RectInt32
+        {
+            X = windowBounds.X,
+            Y = windowBounds.Y,
+            Width = windowBounds.Width,
+            Height = TitleBarHeight
+        };
+    }
+
+    /// <summary>
+    /// Whether enough of the title bar strip falls inside the given screen area for the window to be
+    /// seen and dragged.
+    /// </summary>
+    public static bool IsTitleBarUsable(RectInt32 titleBarStrip, RectInt32 screenArea)
+    {
+        return titleBarStrip.OverlapsAtLeast(
+            screenArea,
+            MinimumVisibleTitleBarWidth,
+            MinimumVisibleTitleBarHeight);
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowBoundsValidator.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowBoundsValidator.cs
@@ -10,8 +10,6 @@ namespace Celbridge.UserInterface.Platform;
 /// </summary>
 public sealed class SkiaWindowBoundsValidator : IWindowBoundsValidator
 {
-    private const int TitleBarHeight = 40;
-
     private readonly ILogger<SkiaWindowBoundsValidator> _logger;
 
     public SkiaWindowBoundsValidator(ILogger<SkiaWindowBoundsValidator> logger)
@@ -38,13 +36,7 @@ public sealed class SkiaWindowBoundsValidator : IWindowBoundsValidator
         // both point space and pixel space. A hit in either accepts the restore, which keeps the unit
         // ambiguity from silently rejecting a valid placement. The values are logged so the
         // interpretation can be tightened once confirmed on device.
-        var titleBarRect = new RectInt32
-        {
-            X = windowBounds.X,
-            Y = windowBounds.Y,
-            Width = windowBounds.Width,
-            Height = TitleBarHeight
-        };
+        var titleBarRect = WindowPlacementPolicy.GetTitleBarStrip(windowBounds);
 
         // The flip from a bottom-left to a top-left origin is relative to the primary display (the one
         // whose origin is at 0,0), falling back to the first screen.
@@ -89,8 +81,8 @@ public sealed class SkiaWindowBoundsValidator : IWindowBoundsValidator
                 pixelRect.X, pixelRect.Y, pixelRect.Width, pixelRect.Height,
                 scale);
 
-            if (titleBarRect.IntersectsWith(pointRect)
-                || titleBarRect.IntersectsWith(pixelRect))
+            if (WindowPlacementPolicy.IsTitleBarUsable(titleBarRect, pointRect)
+                || WindowPlacementPolicy.IsTitleBarUsable(titleBarRect, pixelRect))
             {
                 return true;
             }

--- a/Source/Core/Celbridge.UserInterface/Platform/WinAppSdkWindowBoundsValidator.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/WinAppSdkWindowBoundsValidator.cs
@@ -10,8 +10,6 @@ namespace Celbridge.UserInterface.Platform;
 /// </summary>
 public sealed class WinAppSdkWindowBoundsValidator : IWindowBoundsValidator
 {
-    private const int TitleBarHeight = 40;
-
     private readonly ILogger<WinAppSdkWindowBoundsValidator> _logger;
 
     public WinAppSdkWindowBoundsValidator(ILogger<WinAppSdkWindowBoundsValidator> logger)
@@ -23,13 +21,7 @@ public sealed class WinAppSdkWindowBoundsValidator : IWindowBoundsValidator
     {
         try
         {
-            var titleBarRect = new RectInt32
-            {
-                X = windowBounds.X,
-                Y = windowBounds.Y,
-                Width = windowBounds.Width,
-                Height = TitleBarHeight
-            };
+            var titleBarRect = WindowPlacementPolicy.GetTitleBarStrip(windowBounds);
 
             var displayAreas = DisplayArea.FindAll();
             if (displayAreas == null || displayAreas.Count == 0)
@@ -47,7 +39,7 @@ public sealed class WinAppSdkWindowBoundsValidator : IWindowBoundsValidator
                     continue;
                 }
 
-                if (titleBarRect.IntersectsWith(displayArea.WorkArea))
+                if (WindowPlacementPolicy.IsTitleBarUsable(titleBarRect, displayArea.WorkArea))
                 {
                     return true;
                 }

--- a/Source/Tests/UserInterface/WindowPlacementPolicyTests.cs
+++ b/Source/Tests/UserInterface/WindowPlacementPolicyTests.cs
@@ -1,0 +1,57 @@
+using Celbridge.UserInterface.Helpers;
+using Windows.Graphics;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Tests the rule the window bounds validators use to decide whether a saved window placement leaves
+/// enough of the title bar on screen to be seen and dragged.
+/// </summary>
+[TestFixture]
+public class WindowPlacementPolicyTests
+{
+    private static readonly RectInt32 Display = Rect(0, 0, 3840, 2160);
+
+    private static RectInt32 Rect(int x, int y, int width, int height)
+    {
+        return new RectInt32
+        {
+            X = x,
+            Y = y,
+            Width = width,
+            Height = height
+        };
+    }
+
+    private static bool IsUsable(RectInt32 windowBounds)
+    {
+        var titleBarStrip = WindowPlacementPolicy.GetTitleBarStrip(windowBounds);
+        return WindowPlacementPolicy.IsTitleBarUsable(titleBarStrip, Display);
+    }
+
+    [Test]
+    public void WindowWellInsideDisplay_IsUsable()
+    {
+        IsUsable(Rect(100, 100, 2464, 1936)).Should().BeTrue();
+    }
+
+    [Test]
+    public void WindowSliverInsideDisplayEdge_IsNotUsable()
+    {
+        // The placement that hid the window: 11 pixels on screen, the rest off the right edge.
+        IsUsable(Rect(3829, -17, 2464, 1936)).Should().BeFalse();
+    }
+
+    [Test]
+    public void WindowOnDisconnectedDisplay_IsNotUsable()
+    {
+        IsUsable(Rect(5000, 100, 2464, 1936)).Should().BeFalse();
+    }
+
+    [Test]
+    public void WindowPartlyAboveDisplay_IsUsableWhileEnoughTitleBarRemains()
+    {
+        IsUsable(Rect(100, -17, 2464, 1936)).Should().BeTrue();
+        IsUsable(Rect(100, -25, 2464, 1936)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new shared policy for evaluating window placement usability, ensuring that enough of a window's title bar is visible for users to interact with it. The core logic for determining usable window placements has been refactored from platform-specific implementations into a centralized helper, and comprehensive unit tests have been added to verify the new policy. Additionally, a rectangle intersection helper was updated to support minimum overlap requirements.

**Window placement policy centralization:**
* Introduced the `WindowPlacementPolicy` helper class, which defines rules for determining if a window's title bar is sufficiently visible to be used, and provides methods for extracting the title bar region and checking its usability (`WindowPlacementPolicy.cs`).
* Refactored both `SkiaWindowBoundsValidator` and `WinAppSdkWindowBoundsValidator` to use the shared `WindowPlacementPolicy` logic instead of duplicating title bar calculations and intersection checks. [[1]](diffhunk://#diff-b8dc1ae7b5378dc1246667f747fe855c01ba80135b6e8e9fa90c75226bbf7af5L13-L14) [[2]](diffhunk://#diff-b8dc1ae7b5378dc1246667f747fe855c01ba80135b6e8e9fa90c75226bbf7af5L41-R39) [[3]](diffhunk://#diff-b8dc1ae7b5378dc1246667f747fe855c01ba80135b6e8e9fa90c75226bbf7af5L92-R85) [[4]](diffhunk://#diff-5095bd05f38275e8592fbf40b2c1d1798c1d9fabd8e669a70a9ae96d3ebbff49L13-L14) [[5]](diffhunk://#diff-5095bd05f38275e8592fbf40b2c1d1798c1d9fabd8e669a70a9ae96d3ebbff49L26-R24) [[6]](diffhunk://#diff-5095bd05f38275e8592fbf40b2c1d1798c1d9fabd8e669a70a9ae96d3ebbff49L50-R42)

**Rectangle overlap logic update:**
* Updated the rectangle helper extension: replaced the basic `IntersectsWith` method with `OverlapsAtLeast`, which checks for a minimum required overlap in width and height, supporting the new title bar visibility logic (`RectInt32Extensions.cs`).

**Testing improvements:**
* Added `WindowPlacementPolicyTests`, a new unit test class that verifies the usability rules for window placements in various scenarios, including edge cases where windows are barely visible or entirely off-screen (`WindowPlacementPolicyTests.cs`).

**Project configuration:**
* Exposed internal members of the user interface project to the test project by adding an `InternalsVisibleTo` directive in the `.csproj` file, enabling thorough testing of internal logic.Replaced simple rectangle intersection with `OverlapsAtLeast`, which checks overlap width and height against minimum thresholds. Both Skia and WinAppSDK window bounds validators now require at least 120x20 of title bar visibility before treating saved bounds as usable, preventing windows that are technically intersecting but effectively unreachable. Added `InternalsVisibleTo` and new unit tests to cover normal, edge, and off-screen placement cases.