### PR TITLE
Implement log file retention cleanup in Celbridge.Logging

### DIFF
--- a/Source/Celbridge/App.xaml.cs
+++ b/Source/Celbridge/App.xaml.cs
@@ -26,6 +26,9 @@ public partial class App : Application
         this.InitializeComponent();
     }
 
+    // Log files from previous runs kept on disk. Each run writes one file, so this is a count of runs.
+    private const int RetainedLogFileCount = 50;
+
     protected Window? MainWindow { get; private set; }
     protected IHost? Host { get; private set; }
 
@@ -361,6 +364,7 @@ public partial class App : Application
     /// <summary>
     /// Set an environment variable for where the application log file should be created.
     /// This allows us to easily share the value with both NLog and with Python host child processes.
+    /// Also deletes the oldest log files, since each run adds one.
     /// </summary>
     private static void SetupLoggingEnvironment()
     {
@@ -373,10 +377,13 @@ public partial class App : Application
         var processStartTime = System.Diagnostics.Process.GetCurrentProcess().StartTime;
         var timestamp = processStartTime.ToString("yyyyMMdd_HHmmss");
 
+        var logFolderPath = System.IO.Path.Combine(localDataPath, "Logs");
         var logFileName = $"celbridge_{timestamp}.log";
-        var logFilePath = System.IO.Path.Combine(localDataPath, "Logs", logFileName);
+        var logFilePath = System.IO.Path.Combine(logFolderPath, logFileName);
 
         Environment.SetEnvironmentVariable("CELBRIDGE_LOG_FILE", logFilePath);
+
+        Celbridge.Logging.LogFileRetention.DeleteOldLogFiles(logFolderPath, logFilePath, RetainedLogFileCount);
     }
 }
 

--- a/Source/Core/Celbridge.Logging/Celbridge.Logging.csproj
+++ b/Source/Core/Celbridge.Logging/Celbridge.Logging.csproj
@@ -30,6 +30,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\Core\Celbridge.Foundation\Celbridge.Foundation.csproj" />
+		<ProjectReference Include="..\..\Core\Celbridge.FileSystem\Celbridge.FileSystem.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Core/Celbridge.Logging/LogFileRetention.cs
+++ b/Source/Core/Celbridge.Logging/LogFileRetention.cs
@@ -1,0 +1,85 @@
+using Celbridge.FileSystem;
+
+using Directory = System.IO.Directory;
+using File = System.IO.File;
+using Path = System.IO.Path;
+
+namespace Celbridge.Logging;
+
+/// <summary>
+/// Deletes the oldest application log files so the log folder does not grow without bound.
+/// Every application run writes to its own timestamped log file, so the folder gains a file per launch.
+/// </summary>
+[AllowDirectFileSystemAccess]
+public static class LogFileRetention
+{
+    // Matches the log file names built at application startup.
+    private const string LogFileSearchPattern = "celbridge_*.log";
+
+    /// <summary>
+    /// Deletes all but the newest retainedFileCount log files in the given folder. The starting run's own
+    /// log file is always kept and does not count towards the limit. Called before dependency injection is
+    /// available, so failures are swallowed rather than logged.
+    /// </summary>
+    public static void DeleteOldLogFiles(string logFolderPath, string currentLogFilePath, int retainedFileCount)
+    {
+        if (retainedFileCount < 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!Directory.Exists(logFolderPath))
+            {
+                return;
+            }
+
+            var logFilePaths = new List<string>(Directory.GetFiles(logFolderPath, LogFileSearchPattern));
+
+            // This run appends to its own file for the lifetime of the process, so that file is never a
+            // deletion candidate and does not count towards the retained total.
+            var currentLogFileName = Path.GetFileName(currentLogFilePath);
+            logFilePaths.RemoveAll(logFilePath => HasFileName(logFilePath, currentLogFileName));
+
+            if (logFilePaths.Count <= retainedFileCount)
+            {
+                return;
+            }
+
+            // Each log file name embeds a fixed width, zero padded launch timestamp, so ordering the names
+            // ascending puts the oldest first without reading write times from disk.
+            logFilePaths.Sort(StringComparer.OrdinalIgnoreCase);
+
+            var deletionCount = logFilePaths.Count - retainedFileCount;
+            for (var index = 0; index < deletionCount; index++)
+            {
+                DeleteLogFile(logFilePaths[index]);
+            }
+        }
+        catch
+        {
+            // Log retention is housekeeping. It must never prevent the application from starting.
+        }
+    }
+
+    private static bool HasFileName(string logFilePath, string fileName)
+    {
+        var candidateFileName = Path.GetFileName(logFilePath);
+
+        return string.Equals(candidateFileName, fileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void DeleteLogFile(string logFilePath)
+    {
+        try
+        {
+            File.Delete(logFilePath);
+        }
+        catch
+        {
+            // A concurrently running Celbridge instance may still hold this file open. Leave it in place
+            // and let a later run collect it.
+        }
+    }
+}

--- a/Source/Tests/LogFiles/LogFileRetentionTests.cs
+++ b/Source/Tests/LogFiles/LogFileRetentionTests.cs
@@ -1,0 +1,141 @@
+// Not namespace Celbridge.Tests.Logging: that would shadow the Celbridge.Logging namespace for the
+// test files that reach for it with a bare Logging. prefix.
+namespace Celbridge.Tests.LogFiles;
+
+/// <summary>
+/// Unit tests for LogFileRetention — the startup sweep that bounds the number of
+/// application log files, given that every run writes a new timestamped file.
+/// The tests pin which files are considered, the newest-wins ordering, and the
+/// guarantee that the starting run's own log file survives.
+/// </summary>
+[TestFixture]
+public class LogFileRetentionTests
+{
+    private string _logFolderPath = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _logFolderPath = Path.Combine(
+            Path.GetTempPath(),
+            "Celbridge",
+            nameof(LogFileRetentionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_logFolderPath);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_logFolderPath))
+        {
+            try
+            {
+                Directory.Delete(_logFolderPath, recursive: true);
+            }
+            catch
+            {
+                // Best effort
+            }
+        }
+    }
+
+    [Test]
+    public void DeleteOldLogFiles_DeletesOldestBeyondRetainedCount()
+    {
+        CreateLogFile("celbridge_20260101_000000.log");
+        CreateLogFile("celbridge_20260102_000000.log");
+        CreateLogFile("celbridge_20260103_000000.log");
+        var currentLogFilePath = Path.Combine(_logFolderPath, "celbridge_20260104_000000.log");
+
+        LogFileRetention.DeleteOldLogFiles(_logFolderPath, currentLogFilePath, retainedFileCount: 2);
+
+        var remainingFileNames = GetRemainingFileNames();
+        remainingFileNames.Should().BeEquivalentTo(new[]
+        {
+            "celbridge_20260102_000000.log",
+            "celbridge_20260103_000000.log",
+        });
+    }
+
+    [Test]
+    public void DeleteOldLogFiles_KeepsCurrentRunLogFile()
+    {
+        // The starting run's file is excluded from the sweep even when it already exists on disk, so a
+        // retained count of zero still leaves this run somewhere to write.
+        var currentLogFilePath = CreateLogFile("celbridge_20260101_000000.log");
+        CreateLogFile("celbridge_20260102_000000.log");
+
+        LogFileRetention.DeleteOldLogFiles(_logFolderPath, currentLogFilePath, retainedFileCount: 0);
+
+        var remainingFileNames = GetRemainingFileNames();
+        remainingFileNames.Should().Equal("celbridge_20260101_000000.log");
+    }
+
+    [Test]
+    public void DeleteOldLogFiles_UnderRetainedCount_DeletesNothing()
+    {
+        CreateLogFile("celbridge_20260101_000000.log");
+        CreateLogFile("celbridge_20260102_000000.log");
+        var currentLogFilePath = Path.Combine(_logFolderPath, "celbridge_20260103_000000.log");
+
+        LogFileRetention.DeleteOldLogFiles(_logFolderPath, currentLogFilePath, retainedFileCount: 50);
+
+        var remainingFileNames = GetRemainingFileNames();
+        remainingFileNames.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void DeleteOldLogFiles_LeavesUnrelatedFilesAlone()
+    {
+        // The log folder is Celbridge's own, but the sweep only claims files it recognises as
+        // application logs so anything else dropped in there survives.
+        CreateLogFile("celbridge_20260101_000000.log");
+        CreateLogFile("notes.txt");
+        CreateLogFile("python_20260101_000000.log");
+        var currentLogFilePath = Path.Combine(_logFolderPath, "celbridge_20260102_000000.log");
+
+        LogFileRetention.DeleteOldLogFiles(_logFolderPath, currentLogFilePath, retainedFileCount: 0);
+
+        var remainingFileNames = GetRemainingFileNames();
+        remainingFileNames.Should().BeEquivalentTo(new[]
+        {
+            "notes.txt",
+            "python_20260101_000000.log",
+        });
+    }
+
+    [Test]
+    public void DeleteOldLogFiles_MissingFolder_DoesNotThrow()
+    {
+        // First run on a clean machine: NLog creates the folder later, when it opens the log file.
+        var missingFolderPath = Path.Combine(_logFolderPath, "does-not-exist");
+        var currentLogFilePath = Path.Combine(missingFolderPath, "celbridge_20260101_000000.log");
+
+        var sweep = () => LogFileRetention.DeleteOldLogFiles(missingFolderPath, currentLogFilePath, retainedFileCount: 0);
+
+        sweep.Should().NotThrow();
+    }
+
+    private string CreateLogFile(string fileName)
+    {
+        var filePath = Path.Combine(_logFolderPath, fileName);
+        File.WriteAllText(filePath, "log contents");
+
+        return filePath;
+    }
+
+    private List<string> GetRemainingFileNames()
+    {
+        var filePaths = Directory.GetFiles(_logFolderPath);
+
+        var fileNames = new List<string>();
+        foreach (var filePath in filePaths)
+        {
+            fileNames.Add(Path.GetFileName(filePath));
+        }
+        fileNames.Sort(StringComparer.Ordinal);
+
+        return fileNames;
+    }
+}


### PR DESCRIPTION
This pull request introduces a log file retention mechanism to prevent the application's log folder from growing indefinitely by keeping only a fixed number of log files from previous runs. The main changes include implementing the retention logic, integrating it into application startup, and adding comprehensive unit tests.

**Log file retention implementation:**

* Added the `LogFileRetention` static class in `Celbridge.Logging`, which deletes the oldest log files in the log folder, retaining only a configurable number of the most recent logs (excluding the current run's log file).
* Updated `App.xaml.cs` to invoke the log file retention logic during startup, ensuring the cleanup happens each time the application is launched. [[1]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dR380-R386) [[2]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dR29-R31) [[3]](diffhunk://#diff-dd252d13b0e792cd3f81a8965a300b69f2b0ecf4a831ce9b66e9caf76fd8a11dR367)

**Project and test updates:**

* Added a project reference to `Celbridge.FileSystem` in `Celbridge.Logging.csproj` to support file system operations required by the retention logic.
* Introduced `LogFileRetentionTests` with thorough unit tests covering retention behavior, edge cases, and folder/file handling.Introduce `LogFileRetention` in `Celbridge.Logging` and call it from `App.SetupLoggingEnvironment()` to keep only the most recent 50 prior `celbridge_*.log` files while always preserving the current run’s log file. This prevents unbounded log folder growth across launches and keeps startup resilient by treating retention as best-effort housekeeping. Also adds unit tests covering deletion ordering, current-file preservation, unrelated file safety, under-limit behavior, and missing-folder handling.