### PR TITLE
Add shared nav tabs and rail UI for web panels

### DIFF
--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -128,7 +128,58 @@ Core tokens:
 
 The stylesheet also imports the Cascadia Mono face and applies the UI font, base text color, and window background to `body`. It gives common form controls — `<button>`, `<select>`, `<textarea>`, text `<input>`, checkboxes/radios, and range sliders — an approximate native Fluent look with no markup beyond the plain element; add `class="cel-accent"` to a button for the filled accent (primary) variant. Text-level elements are themed too: `<a>` links take the accent color, `<code>`/`<pre>`/`<kbd>` use the mono font, and placeholders, `::selection`, and `<hr>` follow the theme. These are bare-element rules with the lowest specificity, so an editor overrides any of them by id or class. Larger components (tables, dialogs, cards) are intentionally not pre-styled — build them from the tokens. Icons are opt-in: link `/assets/bootstrap-icons/bootstrap-icons.css` and use the `bi` classes (the same icon font the native chrome uses).
 
-The Utility Demo utility is the minimal reference for consuming these tokens — the UI font, host-styled controls, and a bordered input.
+Shared components sit above the bare-element rules, each mirroring a native control so a WebView surface reads as a peer of the XAML panels beside it: `.cel-expander` (a collapsible card), `.cel-splitter` (a draggable divider, driven by `attachSplitter()` from `ui/splitter.js`), `.cel-panel-footer` (a pinned caption-and-action row), and the two navigation components below. The Utility Demo utility is the reference for all of them — the UI font, host-styled controls, a bordered input, and each shared component in use.
+
+### Panel navigation
+
+A panel whose content divides into sections uses `.cel-nav-tabs`: a strip of icon tabs over an accent underline, above the active section's name and description. This is the standard across utility panels and document inspectors — do not build a section hierarchy out of stacked collapsible cards, which hides the panel's shape and makes a deep panel a scroll hunt.
+
+```html
+<div class="cel-nav-tabs">
+  <div id="tabs" class="cel-nav-tab-strip" role="tablist">
+    <button class="cel-nav-tab" type="button" role="tab" data-section="session" aria-selected="true" title="Session">
+      <span class="cel-nav-tab-icon"><i class="bi bi-terminal"></i></span>
+    </button>
+    <!-- ... one button per section ... -->
+  </div>
+  <div class="cel-section-header" data-section="session"><h1>Session</h1><p>What this section covers.</p></div>
+  <!-- ... one header per section, all but the active one hidden ... -->
+</div>
+```
+
+Drive it with `attachNavTabs()` from `ui/nav-tabs.js`, which owns `aria-selected`, the roving tabindex, and arrow-key navigation, and reports the selected section id:
+
+```javascript
+import { attachNavTabs } from '/assets/celbridge-client/ui/nav-tabs.js';
+
+const tabs = attachNavTabs(document.getElementById('tabs'), {
+    onChange(sectionId) { /* show that section */ },
+});
+tabs.select('environment');   // e.g. when restoring view state
+tabs.selected();              // persist this in onRequestState()
+```
+
+Each tab is an icon with a tooltip, not a text label, so the strip stays a fixed width however many sections a panel has; the section name below it is what names the selection. Add a `<span class="cel-nav-tab-pip">` inside a tab's icon to flag that its section needs attention.
+
+### Inspector rail
+
+An editor that needs a side panel puts it behind `.cel-rail`, a vertical icon rail down the right edge of its content, mirroring the workspace utility rail. The settings button sits at the top, the editor's own action buttons below it, separated by a `.cel-rail-separator`; the settings button uses `bi-sliders`, the same glyph as the workspace Project Settings button, and toggles the panel.
+
+```html
+<div class="cel-rail cel-rail-right">
+  <button class="cel-rail-button selected" type="button" title="Settings">
+    <i class="bi bi-sliders"></i><span class="cel-rail-pip"></span>
+  </button>
+  <div class="cel-rail-separator"></div>
+  <button class="cel-rail-button" type="button" title="Run tests"><i class="bi bi-play-fill"></i></button>
+</div>
+```
+
+Settings goes above the action buttons, inverting the workspace rail's ordering, because an editor's action buttons are usually configured from the panel that settings button opens — below them, its position would shift every time the user adds or removes one. Above them it is fixed, and a growing action group overflows downward into empty space instead. The separator is what carries the family resemblance to the workspace rail, not the ordering.
+
+Rail buttons are icon-only with a tooltip, so a button whose action has no natural glyph still needs a fallback icon rather than a text label. Add `selected` to the button whose surface is showing; its accent edge capsule stays lit for as long as that surface is open. This deliberately differs from the workspace utility rail, whose capsule dims while its panel is unfocused — with several rails and panels on screen at once, "this panel is open" is the more useful signal, and an editor's own content usually holds focus anyway. `.cel-rail-right` moves the rail's border and its capsules to the window edge; omit it for a rail on the left.
+
+The console editor is the reference: its shortcut buttons render into the rail above the settings toggle, and its settings panel is a `.cel-nav-tabs` hierarchy.
 
 ## Edit verbs (optional)
 

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
@@ -29,6 +29,11 @@
     --cel-icon-size-large: 22px;
     --cel-icon-button-size: 32px;
 
+    /* Vertical icon rail sizing, mirroring the workspace utility rail (UtilityPanel.xaml's 50px column and
+       UtilityButton.xaml's 48px cell); keep the three in sync when either changes. */
+    --cel-rail-width: 50px;
+    --cel-rail-item-size: 48px;
+
     color-scheme: light;
 
     --cel-app-bg: #F3F3F3;
@@ -43,6 +48,8 @@
     --cel-text-secondary: rgba(0, 0, 0, 0.6);
     --cel-error-text: #D32F2F;
     --cel-warning-text: #FFA000;
+    /* Attention pip fill (WinUI SystemFillColorCaution), matching the pips on the native rail and tab strip. */
+    --cel-caution: #9D5D00;
     --cel-search-highlight: #C66300;
     --cel-list-selected-bg: rgba(0, 120, 212, 0.235);
 
@@ -73,6 +80,7 @@
     --cel-text-secondary: rgba(255, 255, 255, 0.6);
     --cel-error-text: #FF5252;
     --cel-warning-text: #FFCA28;
+    --cel-caution: #FCE100;
     --cel-search-highlight: #FFD966;
     --cel-list-selected-bg: rgba(0, 120, 212, 0.235);
 

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
@@ -270,6 +270,194 @@ hr {
     background: var(--cel-accent);
 }
 
+/* Navigation tab strip for a panel whose content divides into sections, mirroring the native settings panels
+   (ProjectSettingsPanel.xaml): a row of icon tabs, each over an accent underline slot, above the active
+   section's name and description. Use as:
+     <div class="cel-nav-tabs">
+       <div class="cel-nav-tab-strip" role="tablist">
+         <button class="cel-nav-tab" type="button" role="tab" data-section="session" aria-selected="true"
+                 title="Session">
+           <span class="cel-nav-tab-icon"><i class="bi bi-terminal"></i></span>
+         </button>
+         ...
+       </div>
+       <div class="cel-section-header"><h1>Session</h1><p>What this section covers.</p></div>
+     </div>
+   Drive the selection with attachNavTabs() from ui/nav-tabs.js, which owns aria-selected and the arrow-key
+   navigation. Each tab carries an icon and a tooltip rather than a text label, so the strip stays a fixed
+   width; the section name below it is what names the selection. */
+.cel-nav-tabs {
+    flex: 0 0 auto;
+    padding: 6px 12px 8px;
+    border-bottom: 1px solid var(--cel-divider);
+}
+
+.cel-nav-tab-strip {
+    display: flex;
+    gap: 4px;
+}
+
+/* A bare hit target: the underline is the only selection visual, matching the native strip, which has no
+   hover or pressed state either. */
+.cel-nav-tab {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: var(--cel-text-primary);
+    cursor: pointer;
+}
+
+.cel-nav-tab:hover {
+    background: transparent;
+}
+
+.cel-nav-tab:focus-visible {
+    outline: 1px solid var(--cel-accent);
+    outline-offset: 1px;
+}
+
+.cel-nav-tab-icon {
+    position: relative;
+    display: block;
+    padding: 2px 10px 0;
+    font-size: var(--cel-icon-size-medium);
+    line-height: 1;
+}
+
+/* The underline slot is always present, so selecting a tab shows the bar without shifting the icons. */
+.cel-nav-tab::after {
+    content: "";
+    height: 2px;
+    margin-top: 5px;
+    border-radius: 1px;
+    background: transparent;
+}
+
+.cel-nav-tab[aria-selected="true"]::after {
+    background: var(--cel-accent);
+}
+
+/* Reports that this tab's section has something to look at; the detail belongs in the section itself. Place
+   it inside .cel-nav-tab-icon. */
+.cel-nav-tab-pip {
+    position: absolute;
+    top: -1px;
+    right: 3px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--cel-caution);
+}
+
+/* The active section's name and description. Usable on its own for a panel with no tab strip. */
+.cel-section-header {
+    margin: 6px 0 0 2px;
+}
+
+.cel-section-header h1 {
+    margin: 0 0 2px;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.cel-section-header p {
+    margin: 0;
+    font-size: 12px;
+    color: var(--cel-text-secondary);
+}
+
+/* Vertical icon rail, mirroring the workspace utility rail (UtilityPanel.xaml and UtilityButton.xaml): a
+   fixed-width strip of icon cells with a hover fill, an edge capsule marking the surface on screen, and
+   hairline separators between groups. An editor uses it as an inspector rail down the right of its content,
+   with .cel-rail-right moving the border and the capsules to that edge:
+     <div class="cel-rail cel-rail-right">
+       <button class="cel-rail-button selected" type="button" title="Settings">
+         <i class="bi bi-sliders"></i><span class="cel-rail-pip"></span>
+       </button>
+       <div class="cel-rail-separator"></div>
+       <button class="cel-rail-button" type="button" title="Run tests"><i class="bi bi-play-fill"></i></button>
+     </div>
+   Add `selected` to the button whose surface is showing. Unlike the workspace rail, whose capsule dims while
+   its panel is unfocused, an editor rail's capsule stays accent for as long as the surface is open: with
+   several rails and panels on screen at once, "this panel is open" is the more useful signal. */
+.cel-rail {
+    flex: 0 0 var(--cel-rail-width);
+    display: flex;
+    flex-direction: column;
+    width: var(--cel-rail-width);
+    background: var(--cel-panel-bg);
+    border-right: 1px solid var(--cel-divider-subtle);
+}
+
+.cel-rail-right {
+    border-right: none;
+    border-left: 1px solid var(--cel-divider-subtle);
+}
+
+.cel-rail-separator {
+    flex: 0 0 auto;
+    height: 1px;
+    margin: 4px 8px;
+    background: var(--cel-divider);
+}
+
+.cel-rail-button {
+    position: relative;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--cel-rail-item-size);
+    padding: 0;
+    font-size: var(--cel-icon-size-large);
+    line-height: 1;
+    background: transparent;
+    border: none;
+    border-radius: var(--cel-radius-control);
+    color: var(--cel-text-primary);
+    cursor: pointer;
+}
+
+.cel-rail-button:hover {
+    background: var(--cel-control-hover-bg);
+}
+
+/* Tall capsule on the rail's outer edge, inset evenly from the top and bottom of the cell. */
+.cel-rail-button::before {
+    content: "";
+    position: absolute;
+    top: 2px;
+    bottom: 2px;
+    left: 2px;
+    width: 3px;
+    border-radius: 1.5px;
+    background: var(--cel-accent);
+    opacity: 0;
+}
+
+.cel-rail-right .cel-rail-button::before {
+    left: auto;
+    right: 2px;
+}
+
+.cel-rail-button.selected::before {
+    opacity: 1;
+}
+
+/* Caution pip on the glyph's corner, positioned off the centred 22px icon box the way the native rail
+   button's pip is. */
+.cel-rail-pip {
+    position: absolute;
+    top: 10px;
+    right: 9px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--cel-caution);
+}
+
 /* Pinned action footer for a settings-style panel: a top divider (over the panel background, which the
    native panels' footer also relies on) above a secondary-text caption and an action button that is capped
    and centred rather than full-width. Pair it with a scrolling body -- a flex-column parent whose body is

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/nav-tabs.test.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/nav-tabs.test.js
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { attachNavTabs } from '../ui/nav-tabs.js';
+
+function buildStrip(selectedSection = 'session') {
+    document.body.innerHTML = `
+        <div id="strip" class="cel-nav-tab-strip" role="tablist">
+            <button class="cel-nav-tab" type="button" role="tab" data-section="session"></button>
+            <button class="cel-nav-tab" type="button" role="tab" data-section="environment"></button>
+            <button class="cel-nav-tab" type="button" role="tab" data-section="shortcuts"></button>
+        </div>`;
+
+    const strip = document.getElementById('strip');
+    strip.querySelector(`[data-section="${selectedSection}"]`).setAttribute('aria-selected', 'true');
+
+    return strip;
+}
+
+function tabFor(strip, sectionId) {
+    return strip.querySelector(`[data-section="${sectionId}"]`);
+}
+
+function pressKey(strip, key) {
+    strip.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+describe('attachNavTabs', () => {
+    let strip;
+    let onChange;
+
+    beforeEach(() => {
+        strip = buildStrip();
+        onChange = vi.fn();
+    });
+
+    it('selects the tab marked in the markup and reports it', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+
+        expect(tabs.selected()).toBe('session');
+        expect(onChange).toHaveBeenCalledWith('session');
+        expect(tabFor(strip, 'session').getAttribute('aria-selected')).toBe('true');
+        expect(tabFor(strip, 'environment').getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('falls back to the first tab when the markup marks none', () => {
+        strip = buildStrip();
+        tabFor(strip, 'session').setAttribute('aria-selected', 'false');
+
+        const tabs = attachNavTabs(strip, { onChange });
+
+        expect(tabs.selected()).toBe('session');
+    });
+
+    it('selects a tab on click and moves the tab order to it', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+        onChange.mockClear();
+
+        tabFor(strip, 'shortcuts').click();
+
+        expect(tabs.selected()).toBe('shortcuts');
+        expect(onChange).toHaveBeenCalledExactlyOnceWith('shortcuts');
+        expect(tabFor(strip, 'shortcuts').tabIndex).toBe(0);
+        expect(tabFor(strip, 'session').tabIndex).toBe(-1);
+    });
+
+    it('ignores a click on the already selected tab', () => {
+        attachNavTabs(strip, { onChange });
+        onChange.mockClear();
+
+        tabFor(strip, 'session').click();
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores a select for an unknown section', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+
+        tabs.select('nonexistent');
+
+        expect(tabs.selected()).toBe('session');
+    });
+
+    it('moves between tabs with the arrow keys, wrapping at each end', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+
+        pressKey(strip, 'ArrowRight');
+        expect(tabs.selected()).toBe('environment');
+
+        pressKey(strip, 'ArrowLeft');
+        expect(tabs.selected()).toBe('session');
+
+        pressKey(strip, 'ArrowLeft');
+        expect(tabs.selected()).toBe('shortcuts');
+    });
+
+    it('jumps to the first and last tabs with Home and End', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+
+        pressKey(strip, 'End');
+        expect(tabs.selected()).toBe('shortcuts');
+
+        pressKey(strip, 'Home');
+        expect(tabs.selected()).toBe('session');
+    });
+
+    it('leaves other keys to the page', () => {
+        const tabs = attachNavTabs(strip, { onChange });
+
+        pressKey(strip, 'ArrowDown');
+
+        expect(tabs.selected()).toBe('session');
+    });
+
+    it('returns a no-op controller when the strip is missing', () => {
+        const tabs = attachNavTabs(null, { onChange });
+
+        tabs.select('session');
+
+        expect(tabs.selected()).toBeNull();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/ui/nav-tabs.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/ui/nav-tabs.js
@@ -1,0 +1,98 @@
+// Selection behaviour for the shared `.cel-nav-tabs` strip (styled by celbridge.css), matching the native
+// settings panels' icon tab strip. Mark up the tabs as `.cel-nav-tab` buttons carrying a `data-section` id,
+// then call attachNavTabs() to make them selectable. The helper owns `aria-selected`, the roving tabindex,
+// and arrow-key navigation, and reports the selected section id.
+//
+//   const tabs = attachNavTabs(stripElement, {
+//     onChange(sectionId) { /* show that section */ },
+//   });
+//   tabs.select('environment');   // select programmatically, e.g. when restoring view state
+//   tabs.selected();              // the current section id
+//
+// The initially selected tab is the one marked aria-selected="true" in the markup, or the first tab.
+
+export function attachNavTabs(stripElement, options = {}) {
+    if (!stripElement) {
+        return {
+            select() { },
+            selected() {
+                return null;
+            },
+        };
+    }
+
+    const { onChange } = options;
+    const tabs = Array.from(stripElement.querySelectorAll('.cel-nav-tab'));
+    let selectedId = null;
+
+    function sectionIdOf(tab) {
+        return tab.dataset.section || '';
+    }
+
+    function select(sectionId, notify) {
+        const target = tabs.find((tab) => sectionIdOf(tab) === sectionId);
+        if (!target || sectionId === selectedId) {
+            return;
+        }
+
+        selectedId = sectionId;
+
+        for (const tab of tabs) {
+            const isSelected = tab === target;
+            tab.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+            // Roving tabindex: only the selected tab is in the tab order, so Tab steps over the strip as one
+            // control and the arrow keys move within it.
+            tab.tabIndex = isSelected ? 0 : -1;
+        }
+
+        if (notify && typeof onChange === 'function') {
+            onChange(sectionId);
+        }
+    }
+
+    function selectByOffset(offset) {
+        const currentIndex = tabs.findIndex((tab) => sectionIdOf(tab) === selectedId);
+        const nextIndex = (currentIndex + offset + tabs.length) % tabs.length;
+        const nextTab = tabs[nextIndex];
+        select(sectionIdOf(nextTab), true);
+        nextTab.focus();
+    }
+
+    for (const tab of tabs) {
+        tab.addEventListener('click', () => select(sectionIdOf(tab), true));
+    }
+
+    stripElement.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowLeft') {
+            selectByOffset(-1);
+        } else if (event.key === 'ArrowRight') {
+            selectByOffset(1);
+        } else if (event.key === 'Home') {
+            select(sectionIdOf(tabs[0]), true);
+            tabs[0].focus();
+        } else if (event.key === 'End') {
+            select(sectionIdOf(tabs[tabs.length - 1]), true);
+            tabs[tabs.length - 1].focus();
+        } else {
+            return;
+        }
+
+        event.preventDefault();
+    });
+
+    const initialTab = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0];
+    if (initialTab) {
+        // Clear the markup's selection first, so the initial apply always runs and normalizes every tab.
+        initialTab.setAttribute('aria-selected', 'false');
+        select(sectionIdOf(initialTab), true);
+    }
+
+    return {
+        select(sectionId) {
+            select(sectionId, true);
+        },
+        selected() {
+            return selectedId;
+        },
+    };
+}

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/css/utility-demo.css
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/css/utility-demo.css
@@ -5,11 +5,55 @@ html, body {
     height: 100%;
 }
 
+/* The showcase, the inspector panel, and the inspector rail sit side by side, with the rail pinned to the
+   right edge. */
+#demo-app {
+    display: flex;
+    height: 100%;
+}
+
 #process-container {
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
+    min-width: 0;
     height: 100%;
+    overflow: auto;
     padding: 12px;
+}
+
+/* Illustrates the shared .cel-nav-tabs and .cel-rail components working together as a document inspector: a
+   fixed title and tab strip above a scrolling section, with the rail alongside. */
+#inspector-panel {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    width: 260px;
+    min-height: 0;
+    border-left: 1px solid var(--cel-divider-subtle);
+}
+
+/* Mirrors the native PanelHeader above the settings panels' tab strip: 40px tall, at the base text size. */
+.inspector-title {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    height: 40px;
+    padding: 0 12px;
+    background: var(--cel-panel-bg);
+}
+
+#inspector-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    padding: 12px;
+}
+
+.inspector-section p {
+    margin: 0;
+    font-size: 13px;
+    color: var(--cel-text-secondary);
 }
 
 /* Illustrates the shared .cel-expander component. The container is a gapless flex column, so give it room. */
@@ -106,6 +150,10 @@ html, body {
     margin: 8px 0 0 0;
     font-size: 12px;
     color: var(--cel-text-secondary);
+}
+
+.hidden {
+    display: none !important;
 }
 
 /* Border, radius, fill, and colour come from the shared textarea styling (celbridge.css); only the notes

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/index.html
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/index.html
@@ -6,11 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Celbridge Utility Demo</title>
     <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/assets/bootstrap-icons/bootstrap-icons.css">
     <link rel="stylesheet" href="/assets/celbridge-client/celbridge.css">
     <link rel="stylesheet" href="css/utility-demo.css">
 </head>
 
 <body>
+    <div id="demo-app">
     <div id="process-container">
         <h1 id="process-title">Utility Demo</h1>
         <p id="process-blurb">
@@ -73,6 +75,75 @@
             Every control here is styled by <code>celbridge.css</code>.
             <a href="#">Learn more</a>.
         </p>
+    </div>
+
+    <!-- Illustrates the shared .cel-nav-tabs component: an icon tab strip over the active section's name and
+         description, with the sections themselves in the scrolling area below. -->
+    <div id="inspector-panel" class="hidden">
+        <div class="inspector-title">Inspector</div>
+        <div class="cel-nav-tabs">
+            <div id="inspector-tabs" class="cel-nav-tab-strip" role="tablist">
+                <button class="cel-nav-tab" type="button" role="tab" data-section="general" aria-selected="true"
+                        title="General" aria-label="General">
+                    <span class="cel-nav-tab-icon"><i class="bi bi-info-circle"></i></span>
+                </button>
+                <button class="cel-nav-tab" type="button" role="tab" data-section="appearance"
+                        title="Appearance" aria-label="Appearance">
+                    <span class="cel-nav-tab-icon">
+                        <i class="bi bi-palette"></i>
+                        <span class="cel-nav-tab-pip" title="This section needs attention"></span>
+                    </span>
+                </button>
+                <button class="cel-nav-tab" type="button" role="tab" data-section="advanced"
+                        title="Advanced" aria-label="Advanced">
+                    <span class="cel-nav-tab-icon"><i class="bi bi-gear"></i></span>
+                </button>
+            </div>
+
+            <div class="cel-section-header" data-section="general">
+                <h1>General</h1>
+                <p>The active section's name and description, below the tab strip.</p>
+            </div>
+            <div class="cel-section-header hidden" data-section="appearance">
+                <h1>Appearance</h1>
+                <p>A tab carries a pip when its section has something to look at.</p>
+            </div>
+            <div class="cel-section-header hidden" data-section="advanced">
+                <h1>Advanced</h1>
+                <p>Arrow keys move between tabs once the strip has focus.</p>
+            </div>
+        </div>
+
+        <div id="inspector-scroll">
+            <section class="inspector-section" data-section="general">
+                <p>Each tab is an icon with a tooltip, so the strip stays a fixed width however many
+                    sections a panel has.</p>
+            </section>
+            <section class="inspector-section hidden" data-section="appearance">
+                <p>Only one section shows at a time, which keeps a deep panel navigable without
+                    scroll-hunting through collapsed cards.</p>
+            </section>
+            <section class="inspector-section hidden" data-section="advanced">
+                <p>The selected section is worth persisting as view state, so it survives a reload.</p>
+            </section>
+        </div>
+    </div>
+
+    <!-- Illustrates the shared .cel-rail component: an inspector rail down the right edge, with the settings
+         toggle pinned at the top and icon-only action buttons below it. -->
+    <div class="cel-rail cel-rail-right">
+        <button id="inspector-toggle" class="cel-rail-button" type="button" title="Inspector" aria-label="Inspector">
+            <i class="bi bi-sliders"></i>
+            <span class="cel-rail-pip"></span>
+        </button>
+        <div class="cel-rail-separator"></div>
+        <button class="cel-rail-button" type="button" title="Run" aria-label="Run">
+            <i class="bi bi-play-fill"></i>
+        </button>
+        <button class="cel-rail-button" type="button" title="Stop" aria-label="Stop">
+            <i class="bi bi-stop-fill"></i>
+        </button>
+    </div>
     </div>
 
     <script type="module" src="js/utility-demo.js"></script>

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/js/utility-demo.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/js/utility-demo.js
@@ -7,6 +7,7 @@
 import celbridge from '/assets/celbridge-client/celbridge.js';
 import { ContentLoadedReason } from '/assets/celbridge-client/api/document-api.js';
 import { attachSplitter } from '/assets/celbridge-client/ui/splitter.js';
+import { attachNavTabs } from '/assets/celbridge-client/ui/nav-tabs.js';
 
 const client = celbridge;
 
@@ -28,6 +29,29 @@ attachSplitter(demoSplitter, {
     onReset() {
         demoLeftPane.style.width = '45%';
     },
+});
+
+// Demonstrate the shared inspector rail and nav tab strip: the rail's settings button toggles the inspector
+// panel, and the tab strip switches which of the panel's sections is shown.
+const inspectorPanel = document.getElementById('inspector-panel');
+const inspectorToggle = document.getElementById('inspector-toggle');
+const inspectorSections = Array.from(document.querySelectorAll('.inspector-section'));
+const inspectorHeaders = Array.from(document.querySelectorAll('.cel-section-header'));
+
+attachNavTabs(document.getElementById('inspector-tabs'), {
+    onChange(sectionId) {
+        for (const section of inspectorSections) {
+            section.classList.toggle('hidden', section.dataset.section !== sectionId);
+        }
+        for (const header of inspectorHeaders) {
+            header.classList.toggle('hidden', header.dataset.section !== sectionId);
+        }
+    },
+});
+
+inspectorToggle.addEventListener('click', () => {
+    const visible = inspectorPanel.classList.toggle('hidden') === false;
+    inspectorToggle.classList.toggle('selected', visible);
 });
 
 // Gates change notifications while the document is read-only or being loaded by the framework, so a

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.css
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.css
@@ -2,37 +2,37 @@
    (linked in index.html) so its controls, colors, and fonts match the rest of the application. The terminal
    is its own themed surface, styled here. Only genuinely console-specific rules live in this file. */
 
-/* The terminal surface and its indicators stay console-specific: the terminal is its own themed surface
-   (like a code editor's canvas), not app chrome. The celbridge client mirrors the theme onto
+/* The terminal surface and the config-error callout stay console-specific: the terminal is its own themed
+   surface (like a code editor's canvas), not app chrome. The celbridge client mirrors the theme onto
    html[data-theme]; until it lands, fall back to prefers-color-scheme so the terminal never flashes on load. */
 :root {
     --console-terminal-bg: #ffffff;
     --console-overlay: rgba(255, 255, 255, 0.85);
-    --console-pip: #d9822b;
-    --console-pip-bg: rgba(217, 130, 43, 0.15);
+    --console-alert: #d9822b;
+    --console-alert-bg: rgba(217, 130, 43, 0.15);
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
         --console-terminal-bg: #1e1e1e;
         --console-overlay: rgba(20, 20, 20, 0.85);
-        --console-pip: #e0a458;
-        --console-pip-bg: rgba(224, 164, 88, 0.18);
+        --console-alert: #e0a458;
+        --console-alert-bg: rgba(224, 164, 88, 0.18);
     }
 }
 
 :root[data-theme="light"] {
     --console-terminal-bg: #ffffff;
     --console-overlay: rgba(255, 255, 255, 0.85);
-    --console-pip: #d9822b;
-    --console-pip-bg: rgba(217, 130, 43, 0.15);
+    --console-alert: #d9822b;
+    --console-alert-bg: rgba(217, 130, 43, 0.15);
 }
 
 :root[data-theme="dark"] {
     --console-terminal-bg: #1e1e1e;
     --console-overlay: rgba(20, 20, 20, 0.85);
-    --console-pip: #e0a458;
-    --console-pip-bg: rgba(224, 164, 88, 0.18);
+    --console-alert: #e0a458;
+    --console-alert-bg: rgba(224, 164, 88, 0.18);
 }
 
 html, body {
@@ -41,67 +41,32 @@ html, body {
     overflow: hidden;
 }
 
+/* The content and the inspector rail sit side by side, with the rail pinned to the right edge of the
+   document. */
 #app {
     display: flex;
-    flex-direction: column;
     height: 100vh;
     width: 100vw;
 }
 
-/* The terminal and the settings sidebar sit side by side below the toolbar, split by a draggable divider,
-   so opening settings narrows the terminal rather than hiding it. */
+/* The terminal and the settings sidebar sit side by side, split by a draggable divider, so opening settings
+   narrows the terminal rather than hiding it. */
 #content {
     display: flex;
     flex: 1 1 auto;
+    min-width: 0;
     min-height: 0;
 }
 
-#toolbar {
-    flex: 0 0 auto;
+/* The shortcut group sits below the settings button and scrolls once it outgrows the rail, so growth pushes
+   downward into empty space rather than moving the settings button. */
+#shortcut-rail {
     display: flex;
-    align-items: center;
-    height: 40px;
-    padding: 0 6px;
-    border-bottom: 1px solid var(--cel-divider);
-    background: var(--cel-panel-bg);
-}
-
-/* The shortcut toolbar fills the left of the bar; the settings button is pushed to the right edge. */
-#shortcut-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    overflow-x: auto;
-    flex: 1 1 auto;
-    min-width: 0;
-}
-
-.shortcut-button {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    white-space: nowrap;
-    flex: 0 0 auto;
-}
-
-#settings-toggle {
-    position: relative;
-    margin-left: auto;
-    flex: 0 0 auto;
-}
-
-#settings-toggle.active {
-    background: var(--cel-control-hover-bg);
-}
-
-.pip {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--console-pip);
+    flex: 0 1 auto;
+    flex-direction: column;
+    min-height: 0;
+    overflow-y: auto;
+    scrollbar-width: none;
 }
 
 .hidden {
@@ -180,16 +145,25 @@ html, body {
     flex-direction: column;
 }
 
-/* The heading stays fixed above the scrolling cards, separated by a divider so the title can't be scrolled
-   out of view, mirroring the native settings panels (fixed header, scrolling content, fixed action footer).
-   The left inset is pulled in 4px to 8px like .settings-scroll so the title lines up with the cards. */
-.settings-header {
+/* The panel title, mirroring the native PanelHeader above the settings panels' tab strip (40px tall, over the
+   panel background, at the base text size). The left inset is pulled in 4px to 8px like .settings-scroll so
+   it lines up with the content below. */
+.settings-title {
     flex: 0 0 auto;
-    padding: 12px 12px 10px 8px;
-    border-bottom: 1px solid var(--cel-divider);
+    display: flex;
+    align-items: center;
+    height: 40px;
+    padding: 0 12px 0 8px;
+    background: var(--cel-panel-bg);
 }
 
-/* Only the cards scroll; the header above and the footer below stay pinned. */
+/* The shared tab strip stays fixed above the scrolling section, so the section name and any config error
+   can't be scrolled out of view. Its left inset matches the content below (see .settings-scroll). */
+#settings-view .cel-nav-tabs {
+    padding-left: 8px;
+}
+
+/* Only the active section scrolls; the title and tab strip above and the footer below stay pinned. */
 .settings-scroll {
     flex: 1 1 auto;
     min-height: 0;
@@ -201,40 +175,16 @@ html, body {
     padding: 12px 12px 12px 8px;
 }
 
-/* Match the native settings panels' section header (ProjectSettingsPanel.xaml: 20px SemiBold) so the
-   console settings surface reads as a peer of the XAML settings panels shown beside it. */
-#settings-view h1 {
-    font-size: 20px;
-    font-weight: 600;
-    /* 2px title->subtitle gap matches the native section title StackPanel (Spacing="2"). */
-    margin: 0 0 2px;
-}
-
-/* Mirrors the native settings panels' description line under the title (12px secondary). The header's
-   padding provides the gap to the divider below, so the subtitle needs no bottom margin. */
-.settings-subtitle {
-    font-size: 12px;
-    color: var(--cel-text-secondary);
-    margin: 0;
-}
-
-/* Pinned in the fixed header under the subtitle (hidden until a parse error), so a validation error stays
-   visible while the cards scroll. The top margin separates it from the subtitle; the header padding below
-   provides the gap to the divider. */
+/* Pinned in the tab strip below the section header (hidden until a parse error), so a validation error stays
+   visible while the section scrolls. The top margin separates it from the description; the strip's padding
+   below provides the gap to the divider. */
 .config-error {
-    border: 1px solid var(--console-pip);
-    background: var(--console-pip-bg);
+    border: 1px solid var(--console-alert);
+    background: var(--console-alert-bg);
     padding: 8px 10px;
     border-radius: var(--cel-radius-control);
     margin: 12px 0 0;
     white-space: pre-wrap;
-}
-
-/* The settings cards use the shared .cel-expander component (celbridge.css). Only the settings-panel layout
-   here is console-specific. All cards start collapsed. Their open state is persisted as document view state. */
-#settings-view .cel-expander {
-    max-width: 640px;
-    margin-bottom: 8px;
 }
 
 .field {
@@ -243,7 +193,7 @@ html, body {
     max-width: 640px;
 }
 
-.cel-expander-body .field:last-child {
+.settings-section .field:last-child {
     margin-bottom: 0;
 }
 

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.js
@@ -7,6 +7,7 @@ import celbridge from '/assets/celbridge-client/celbridge.js';
 import { ContentLoadedReason } from '/assets/celbridge-client/api/document-api.js';
 import { t } from '/assets/celbridge-client/localization.js';
 import { attachSplitter } from '/assets/celbridge-client/ui/splitter.js';
+import { attachNavTabs } from '/assets/celbridge-client/ui/nav-tabs.js';
 import { parseConsoleToml, serializeConsoleToml, defaultConsoleConfig } from './console-toml.js';
 import {
     splitLines,
@@ -75,7 +76,8 @@ fitAddon.fit();
 // DOM references.
 const settingsToggle = document.getElementById('settings-toggle');
 const pip = document.getElementById('pip');
-const shortcutToolbar = document.getElementById('shortcut-toolbar');
+const shortcutRail = document.getElementById('shortcut-rail');
+const shortcutSeparator = document.getElementById('shortcut-separator');
 const terminalView = document.getElementById('terminal-view');
 const splitter = document.getElementById('splitter');
 const settingsView = document.getElementById('settings-view');
@@ -100,10 +102,24 @@ const runnersInput = document.getElementById('runners');
 const shortcutsInput = document.getElementById('shortcuts');
 const reopenSettingsButton = document.getElementById('reopen-settings');
 
-// The collapsible settings cards, in document order (Session, Environment, Script Runners, Shortcuts).
-function settingsCards() {
-    return settingsScroll.querySelectorAll('details.cel-expander');
+// The settings sections and their headers, selected by the shared nav tab strip. Both are present in the
+// markup with only the active one shown, mirroring how the native settings panel toggles its section views.
+const settingsSections = Array.from(settingsScroll.querySelectorAll('.settings-section'));
+const sectionHeaders = Array.from(settingsView.querySelectorAll('.cel-section-header'));
+
+function showSection(sectionId) {
+    for (const section of settingsSections) {
+        section.classList.toggle('hidden', section.dataset.section !== sectionId);
+    }
+    for (const header of sectionHeaders) {
+        header.classList.toggle('hidden', header.dataset.section !== sectionId);
+    }
+    settingsScroll.scrollTop = 0;
 }
+
+const navTabs = attachNavTabs(document.getElementById('settings-tabs'), {
+    onChange: (sectionId) => showSection(sectionId),
+});
 
 // State. currentConfig mirrors the settings form / .console file. launchedConfig is the config the live
 // session was started from, so the pip can flag "changed, needs a reopen".
@@ -246,7 +262,9 @@ settingsToggle.addEventListener('click', () => {
 function setSettingsVisible(visible) {
     settingsView.classList.toggle('hidden', !visible);
     splitter.classList.toggle('hidden', !visible);
-    settingsToggle.classList.toggle('active', visible);
+    // The rail capsule tracks the panel being open, not focused: the terminal holds focus most of the time,
+    // so a focus-following capsule would read as "closed" while the panel is plainly on screen.
+    settingsToggle.classList.toggle('selected', visible);
     refitTerminal();
     if (!visible) {
         term.focus();
@@ -310,7 +328,7 @@ function populateForm(config) {
         .join('\n');
     runnersInput.value = formatRunnerLines(config.runners);
     shortcutsInput.value = formatShortcutLines(config.shortcuts);
-    renderShortcutToolbar();
+    renderShortcutRail();
 }
 
 function readForm() {
@@ -328,31 +346,36 @@ function readForm() {
     };
 }
 
-// The per-console shortcut toolbar: flat buttons that inject their text into the pty on click.
-function renderShortcutToolbar() {
-    shortcutToolbar.replaceChildren();
+// A shortcut with no icon still needs a glyph to be clickable, so it falls back to the icon the Automation
+// settings tab uses.
+const SHORTCUT_FALLBACK_ICON = 'bi-lightning-charge';
+
+// The per-console shortcuts, rendered as icon-only cells at the top of the inspector rail. Each injects its
+// text into the pty on click; the tooltip carries the label, falling back to the text it types.
+function renderShortcutRail() {
+    shortcutRail.replaceChildren();
     const shortcuts = currentConfig.shortcuts || [];
-    shortcutToolbar.classList.toggle('hidden', shortcuts.length === 0);
+    shortcutSeparator.classList.toggle('hidden', shortcuts.length === 0);
 
     for (const shortcut of shortcuts) {
         const button = document.createElement('button');
         button.type = 'button';
-        button.className = 'shortcut-button';
-        button.title = shortcut.text || shortcut.label || '';
+        button.className = 'cel-rail-button';
 
+        const tooltip = shortcut.label || shortcut.text || '';
+        button.title = tooltip;
+        button.setAttribute('aria-label', tooltip);
+
+        const iconElement = document.createElement('i');
         if (shortcut.icon && shortcut.icon.startsWith('bs-')) {
-            const iconElement = document.createElement('i');
             iconElement.className = 'bi bi-' + shortcut.icon.slice('bs-'.length);
-            button.appendChild(iconElement);
+        } else {
+            iconElement.className = 'bi ' + SHORTCUT_FALLBACK_ICON;
         }
-        if (shortcut.label) {
-            const labelElement = document.createElement('span');
-            labelElement.textContent = shortcut.label;
-            button.appendChild(labelElement);
-        }
+        button.appendChild(iconElement);
 
         button.addEventListener('click', () => injectShortcut(shortcut.text));
-        shortcutToolbar.appendChild(button);
+        shortcutRail.appendChild(button);
     }
 }
 
@@ -371,9 +394,9 @@ function onFormInput() {
     configError = null;
     // Mark the document dirty so the host's save timer flushes the serialised TOML through onRequestSave.
     client.document.notifyChanged();
-    // The shortcut toolbar is pure client-side UI, so it previews live as the user edits. Every other
+    // The shortcut rail is pure client-side UI, so it previews live as the user edits. Every other
     // setting applies on the next reopen, flagged by updateAttention.
-    renderShortcutToolbar();
+    renderShortcutRail();
     updateAttention();
 }
 
@@ -654,12 +677,12 @@ async function main() {
             // Ack the reload so the host's external-change handshake does not time out.
             client.document.notifyContentLoaded(ContentLoadedReason.ExternalReload);
         },
-        // Persist the settings sidebar's open state and width, each card's expanded state, and the scroll
-        // position so they survive a reopen. openCards is by card order; the cards are a fixed set.
+        // Persist the settings sidebar's open state and width, the selected section, and the scroll position
+        // so they survive a reopen.
         onRequestState: () => JSON.stringify({
             settingsOpen: !settingsView.classList.contains('hidden'),
             sidebarWidth,
-            openCards: Array.from(settingsCards()).map((card) => card.open),
+            activeSection: navTabs.selected(),
             scrollTop: settingsScroll.scrollTop,
         }),
         onRestoreState: (stateJson) => {
@@ -668,12 +691,10 @@ async function main() {
                 if (typeof state.sidebarWidth === 'number' && state.sidebarWidth > 0) {
                     applySidebarWidth(state.sidebarWidth);
                 }
-                // Restore each card's expanded state before showing the sidebar, so the scroll height is
-                // correct when the scroll position is applied below.
-                if (Array.isArray(state.openCards)) {
-                    settingsCards().forEach((card, index) => {
-                        card.open = state.openCards[index] === true;
-                    });
+                // Select the section before showing the sidebar, so the scroll height is correct when the
+                // scroll position is applied below. An unknown id leaves the default section selected.
+                if (typeof state.activeSection === 'string') {
+                    navTabs.select(state.activeSection);
                 }
                 if (state.settingsOpen) {
                     setSettingsVisible(true);

--- a/Source/Workspace/Celbridge.Console/Web/Console/index.html
+++ b/Source/Workspace/Celbridge.Console/Web/Console/index.html
@@ -19,14 +19,6 @@
 </head>
 <body>
     <div id="app">
-        <div id="toolbar">
-            <div id="shortcut-toolbar" class="hidden"></div>
-            <button id="settings-toggle" class="cel-icon-button" type="button" data-loc-key="Console_Settings_Title" data-loc-attr="title,aria-label">
-                <i class="bi bi-gear"></i>
-                <span id="pip" class="pip hidden"></span>
-            </button>
-        </div>
-
         <div id="content">
             <div id="terminal-view">
                 <div id="terminal"></div>
@@ -44,16 +36,37 @@
             <div id="splitter" class="cel-splitter hidden"></div>
 
             <div id="settings-view" class="hidden">
-                <div class="settings-header">
-                    <h1 data-loc-key="Console_Settings_Heading"></h1>
-                    <p class="settings-subtitle" data-loc-key="Console_Settings_Subtitle"></p>
+                <div class="settings-title" data-loc-key="Console_Settings_Heading"></div>
+
+                <div class="cel-nav-tabs">
+                    <div id="settings-tabs" class="cel-nav-tab-strip" role="tablist">
+                        <button class="cel-nav-tab" type="button" role="tab" data-section="session" aria-selected="true"
+                                data-loc-key="Console_Group_Session" data-loc-attr="title,aria-label">
+                            <span class="cel-nav-tab-icon"><i class="bi bi-terminal"></i></span>
+                        </button>
+                        <button class="cel-nav-tab" type="button" role="tab" data-section="automation"
+                                data-loc-key="Console_Group_Automation" data-loc-attr="title,aria-label">
+                            <span class="cel-nav-tab-icon"><i class="bi bi-lightning-charge"></i></span>
+                        </button>
+                    </div>
+
+                    <!-- One header per section, all present with the active one shown, mirroring how the
+                         native settings panel toggles between its section views. -->
+                    <div class="cel-section-header" data-section="session">
+                        <h1 data-loc-key="Console_Group_Session"></h1>
+                        <p data-loc-key="Console_Desc_Session"></p>
+                    </div>
+                    <div class="cel-section-header hidden" data-section="automation">
+                        <h1 data-loc-key="Console_Group_Automation"></h1>
+                        <p data-loc-key="Console_Desc_Automation"></p>
+                    </div>
+
                     <div id="config-error" class="config-error hidden"></div>
                 </div>
+
                 <div id="settings-scroll" class="settings-scroll">
 
-                <details class="cel-expander">
-                    <summary data-loc-key="Console_Group_Session"></summary>
-                    <div class="cel-expander-body">
+                    <section class="settings-section" data-section="session">
                         <label class="field">
                             <span class="field-label" data-loc-key="Console_Field_Type"></span>
                             <select id="session-type">
@@ -93,45 +106,33 @@
                         </label>
 
                         <label class="field">
-                            <span class="field-label" data-loc-key="Console_Field_StartupScript"></span>
-                            <textarea id="startup-script" rows="3" spellcheck="false" data-loc-key="Console_Placeholder_StartupScript" data-loc-attr="placeholder"></textarea>
-                            <span class="field-hint" data-loc-key="Console_Hint_StartupScript"></span>
-                        </label>
-                    </div>
-                </details>
-
-                <details class="cel-expander">
-                    <summary data-loc-key="Console_Group_Environment"></summary>
-                    <div class="cel-expander-body">
-                        <label class="field">
                             <span class="field-label" data-loc-key="Console_Field_Environment"></span>
                             <textarea id="environment" rows="4" spellcheck="false" data-loc-key="Console_Placeholder_Environment" data-loc-attr="placeholder"></textarea>
                             <span class="field-hint" data-loc-key="Console_Hint_Environment"></span>
                         </label>
-                    </div>
-                </details>
 
-                <details class="cel-expander">
-                    <summary data-loc-key="Console_Group_Runners"></summary>
-                    <div class="cel-expander-body">
+                        <label class="field">
+                            <span class="field-label" data-loc-key="Console_Field_StartupScript"></span>
+                            <textarea id="startup-script" rows="3" spellcheck="false" data-loc-key="Console_Placeholder_StartupScript" data-loc-attr="placeholder"></textarea>
+                            <span class="field-hint" data-loc-key="Console_Hint_StartupScript"></span>
+                        </label>
+                    </section>
+
+                    <!-- Every way of getting a command into this console: keyed on a file extension, or on a
+                         button press. -->
+                    <section class="settings-section hidden" data-section="automation">
                         <label class="field">
                             <span class="field-label" data-loc-key="Console_Field_Runners"></span>
-                            <textarea id="runners" rows="3" spellcheck="false" data-loc-key="Console_Placeholder_Runners" data-loc-attr="placeholder"></textarea>
+                            <textarea id="runners" rows="4" spellcheck="false" data-loc-key="Console_Placeholder_Runners" data-loc-attr="placeholder"></textarea>
                             <span class="field-hint" data-loc-key="Console_Hint_Runners"></span>
                         </label>
-                    </div>
-                </details>
 
-                <details class="cel-expander">
-                    <summary data-loc-key="Console_Group_Shortcuts"></summary>
-                    <div class="cel-expander-body">
                         <label class="field">
                             <span class="field-label" data-loc-key="Console_Field_Shortcuts"></span>
-                            <textarea id="shortcuts" rows="3" spellcheck="false" data-loc-key="Console_Placeholder_Shortcuts" data-loc-attr="placeholder"></textarea>
+                            <textarea id="shortcuts" rows="4" spellcheck="false" data-loc-key="Console_Placeholder_Shortcuts" data-loc-attr="placeholder"></textarea>
                             <span class="field-hint" data-loc-key="Console_Hint_Shortcuts"></span>
                         </label>
-                    </div>
-                </details>
+                    </section>
 
                 </div>
                 <div class="cel-panel-footer">
@@ -139,6 +140,17 @@
                     <button id="reopen-settings" type="button" data-loc-key="Console_ReopenSession" data-loc-title="Console_Reopen_Tooltip"></button>
                 </div>
             </div>
+        </div>
+
+        <!-- Inspector rail: the settings toggle sits above the shortcut buttons, so its position stays fixed
+             as the user adds and removes shortcuts from the panel that button opens. -->
+        <div class="cel-rail cel-rail-right">
+            <button id="settings-toggle" class="cel-rail-button" type="button" data-loc-key="Console_Settings_Title" data-loc-attr="title,aria-label">
+                <i class="bi bi-sliders"></i>
+                <span id="pip" class="cel-rail-pip hidden"></span>
+            </button>
+            <div id="shortcut-separator" class="cel-rail-separator hidden"></div>
+            <div id="shortcut-rail"></div>
         </div>
     </div>
 

--- a/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
+++ b/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
@@ -7,7 +7,6 @@
 
     "Console_Settings_Title": "Settings",
     "Console_Settings_Heading": "Console Settings",
-    "Console_Settings_Subtitle": "Configure how this console launches and what it runs.",
     "Console_Reopen": "Reopen Console",
     "Console_ReopenSession": "Reopen Console",
     "Console_Reopen_Tooltip": "Close and reopen the console session.",
@@ -19,9 +18,10 @@
     "Console_InvalidConfig": "Invalid .console configuration.",
 
     "Console_Group_Session": "Session",
-    "Console_Group_Environment": "Environment",
-    "Console_Group_Runners": "Script Runners",
-    "Console_Group_Shortcuts": "Shortcuts",
+    "Console_Group_Automation": "Automation",
+
+    "Console_Desc_Session": "Choose what this console launches, the environment it launches into, and what it runs on open.",
+    "Console_Desc_Automation": "Ways to run a command in this console, keyed on a file extension or a button press.",
 
     "Console_Field_Type": "Type",
     "Console_Field_Executable": "Executable",
@@ -29,8 +29,8 @@
     "Console_Field_Arguments": "Arguments",
     "Console_Field_Dependencies": "Dependencies",
     "Console_Field_WorkingDirectory": "Working Directory",
-    "Console_Field_StartupScript": "Startup Script",
     "Console_Field_Environment": "Environment Variables",
+    "Console_Field_StartupScript": "Startup Script",
     "Console_Field_Runners": "Script Runners",
     "Console_Field_Shortcuts": "Shortcuts",
 
@@ -55,5 +55,5 @@
     "Console_Hint_StartupScript": "Runs each time the console opens, once it is ready. Example: import numpy as np",
     "Console_Hint_Environment": "Injected before launch, one per line. Example: PYTHONWARNINGS=default",
     "Console_Hint_Runners": "Run a file in this console; {script_path} is the file path. Example: .py, .ipy = %run \"{script_path}\"",
-    "Console_Hint_Shortcuts": "Toolbar button that types text; icon is a Bootstrap name. Example: Run tests | bs-play-fill | pytest -q"
+    "Console_Hint_Shortcuts": "Rail button that types text; the label is its tooltip and the icon is a Bootstrap name. Example: Run tests | bs-play-fill | pytest -q"
 }


### PR DESCRIPTION
Introduces a reusable `attachNavTabs` helper with Vitest coverage, plus new shared CSS tokens/components for icon tab strips and vertical rails (`.cel-nav-tabs`, `.cel-rail`, caution pips). Refactors the Console editor from expander cards and top toolbar to a sectioned settings panel with tab navigation and a right-side inspector rail (including shortcut rail buttons and persisted active section), updates localization text, and expands the Utility Demo and contributor guide to document and showcase the new patterns.