### PR TITLE
Implement card-based editor and drag-and-drop reordering for console

### DIFF
--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -183,7 +183,17 @@ The console editor is the reference: its shortcut buttons render into the rail b
 
 ### Editing a list of entries
 
-A setting that is a list of records — the console's script runners and shortcuts — is edited as one `.cel-expander` card per entry, matching how the native Packages and Pages panels render their lists. The card header carries the entry's name and a one-line summary; the body carries its fields. Add and delete controls belong on the list and the card header, and a list whose order is user-visible needs move-up and move-down buttons too.
+A setting that is a list of records — the console's script runners and shortcuts — is edited as one `.cel-expander` card per entry, matching how the native Packages and Pages panels render their lists. The card header carries just the entry's name; its fields are one expand away, so the header stays scannable. Add and delete controls belong on the list and the card header.
+
+A list whose order is user-visible reorders by dragging a `.card-grip` handle in the header, with Alt+Up / Alt+Down on the focused header as the keyboard equivalent. Do not use move-up / move-down buttons: chevrons read as a second expander control, and clicking one while a card is expanded jumps the layout out from under the user. A drag runs only against a collapsed list. Pressing the handle while any card is open therefore collapses the list and starts no drag; the user presses again to actually drag, and the cards stay collapsed afterwards. The extra press buys an exact grab: collapsing as part of the grab would shorten everything above the grabbed row and slide it out from under the pointer, by as much as a few hundred pixels, and no amount of scroll compensation reliably gets it back — the panel is often already at the top of its scroll range. Splitting the two makes the collapse a visible, understandable step rather than a mysterious offset.
+
+The list then reorders live under the pointer, and Escape (or the browser cancelling the pointer) restores the order it started in.
+
+Collapsing is what makes the live reorder tractable: uniform rows give the list a single row pitch, so the target slot can come from how far the pointer has travelled in whole pitches rather than from hit-testing the rows themselves. That one-way dependency is the important part — a reorder driven by the rows' live positions feeds its own output back into its next input, and the list oscillates as the row you just moved lands back under the cursor. Report the change once on release, not per slot, or every pixel of drag marks the document dirty and re-renders whatever the order drives.
+
+Displaced rows slide to their new positions with a FLIP transition (measure, reorder, invert with a transform, let the transition carry it away), gated on `prefers-reduced-motion`. The before-positions are measured live, so a row interrupted mid-slide continues from where it visually is. The dragged row is excluded from both the slide and its transition, and instead carries a transform of the pointer delta minus the pitches its slot has already absorbed — so it stays under the pointer while the rows snap around it, and is stacked above them since it spends most of a drag straddling two. Because the slot rounds to the nearest pitch, that leftover never exceeds half a row, which is all the card has to travel when it settles on release.
+
+All of this is decoration layered on a gesture that never reads the rows, so no transform in flight can influence where the next slot lands.
 
 `Source/Workspace/Celbridge.Console/Web/Console/console-cards.js` implements this as `createCardList()`. It is console-local rather than shared, since it has one consumer so far, but it is the pattern to copy or promote:
 
@@ -192,7 +202,7 @@ const list = createCardList({
     listElement, emptyElement, addButton, template,
     blankItem: () => ({ label: '', command: '' }),
     focusSelector: '.entry-label',
-    reorderable: true,              // wires move-up / move-down
+    reorderable: true,              // wires the grip handle and Alt+Up / Alt+Down
     fillCard(card, item) { },       // entry -> inputs
     readCard(card) { },             // inputs -> entry, or null to drop the card
     updateHeader(card) { },         // refresh the collapsed summary

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -179,7 +179,28 @@ Settings goes above the action buttons, inverting the workspace rail's ordering,
 
 Rail buttons are icon-only with a tooltip, so a button whose action has no natural glyph still needs a fallback icon rather than a text label. Add `selected` to the button whose surface is showing; its accent edge capsule stays lit for as long as that surface is open. This deliberately differs from the workspace utility rail, whose capsule dims while its panel is unfocused — with several rails and panels on screen at once, "this panel is open" is the more useful signal, and an editor's own content usually holds focus anyway. `.cel-rail-right` moves the rail's border and its capsules to the window edge; omit it for a rail on the left.
 
-The console editor is the reference: its shortcut buttons render into the rail above the settings toggle, and its settings panel is a `.cel-nav-tabs` hierarchy.
+The console editor is the reference: its shortcut buttons render into the rail below the settings toggle, and its settings panel is a `.cel-nav-tabs` hierarchy.
+
+### Editing a list of entries
+
+A setting that is a list of records — the console's script runners and shortcuts — is edited as one `.cel-expander` card per entry, matching how the native Packages and Pages panels render their lists. The card header carries the entry's name and a one-line summary; the body carries its fields. Add and delete controls belong on the list and the card header, and a list whose order is user-visible needs move-up and move-down buttons too.
+
+`Source/Workspace/Celbridge.Console/Web/Console/console-cards.js` implements this as `createCardList()`. It is console-local rather than shared, since it has one consumer so far, but it is the pattern to copy or promote:
+
+```javascript
+const list = createCardList({
+    listElement, emptyElement, addButton, template,
+    blankItem: () => ({ label: '', command: '' }),
+    focusSelector: '.entry-label',
+    reorderable: true,              // wires move-up / move-down
+    fillCard(card, item) { },       // entry -> inputs
+    readCard(card) { },             // inputs -> entry, or null to drop the card
+    updateHeader(card) { },         // refresh the collapsed summary
+    localize, onChanged, isWritable,
+});
+```
+
+Prefer this over a delimited text field (`a | b | c` per line) for anything Celbridge-specific: it removes a syntax the user has to learn and a parser you have to maintain. The exception is a setting whose data has a canonical text form elsewhere — command-line arguments, `requirements.txt` entries, `KEY=value` environment pairs — where a plain textarea is the better control, because it lets the user paste from the file the data already lives in.
 
 ## Edit verbs (optional)
 

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
@@ -59,10 +59,14 @@
     --cel-control-hover-bg: #F0F0F0;
     --cel-control-border: #E5E5E5;
 
-    /* Expander header fill and card border, matching WinUI's Expander header and card-stroke brushes used by
-       the native settings panels. Both themes are sampled exactly from the running app (header #FBFBFB /
-       #36383B, border #E5E5E5 / #27292B). */
+    /* Expander header fill, expanded-content fill, and card border, matching the WinUI Expander brushes used
+       by the native settings panels. The header and border are sampled exactly from the running app (header
+       #FBFBFB / #36383B, border #E5E5E5 / #27292B). The content fill is ExpanderContentBackground
+       (CardBackgroundFillColorSecondary) composited over the panel background, the same derivation that
+       reproduces the sampled header from CardBackgroundFillColorDefault. It is a shade below the header, so
+       an expanded card's body still reads as part of the card. */
     --cel-expander-header-bg: #FBFBFB;
+    --cel-expander-content-bg: #F4F4F4;
     --cel-card-border: #E5E5E5;
 }
 
@@ -89,5 +93,6 @@
     --cel-control-border: #3F4143;
 
     --cel-expander-header-bg: #36383B;
+    --cel-expander-content-bg: #323437;
     --cel-card-border: #27292B;
 }

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge.css
@@ -210,8 +210,11 @@ hr {
     border-bottom: 1px solid var(--cel-card-border);
 }
 
+/* The expanded content carries its own fill, a shade below the header, so the body reads as belonging to the
+   card rather than floating on the panel behind it. */
 .cel-expander-body {
     padding: 12px;
+    background: var(--cel-expander-content-bg);
 }
 
 /* Splitter: a draggable divider between two flex panes, matching the native WinUI Splitter — a thin base

--- a/Source/Workspace/Celbridge.Console/Web/Console/console-cards.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console-cards.js
@@ -1,0 +1,151 @@
+// Card-list editor for the console's Automation settings: one expander card per entry, with add, delete and
+// optional reorder controls. The cards are the source of truth for the setting they edit, the way the form
+// inputs are for the rest of the settings.
+//
+// The module drives the DOM and nothing else. Localization, the change notification and the writable check
+// are injected, so it carries no dependency on the celbridge client.
+//
+//   const list = createCardList({
+//     listElement, emptyElement, addButton, template,
+//     blankItem: () => ({ ... }),   // the entry an added card starts from
+//     focusSelector: '.some-input', // focused when a card is added
+//     reorderable: true,            // wires the move-up / move-down buttons
+//     fillCard(card, item) {},      // entry -> inputs
+//     readCard(card) {},            // inputs -> entry, or null to drop the card from the result
+//     updateHeader(card) {},        // refresh the collapsed summary
+//     localize(card) {},            // apply localized strings to a cloned card
+//     onChanged() {},               // an edit the document should record
+//     isWritable() {},              // false disables every control
+//   });
+
+export function createCardList(options) {
+    const {
+        listElement,
+        emptyElement,
+        addButton,
+        template,
+        blankItem,
+        focusSelector,
+        reorderable = false,
+        fillCard,
+        readCard,
+        updateHeader,
+        localize,
+        onChanged,
+        isWritable,
+    } = options;
+
+    function createCard(item) {
+        const card = template.content.firstElementChild.cloneNode(true);
+        localize(card);
+        fillCard(card, item);
+
+        for (const input of card.querySelectorAll('input')) {
+            input.addEventListener('input', () => {
+                updateHeader(card);
+                onChanged();
+            });
+        }
+
+        // The card controls sit inside the <summary>, whose default action toggles the card open, so each
+        // one cancels that before acting.
+        card.querySelector('.card-delete').addEventListener('click', (event) => {
+            event.preventDefault();
+            card.remove();
+            refreshState();
+            onChanged();
+        });
+
+        if (reorderable) {
+            card.querySelector('.card-move-up').addEventListener('click', (event) => {
+                event.preventDefault();
+                moveCard(card, -1);
+            });
+            card.querySelector('.card-move-down').addEventListener('click', (event) => {
+                event.preventDefault();
+                moveCard(card, 1);
+            });
+        }
+
+        return card;
+    }
+
+    // The header is filled in after the card is in the document, so a header that resolves styles (the
+    // shortcut card's icon glyph) has them available.
+    function appendCard(item) {
+        const card = createCard(item);
+        listElement.appendChild(card);
+        updateHeader(card);
+
+        return card;
+    }
+
+    // Moving the element keeps its open state and its in-progress edits, which rebuilding the list would
+    // discard.
+    function moveCard(card, offset) {
+        if (offset < 0 && card.previousElementSibling) {
+            listElement.insertBefore(card, card.previousElementSibling);
+        } else if (offset > 0 && card.nextElementSibling) {
+            listElement.insertBefore(card.nextElementSibling, card);
+        } else {
+            return;
+        }
+
+        refreshState();
+        onChanged();
+    }
+
+    function populate(items) {
+        listElement.replaceChildren();
+        for (const item of items || []) {
+            appendCard(item);
+        }
+
+        refreshState();
+    }
+
+    function read() {
+        const items = [];
+
+        for (const card of listElement.children) {
+            const item = readCard(card);
+            if (item !== null) {
+                items.push(item);
+            }
+        }
+
+        return items;
+    }
+
+    // Shows the empty-list message, applies the document's writable state, and stops the end cards moving
+    // past the ends. The blanket writable pass runs first so the move buttons settle last.
+    function refreshState() {
+        const writable = isWritable();
+        const cards = Array.from(listElement.children);
+
+        emptyElement.classList.toggle('hidden', cards.length > 0);
+        addButton.disabled = !writable;
+
+        for (const control of listElement.querySelectorAll('input, button')) {
+            control.disabled = !writable;
+        }
+
+        if (!reorderable) {
+            return;
+        }
+
+        cards.forEach((card, index) => {
+            card.querySelector('.card-move-up').disabled = !writable || index === 0;
+            card.querySelector('.card-move-down').disabled = !writable || index === cards.length - 1;
+        });
+    }
+
+    addButton.addEventListener('click', () => {
+        const card = appendCard(blankItem());
+        card.open = true;
+        refreshState();
+        card.querySelector(focusSelector).focus();
+    });
+
+    return { populate, read, refreshState };
+}

--- a/Source/Workspace/Celbridge.Console/Web/Console/console-cards.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console-cards.js
@@ -9,7 +9,7 @@
 //     listElement, emptyElement, addButton, template,
 //     blankItem: () => ({ ... }),   // the entry an added card starts from
 //     focusSelector: '.some-input', // focused when a card is added
-//     reorderable: true,            // wires the move-up / move-down buttons
+//     reorderable: true,            // wires the grip handle and Alt+Up / Alt+Down on the header
 //     fillCard(card, item) {},      // entry -> inputs
 //     readCard(card) {},            // inputs -> entry, or null to drop the card from the result
 //     updateHeader(card) {},        // refresh the collapsed summary
@@ -17,6 +17,27 @@
 //     onChanged() {},               // an edit the document should record
 //     isWritable() {},              // false disables every control
 //   });
+
+// Places a dragged row for a pointer position: the slot it should occupy, and how far it sits from that
+// slot's resting position so it stays under the pointer. The row is held inside the list, so dragging past
+// either end pins it to the first or last slot instead of carrying it off the list.
+//
+// Every input is either the pointer or a measurement taken at the grab, never where the rows currently sit,
+// so a row that has just moved cannot feed back into the next placement and set the list oscillating.
+// Returns null for a list too small to measure, which simply does not reorder.
+export function placementForPointer(options) {
+    const { pointerY, grabOffset, listTop, rowPitch, rowCount } = options;
+
+    if (rowPitch <= 0) {
+        return null;
+    }
+
+    const lastSlotTop = listTop + (rowCount - 1) * rowPitch;
+    const rowTop = Math.max(listTop, Math.min(pointerY - grabOffset, lastSlotTop));
+    const slotIndex = Math.round((rowTop - listTop) / rowPitch);
+
+    return { slotIndex, offset: rowTop - (listTop + slotIndex * rowPitch) };
+}
 
 export function createCardList(options) {
     const {
@@ -57,13 +78,37 @@ export function createCardList(options) {
         });
 
         if (reorderable) {
-            card.querySelector('.card-move-up').addEventListener('click', (event) => {
-                event.preventDefault();
-                moveCard(card, -1);
+            const grip = card.querySelector('.card-grip');
+
+            grip.addEventListener('pointerdown', (event) => {
+                // Only the primary button starts a drag.
+                if (event.button !== 0) {
+                    return;
+                }
+                beginDrag(card, event);
             });
-            card.querySelector('.card-move-down').addEventListener('click', (event) => {
+
+            // The grip sits inside the <summary>, so the click ending a press on it would otherwise toggle
+            // the card. A handle is not a toggle, and the press may just have collapsed the list.
+            grip.addEventListener('click', (event) => event.preventDefault());
+
+            // The keyboard path to the same reorder. The summary is focusable already, and Alt+Arrow carries
+            // no default action on it, so this adds no tab stop and steals no key.
+            card.querySelector('summary').addEventListener('keydown', (event) => {
+                if (!event.altKey) {
+                    return;
+                }
+
+                if (event.key === 'ArrowUp') {
+                    moveCard(card, -1);
+                } else if (event.key === 'ArrowDown') {
+                    moveCard(card, 1);
+                } else {
+                    return;
+                }
+
                 event.preventDefault();
-                moveCard(card, 1);
+                card.querySelector('summary').focus();
             });
         }
 
@@ -83,6 +128,10 @@ export function createCardList(options) {
     // Moving the element keeps its open state and its in-progress edits, which rebuilding the list would
     // discard.
     function moveCard(card, offset) {
+        if (!isWritable()) {
+            return;
+        }
+
         if (offset < 0 && card.previousElementSibling) {
             listElement.insertBefore(card, card.previousElementSibling);
         } else if (offset > 0 && card.nextElementSibling) {
@@ -93,6 +142,202 @@ export function createCardList(options) {
 
         refreshState();
         onChanged();
+    }
+
+    // Reordering by drag, with the list reordering live under the pointer. Every card collapses on grab and
+    // stays collapsed, which gives the rows a uniform pitch; the dragged row then follows the pointer, and
+    // its slot follows the row. Neither reads where the rows currently sit, which is the one-way dependency
+    // that lets them move during the drag without the list oscillating.
+    let dragState = null;
+
+    function beginDrag(card, event) {
+        if (!isWritable()) {
+            return;
+        }
+
+        // A drag can only run against a collapsed list, since uniform rows are what make the placement below
+        // work. Collapsing as part of the grab would shorten everything above the grabbed row and slide it
+        // out from under the pointer, so the first press on a grip while anything is open only tidies the
+        // list; the user presses again to drag. The cards stay collapsed afterwards.
+        const expandedCards = Array.from(listElement.children).filter((other) => other.open);
+        if (expandedCards.length > 0) {
+            for (const expandedCard of expandedCards) {
+                expandedCard.open = false;
+            }
+
+            return;
+        }
+
+        const cards = Array.from(listElement.children);
+        const rects = cards.map((other) => other.getBoundingClientRect());
+        const originalIndex = cards.indexOf(card);
+
+        // The pitch is measured between two rows rather than from one row's height, so it includes the gap
+        // between cards. A single card cannot be reordered, so its own height is a harmless stand-in.
+        let rowPitch = rects[0].height;
+        if (rects.length > 1) {
+            rowPitch = rects[1].top - rects[0].top;
+        }
+
+        dragState = {
+            card,
+            cards,
+            otherCards: cards.filter((other) => other !== card),
+            originalIndex,
+            slotIndex: originalIndex,
+            // Where the pointer took hold within the row. Exact, because the list was already collapsed when
+            // the press landed, so nothing moved between the press and this measurement.
+            grabOffset: event.clientY - rects[originalIndex].top,
+            rowPitch,
+        };
+
+        card.classList.add('dragging');
+        listElement.classList.add('reordering');
+
+        event.preventDefault();
+        window.addEventListener('pointermove', onDragMove);
+        window.addEventListener('pointerup', dropDrag);
+        window.addEventListener('pointercancel', cancelDrag);
+        window.addEventListener('keydown', onDragKeyDown);
+    }
+
+    function onDragMove(event) {
+        const placement = placementForPointer({
+            pointerY: event.clientY,
+            grabOffset: dragState.grabOffset,
+            // Read live: the list's own box is unaffected by the rows reordering inside it or by their
+            // transforms, but it does follow the panel scrolling under the drag.
+            listTop: listElement.getBoundingClientRect().top,
+            rowPitch: dragState.rowPitch,
+            rowCount: dragState.cards.length,
+        });
+
+        if (placement === null) {
+            return;
+        }
+
+        applySlot(placement.slotIndex);
+
+        // Transforms do not affect layout, so holding the card away from its slot neither moves the rows
+        // around it nor feeds back into the next placement.
+        dragState.card.style.transform = `translateY(${placement.offset}px)`;
+    }
+
+    // The other cards hold their relative order for the whole drag, so inserting before whichever one now
+    // holds the target slot always produces the same arrangement, whatever the list currently looks like.
+    // That makes reapplying a slot a no-op and leaves no incremental state to drift.
+    function applySlot(slotIndex) {
+        if (slotIndex === dragState.slotIndex) {
+            return;
+        }
+
+        dragState.slotIndex = slotIndex;
+        animateDisplacedCards(() => {
+            listElement.insertBefore(dragState.card, dragState.otherCards[slotIndex] || null);
+        });
+    }
+
+    // Slides the cards the reorder displaced, by measuring them either side of the change, putting them back
+    // where they were with a transform, then letting the CSS transition carry that transform away. The
+    // dragged card is left out so it snaps to the slot under the pointer instead of lagging behind it.
+    //
+    // Purely decorative: the slot arithmetic reads the pointer delta and a pitch measured once at the grab,
+    // never the rows, so a transform in flight cannot feed back into where the next slot lands.
+    function animateDisplacedCards(applyReorder) {
+        if (prefersReducedMotion()) {
+            applyReorder();
+            return;
+        }
+
+        const displacedCards = dragState.otherCards;
+
+        // Measured live rather than from the grab snapshot, so a card interrupted mid-slide continues from
+        // where it visually is instead of jumping back to its resting position.
+        const positionsBefore = new Map();
+        for (const displacedCard of displacedCards) {
+            positionsBefore.set(displacedCard, displacedCard.getBoundingClientRect().top);
+        }
+
+        applyReorder();
+
+        for (const displacedCard of displacedCards) {
+            const offset = positionsBefore.get(displacedCard) - displacedCard.getBoundingClientRect().top;
+            if (offset === 0) {
+                continue;
+            }
+
+            displacedCard.style.transition = 'none';
+            displacedCard.style.transform = `translateY(${offset}px)`;
+        }
+
+        // Reading a layout property commits the inverted transforms, so re-enabling the transition below
+        // animates away from them rather than the browser coalescing both writes into no visible change.
+        listElement.getBoundingClientRect();
+
+        for (const displacedCard of displacedCards) {
+            displacedCard.style.transition = '';
+            displacedCard.style.transform = '';
+        }
+    }
+
+    function prefersReducedMotion() {
+        return window.matchMedia !== undefined
+            && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    function onDragKeyDown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            cancelDrag();
+        }
+    }
+
+    function dropDrag() {
+        if (dragState === null) {
+            return;
+        }
+
+        const moved = dragState.slotIndex !== dragState.originalIndex;
+        finishDrag();
+
+        // Reported once, on release, rather than on each slot: a notification per slot would mark the
+        // document dirty and re-render anything driven by the order all the way through the drag.
+        if (moved) {
+            refreshState();
+            onChanged();
+        }
+    }
+
+    // Escape, or a pointer the browser has taken over, puts the list back exactly as it was. Re-appending the
+    // snapshot in order restores it whatever slot the card had reached.
+    function cancelDrag() {
+        if (dragState === null) {
+            return;
+        }
+
+        for (const snapshotCard of dragState.cards) {
+            listElement.appendChild(snapshotCard);
+        }
+
+        finishDrag();
+    }
+
+    function finishDrag() {
+        window.removeEventListener('pointermove', onDragMove);
+        window.removeEventListener('pointerup', dropDrag);
+        window.removeEventListener('pointercancel', cancelDrag);
+        window.removeEventListener('keydown', onDragKeyDown);
+
+        // A slide still in flight ends here: the DOM order is already final, so the card snaps the last few
+        // pixels rather than animating on after the gesture is over.
+        for (const snapshotCard of dragState.cards) {
+            snapshotCard.style.transition = '';
+            snapshotCard.style.transform = '';
+        }
+
+        dragState.card.classList.remove('dragging');
+        listElement.classList.remove('reordering');
+        dragState = null;
     }
 
     function populate(items) {
@@ -117,27 +362,21 @@ export function createCardList(options) {
         return items;
     }
 
-    // Shows the empty-list message, applies the document's writable state, and stops the end cards moving
-    // past the ends. The blanket writable pass runs first so the move buttons settle last.
+    // Shows the empty-list message and applies the document's writable state. The grip is not a control, so
+    // read-only is carried on the list for the styling and enforced in the gesture itself.
     function refreshState() {
         const writable = isWritable();
-        const cards = Array.from(listElement.children);
 
-        emptyElement.classList.toggle('hidden', cards.length > 0);
+        emptyElement.classList.toggle('hidden', listElement.children.length > 0);
         addButton.disabled = !writable;
 
         for (const control of listElement.querySelectorAll('input, button')) {
             control.disabled = !writable;
         }
 
-        if (!reorderable) {
-            return;
+        if (reorderable) {
+            listElement.classList.toggle('reorder-disabled', !writable);
         }
-
-        cards.forEach((card, index) => {
-            card.querySelector('.card-move-up').disabled = !writable || index === 0;
-            card.querySelector('.card-move-down').disabled = !writable || index === cards.length - 1;
-        });
     }
 
     addButton.addEventListener('click', () => {

--- a/Source/Workspace/Celbridge.Console/Web/Console/console-config.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console-config.js
@@ -26,71 +26,9 @@ export function parseEnvironmentLines(text) {
     return environment;
 }
 
-// A runner is edited as one line per runner: comma-separated extensions, then '=', then the command.
-export function parseRunnerLines(text) {
-    const runners = [];
-    for (const rawLine of text.split('\n')) {
-        const line = rawLine.trim();
-        if (line === '') {
-            continue;
-        }
-        const equalsIndex = line.indexOf('=');
-        if (equalsIndex < 0) {
-            continue;
-        }
-        const extensions = line.slice(0, equalsIndex).split(',').map((part) => part.trim()).filter((part) => part !== '');
-        const command = line.slice(equalsIndex + 1).trim();
-        if (extensions.length === 0 || command === '') {
-            continue;
-        }
-        runners.push({ extensions, command });
-    }
-    return runners;
-}
-
-export function formatRunnerLines(runners) {
-    return (runners || [])
-        .map((runner) => `${(runner.extensions || []).join(', ')} = ${runner.command || ''}`)
-        .join('\n');
-}
-
-// A shortcut is edited as one line per shortcut: label, then icon, then injected text, separated by '|'.
-// Only the first two pipes delimit, so the injected text may itself be a shell pipeline with its interior
-// spacing preserved.
-export function parseShortcutLines(text) {
-    const shortcuts = [];
-    for (const rawLine of text.split('\n')) {
-        const line = rawLine.trim();
-        if (line === '') {
-            continue;
-        }
-        const firstPipe = line.indexOf('|');
-        const secondPipe = firstPipe >= 0 ? line.indexOf('|', firstPipe + 1) : -1;
-        let label = '';
-        let icon = '';
-        let injected = '';
-        if (secondPipe >= 0) {
-            label = line.slice(0, firstPipe).trim();
-            icon = line.slice(firstPipe + 1, secondPipe).trim();
-            injected = line.slice(secondPipe + 1).trim();
-        } else if (firstPipe >= 0) {
-            label = line.slice(0, firstPipe).trim();
-            injected = line.slice(firstPipe + 1).trim();
-        } else {
-            label = line;
-        }
-        if (label === '' && injected === '') {
-            continue;
-        }
-        shortcuts.push({ label, icon, text: injected });
-    }
-    return shortcuts;
-}
-
-export function formatShortcutLines(shortcuts) {
-    return (shortcuts || [])
-        .map((shortcut) => `${shortcut.label || ''} | ${shortcut.icon || ''} | ${shortcut.text || ''}`)
-        .join('\n');
+// Comma-separated extensions, as a runner card edits them.
+export function parseExtensionList(text) {
+    return text.split(',').map((part) => part.trim()).filter((part) => part !== '');
 }
 
 // A comparable view of the config for the "needs a reopen" check: the start payload with a stable env

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.css
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.css
@@ -193,8 +193,82 @@ html, body {
     max-width: 640px;
 }
 
-.settings-section .field:last-child {
+.settings-section .field:last-child,
+.cel-expander-body .field:last-child {
     margin-bottom: 0;
+}
+
+/* The Automation lists: a titled group per entry kind, its cards, and the button that appends one. */
+.card-list-group {
+    max-width: 640px;
+}
+
+.card-list-group + .card-list-group {
+    margin-top: 20px;
+}
+
+.card-list-title {
+    margin: 0 0 2px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.card-list-hint,
+.card-list-empty {
+    margin: 0 0 8px;
+    font-size: 11px;
+    color: var(--cel-text-secondary);
+}
+
+.add-card-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* Card header: the entry's name, with the card's controls right-aligned before the expander's chevron. The
+   name alone identifies the entry; its fields are one expand away. */
+.card-list .cel-expander {
+    margin-bottom: 8px;
+}
+
+.card-list .cel-expander > summary {
+    gap: 8px;
+}
+
+.card-icon {
+    flex: 0 0 auto;
+    font-size: var(--cel-icon-size-medium);
+    line-height: 1;
+}
+
+.card-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.card-actions {
+    flex: 0 0 auto;
+    display: flex;
+    gap: 2px;
+}
+
+/* Smaller than the standard icon button, so three of them do not stretch the card header. */
+.card-actions .cel-icon-button {
+    width: 24px;
+    height: 24px;
+    font-size: var(--cel-icon-size-small);
+}
+
+/* Flags a setting the console will not be able to honour, below the field that produced it. */
+.field-warning {
+    display: block;
+    font-size: 11px;
+    color: var(--cel-warning-text);
+    margin-top: 4px;
 }
 
 .field-label {

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.css
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.css
@@ -242,6 +242,62 @@ html, body {
     line-height: 1;
 }
 
+/* Drag handle for a reorderable card. A drag starts here rather than anywhere on the header, so clicking the
+   header still expands the card and the body's inputs keep their own text selection. */
+.card-grip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    color: var(--cel-text-secondary);
+    cursor: grab;
+    touch-action: none;
+}
+
+.card-list.reorder-disabled .card-grip {
+    opacity: 0.5;
+    cursor: default;
+}
+
+/* Suppressing selection is what actually stops WebKit starting a native text drag mid-gesture, so the
+   prefixed property is kept for the WKWebView the macOS head runs on. */
+.card-list.reordering {
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.card-list.reordering .card-grip {
+    cursor: grabbing;
+}
+
+/* The card being held takes an accent border, which reads across the full width of the row and stays clear of
+   where the pointer sits. Deliberately not dimmed: opacity would fade the border doing the work, and it
+   applies to the whole subtree so the accent grip would go with it. Swapping a border to the accent colour is
+   how the rest of the app marks an active control, so this borrows an idiom rather than inventing one. */
+.card-list .cel-expander.dragging {
+    border-color: var(--cel-accent);
+    /* Lifted over its neighbours, since it follows the pointer and so spends most of a drag straddling two
+       rows. Stacking it above them is also what makes it read as picked up. */
+    position: relative;
+    z-index: 1;
+}
+
+.card-list .cel-expander.dragging .card-grip {
+    color: var(--cel-accent);
+}
+
+/* Carries the FLIP slide that console-cards.js sets up when a drag displaces a row. Scoped to the drag, so
+   cards never animate while the list is being populated or edited, and excluding the dragged card, which
+   tracks the pointer and must not lag behind it. */
+.card-list.reordering .cel-expander:not(.dragging) {
+    transition: transform 160ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .card-list.reordering .cel-expander:not(.dragging) {
+        transition: none;
+    }
+}
+
 .card-title {
     flex: 1 1 auto;
     min-width: 0;

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.js
@@ -5,20 +5,18 @@
 
 import celbridge from '/assets/celbridge-client/celbridge.js';
 import { ContentLoadedReason } from '/assets/celbridge-client/api/document-api.js';
-import { t } from '/assets/celbridge-client/localization.js';
+import { t, applyLocalization } from '/assets/celbridge-client/localization.js';
 import { attachSplitter } from '/assets/celbridge-client/ui/splitter.js';
 import { attachNavTabs } from '/assets/celbridge-client/ui/nav-tabs.js';
 import { parseConsoleToml, serializeConsoleToml, defaultConsoleConfig } from './console-toml.js';
 import {
     splitLines,
     parseEnvironmentLines,
-    parseRunnerLines,
-    formatRunnerLines,
-    parseShortcutLines,
-    formatShortcutLines,
+    parseExtensionList,
     configsEqual,
     buildStartConfig,
 } from './console-config.js';
+import { createCardList } from './console-cards.js';
 
 const client = celbridge;
 
@@ -98,8 +96,6 @@ const dependenciesInput = document.getElementById('dependencies');
 const workingDirectoryInput = document.getElementById('working-directory');
 const startupScriptInput = document.getElementById('startup-script');
 const environmentInput = document.getElementById('environment');
-const runnersInput = document.getElementById('runners');
-const shortcutsInput = document.getElementById('shortcuts');
 const reopenSettingsButton = document.getElementById('reopen-settings');
 
 // The settings sections and their headers, selected by the shared nav tab strip. Both are present in the
@@ -326,8 +322,8 @@ function populateForm(config) {
     environmentInput.value = Object.entries(config.environment || {})
         .map(([name, value]) => `${name}=${value}`)
         .join('\n');
-    runnersInput.value = formatRunnerLines(config.runners);
-    shortcutsInput.value = formatShortcutLines(config.shortcuts);
+    runnerCards.populate(config.runners);
+    shortcutCards.populate(config.shortcuts);
     renderShortcutRail();
 }
 
@@ -341,14 +337,126 @@ function readForm() {
         workingDirectory: workingDirectoryInput.value.trim(),
         startupScript: startupScriptInput.value.trimEnd(),
         environment: parseEnvironmentLines(environmentInput.value),
-        runners: parseRunnerLines(runnersInput.value),
-        shortcuts: parseShortcutLines(shortcutsInput.value),
+        runners: runnerCards.read(),
+        shortcuts: shortcutCards.read(),
     };
 }
 
-// A shortcut with no icon still needs a glyph to be clickable, so it falls back to the icon the Automation
-// settings tab uses.
+// A shortcut with no icon, or one the bundled icon set does not carry, still needs a glyph to be clickable,
+// so it falls back to the icon the Automation settings tab uses.
 const SHORTCUT_FALLBACK_ICON = 'bi-lightning-charge';
+
+// Config stores icons under the host's bs- prefix (matching IconService's symbol names); the bundled icon
+// font addresses them as bi-.
+function toBootstrapIconClass(iconName) {
+    if (iconName && iconName.startsWith('bs-')) {
+        return 'bi-' + iconName.slice('bs-'.length);
+    }
+
+    return SHORTCUT_FALLBACK_ICON;
+}
+
+// The icon font defines a ::before glyph per icon class, so a name the bundled set does not carry resolves
+// to no content at all.
+function hasIconGlyph(element) {
+    const content = getComputedStyle(element, '::before').content;
+
+    return content !== '' && content !== 'none' && content !== 'normal';
+}
+
+// Resolves a shortcut's icon to the class that will actually render, so the rail button and the card preview
+// agree on what an unrecognized name falls back to. probeElement must already be in the document: the check
+// resolves the candidate class against the loaded icon font.
+function resolveShortcutIconClass(iconName, probeElement) {
+    const candidate = toBootstrapIconClass(iconName);
+    probeElement.className = 'bi ' + candidate;
+    if (hasIconGlyph(probeElement)) {
+        return candidate;
+    }
+
+    return SHORTCUT_FALLBACK_ICON;
+}
+
+// The Automation lists. Each runner and shortcut is edited through its own card, so the cards are the source
+// of truth for those two settings, the way the inputs above are for the rest of the form.
+
+const runnerCards = createCardList({
+    listElement: document.getElementById('runner-cards'),
+    emptyElement: document.getElementById('runner-empty'),
+    addButton: document.getElementById('add-runner'),
+    template: document.getElementById('runner-card-template'),
+    blankItem: () => ({ extensions: [], command: '' }),
+    focusSelector: '.runner-extensions',
+    localize: applyLocalization,
+    onChanged: () => onFormInput(),
+    isWritable: isDocumentWritable,
+
+    fillCard(card, runner) {
+        card.querySelector('.runner-extensions').value = (runner.extensions || []).join(', ');
+        card.querySelector('.runner-command').value = runner.command || '';
+    },
+
+    readCard(card) {
+        const extensions = parseExtensionList(card.querySelector('.runner-extensions').value);
+        const command = card.querySelector('.runner-command').value.trim();
+        if (extensions.length === 0 || command === '') {
+            return null;
+        }
+
+        return { extensions, command };
+    },
+
+    // The collapsed card identifies the runner by the extensions it handles; the command is one expand away.
+    updateHeader(card) {
+        const extensions = card.querySelector('.runner-extensions').value.trim();
+        card.querySelector('.card-title').textContent = extensions || t('Console_Runner_Untitled');
+    },
+});
+
+const shortcutCards = createCardList({
+    listElement: document.getElementById('shortcut-cards'),
+    emptyElement: document.getElementById('shortcut-empty'),
+    addButton: document.getElementById('add-shortcut'),
+    template: document.getElementById('shortcut-card-template'),
+    blankItem: () => ({ label: '', icon: '', text: '' }),
+    focusSelector: '.shortcut-label',
+    // Shortcut order is rail order, so the user needs to be able to reorder the cards.
+    reorderable: true,
+    localize: applyLocalization,
+    onChanged: () => onFormInput(),
+    isWritable: isDocumentWritable,
+
+    fillCard(card, shortcut) {
+        card.querySelector('.shortcut-label').value = shortcut.label || '';
+        card.querySelector('.shortcut-icon').value = shortcut.icon || '';
+        card.querySelector('.shortcut-text').value = shortcut.text || '';
+    },
+
+    readCard(card) {
+        const label = card.querySelector('.shortcut-label').value.trim();
+        const icon = card.querySelector('.shortcut-icon').value.trim();
+        const text = card.querySelector('.shortcut-text').value.trim();
+        if (label === '' && text === '') {
+            return null;
+        }
+
+        return { label, icon, text };
+    },
+
+    // The header doubles as the shortcut's preview: the glyph and label here are what the rail button shows.
+    updateHeader(card) {
+        const label = card.querySelector('.shortcut-label').value.trim();
+        card.querySelector('.card-title').textContent = label || t('Console_Shortcut_Untitled');
+
+        const iconName = card.querySelector('.shortcut-icon').value.trim();
+        const iconElement = card.querySelector('.card-icon');
+        const resolved = resolveShortcutIconClass(iconName, iconElement);
+        iconElement.className = 'card-icon bi ' + resolved;
+
+        const isKnownIcon = resolved === toBootstrapIconClass(iconName);
+        card.querySelector('.shortcut-icon-unknown').classList.toggle('hidden', iconName === '' || isKnownIcon);
+    },
+});
 
 // The per-console shortcuts, rendered as icon-only cells at the top of the inspector rail. Each injects its
 // text into the pty on click; the tooltip carries the label, falling back to the text it types.
@@ -367,15 +475,12 @@ function renderShortcutRail() {
         button.setAttribute('aria-label', tooltip);
 
         const iconElement = document.createElement('i');
-        if (shortcut.icon && shortcut.icon.startsWith('bs-')) {
-            iconElement.className = 'bi bi-' + shortcut.icon.slice('bs-'.length);
-        } else {
-            iconElement.className = 'bi ' + SHORTCUT_FALLBACK_ICON;
-        }
         button.appendChild(iconElement);
-
         button.addEventListener('click', () => injectShortcut(shortcut.text));
         shortcutRail.appendChild(button);
+
+        // Resolved once the button is in the rail: the glyph check reads the loaded icon font.
+        iconElement.className = 'bi ' + resolveShortcutIconClass(shortcut.icon, iconElement);
     }
 }
 
@@ -414,8 +519,6 @@ const formFields = [
     workingDirectoryInput,
     startupScriptInput,
     environmentInput,
-    runnersInput,
-    shortcutsInput,
 ];
 
 for (const field of formFields) {
@@ -424,13 +527,21 @@ for (const field of formFields) {
     }
 }
 
+function isDocumentWritable() {
+    return client.viewState.current?.writable !== false;
+}
+
 // A read-only document disables the settings form so no edit marks the document dirty. The terminal stays
-// interactive and Reopen stays available, since neither writes the file.
+// interactive and Reopen stays available, since neither writes the file. The blanket pass runs first so the
+// per-card refinement below it decides the final state of the move buttons.
 function applyWritableState() {
-    const writable = client.viewState.current?.writable !== false;
+    const writable = isDocumentWritable();
     for (const field of formFields) {
         field.disabled = !writable;
     }
+
+    runnerCards.refreshState();
+    shortcutCards.refreshState();
 }
 
 client.viewState.onChanged(() => applyWritableState());

--- a/Source/Workspace/Celbridge.Console/Web/Console/index.html
+++ b/Source/Workspace/Celbridge.Console/Web/Console/index.html
@@ -195,15 +195,12 @@
     <template id="shortcut-card-template">
         <details class="cel-expander card">
             <summary>
+                <span class="card-grip" data-loc-key="Console_Card_Reorder" data-loc-attr="title,aria-label">
+                    <i class="bi bi-grip-vertical"></i>
+                </span>
                 <i class="card-icon bi"></i>
                 <span class="card-title"></span>
                 <span class="card-actions">
-                    <button class="cel-icon-button card-move-up" type="button" data-loc-key="Console_Card_MoveUp" data-loc-attr="title,aria-label">
-                        <i class="bi bi-chevron-up"></i>
-                    </button>
-                    <button class="cel-icon-button card-move-down" type="button" data-loc-key="Console_Card_MoveDown" data-loc-attr="title,aria-label">
-                        <i class="bi bi-chevron-down"></i>
-                    </button>
                     <button class="cel-icon-button card-delete" type="button" data-loc-key="Console_Card_Delete" data-loc-attr="title,aria-label">
                         <i class="bi bi-trash"></i>
                     </button>

--- a/Source/Workspace/Celbridge.Console/Web/Console/index.html
+++ b/Source/Workspace/Celbridge.Console/Web/Console/index.html
@@ -119,19 +119,30 @@
                     </section>
 
                     <!-- Every way of getting a command into this console: keyed on a file extension, or on a
-                         button press. -->
+                         button press. Each entry is a card, so the list is edited through the cards rather
+                         than through a delimited text format. -->
                     <section class="settings-section hidden" data-section="automation">
-                        <label class="field">
-                            <span class="field-label" data-loc-key="Console_Field_Runners"></span>
-                            <textarea id="runners" rows="4" spellcheck="false" data-loc-key="Console_Placeholder_Runners" data-loc-attr="placeholder"></textarea>
-                            <span class="field-hint" data-loc-key="Console_Hint_Runners"></span>
-                        </label>
 
-                        <label class="field">
-                            <span class="field-label" data-loc-key="Console_Field_Shortcuts"></span>
-                            <textarea id="shortcuts" rows="4" spellcheck="false" data-loc-key="Console_Placeholder_Shortcuts" data-loc-attr="placeholder"></textarea>
-                            <span class="field-hint" data-loc-key="Console_Hint_Shortcuts"></span>
-                        </label>
+                        <div class="card-list-group">
+                            <h2 class="card-list-title" data-loc-key="Console_Field_Runners"></h2>
+                            <p class="card-list-hint" data-loc-key="Console_Hint_Runners"></p>
+                            <div id="runner-cards" class="card-list"></div>
+                            <p id="runner-empty" class="card-list-empty" data-loc-key="Console_Empty_Runners"></p>
+                            <button id="add-runner" type="button" class="add-card-button">
+                                <i class="bi bi-plus-lg"></i><span data-loc-key="Console_Add_Runner"></span>
+                            </button>
+                        </div>
+
+                        <div class="card-list-group">
+                            <h2 class="card-list-title" data-loc-key="Console_Field_Shortcuts"></h2>
+                            <p class="card-list-hint" data-loc-key="Console_Hint_Shortcuts"></p>
+                            <div id="shortcut-cards" class="card-list"></div>
+                            <p id="shortcut-empty" class="card-list-empty" data-loc-key="Console_Empty_Shortcuts"></p>
+                            <button id="add-shortcut" type="button" class="add-card-button">
+                                <i class="bi bi-plus-lg"></i><span data-loc-key="Console_Add_Shortcut"></span>
+                            </button>
+                        </div>
+
                     </section>
 
                 </div>
@@ -153,6 +164,69 @@
             <div id="shortcut-rail"></div>
         </div>
     </div>
+
+    <!-- Card templates for the Automation lists, cloned per entry. Template content sits outside the document
+         tree, so a cloned card is localized explicitly rather than by the host's startup pass. -->
+    <template id="runner-card-template">
+        <details class="cel-expander card">
+            <summary>
+                <span class="card-title"></span>
+                <span class="card-actions">
+                    <button class="cel-icon-button card-delete" type="button" data-loc-key="Console_Card_Delete" data-loc-attr="title,aria-label">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </span>
+            </summary>
+            <div class="cel-expander-body">
+                <label class="field">
+                    <span class="field-label" data-loc-key="Console_Field_RunnerExtensions"></span>
+                    <input class="runner-extensions" type="text" spellcheck="false" data-loc-key="Console_Placeholder_RunnerExtensions" data-loc-attr="placeholder">
+                    <span class="field-hint" data-loc-key="Console_Hint_RunnerExtensions"></span>
+                </label>
+                <label class="field">
+                    <span class="field-label" data-loc-key="Console_Field_RunnerCommand"></span>
+                    <input class="runner-command" type="text" spellcheck="false" data-loc-key="Console_Placeholder_RunnerCommand" data-loc-attr="placeholder">
+                    <span class="field-hint" data-loc-key="Console_Hint_RunnerCommand"></span>
+                </label>
+            </div>
+        </details>
+    </template>
+
+    <template id="shortcut-card-template">
+        <details class="cel-expander card">
+            <summary>
+                <i class="card-icon bi"></i>
+                <span class="card-title"></span>
+                <span class="card-actions">
+                    <button class="cel-icon-button card-move-up" type="button" data-loc-key="Console_Card_MoveUp" data-loc-attr="title,aria-label">
+                        <i class="bi bi-chevron-up"></i>
+                    </button>
+                    <button class="cel-icon-button card-move-down" type="button" data-loc-key="Console_Card_MoveDown" data-loc-attr="title,aria-label">
+                        <i class="bi bi-chevron-down"></i>
+                    </button>
+                    <button class="cel-icon-button card-delete" type="button" data-loc-key="Console_Card_Delete" data-loc-attr="title,aria-label">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </span>
+            </summary>
+            <div class="cel-expander-body">
+                <label class="field">
+                    <span class="field-label" data-loc-key="Console_Field_ShortcutLabel"></span>
+                    <input class="shortcut-label" type="text" spellcheck="false" data-loc-key="Console_Placeholder_ShortcutLabel" data-loc-attr="placeholder">
+                </label>
+                <label class="field">
+                    <span class="field-label" data-loc-key="Console_Field_ShortcutIcon"></span>
+                    <input class="shortcut-icon" type="text" spellcheck="false" data-loc-key="Console_Placeholder_ShortcutIcon" data-loc-attr="placeholder">
+                    <span class="field-hint" data-loc-key="Console_Hint_ShortcutIcon"></span>
+                    <span class="field-warning shortcut-icon-unknown hidden" data-loc-key="Console_Warning_UnknownIcon"></span>
+                </label>
+                <label class="field">
+                    <span class="field-label" data-loc-key="Console_Field_ShortcutText"></span>
+                    <input class="shortcut-text" type="text" spellcheck="false" data-loc-key="Console_Placeholder_ShortcutText" data-loc-attr="placeholder">
+                </label>
+            </div>
+        </details>
+    </template>
 
     <script src="terminal-themes.js"></script>
     <script type="module" src="console.js"></script>

--- a/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
+++ b/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
@@ -34,6 +34,23 @@
     "Console_Field_Runners": "Script Runners",
     "Console_Field_Shortcuts": "Shortcuts",
 
+    "Console_Field_RunnerExtensions": "Extensions",
+    "Console_Field_RunnerCommand": "Command",
+    "Console_Field_ShortcutLabel": "Label",
+    "Console_Field_ShortcutIcon": "Icon",
+    "Console_Field_ShortcutText": "Command",
+
+    "Console_Add_Runner": "Add Script Runner",
+    "Console_Add_Shortcut": "Add Shortcut",
+    "Console_Empty_Runners": "No script runners yet.",
+    "Console_Empty_Shortcuts": "No shortcuts yet.",
+    "Console_Runner_Untitled": "New script runner",
+    "Console_Shortcut_Untitled": "New shortcut",
+    "Console_Card_Delete": "Delete",
+    "Console_Card_MoveUp": "Move up",
+    "Console_Card_MoveDown": "Move down",
+    "Console_Warning_UnknownIcon": "Unknown icon. The button will use the default glyph.",
+
     "Console_Type_Shell": "Shell",
     "Console_Type_Python": "Python",
 
@@ -44,8 +61,11 @@
     "Console_Placeholder_WorkingDirectory": "Folder path",
     "Console_Placeholder_StartupScript": "Commands to run on open",
     "Console_Placeholder_Environment": "KEY=value, one per line",
-    "Console_Placeholder_Runners": "extensions = command, one per line",
-    "Console_Placeholder_Shortcuts": "label | icon | text, one per line",
+    "Console_Placeholder_RunnerExtensions": "Comma-separated file extensions",
+    "Console_Placeholder_RunnerCommand": "Command that runs the file",
+    "Console_Placeholder_ShortcutLabel": "Shown as the button tooltip",
+    "Console_Placeholder_ShortcutIcon": "Bootstrap icon name",
+    "Console_Placeholder_ShortcutText": "Text typed into the console",
 
     "Console_Hint_Executable": "Typed into the platform shell after it starts; blank leaves just the shell. Example: node",
     "Console_Hint_PythonVersion": "Blank uses the default. Examples: 3.13, >=3.12",
@@ -54,6 +74,9 @@
     "Console_Hint_WorkingDirectory": "Relative to the project root; blank uses it. Example: tools",
     "Console_Hint_StartupScript": "Runs each time the console opens, once it is ready. Example: import numpy as np",
     "Console_Hint_Environment": "Injected before launch, one per line. Example: PYTHONWARNINGS=default",
-    "Console_Hint_Runners": "Run a file in this console; {script_path} is the file path. Example: .py, .ipy = %run \"{script_path}\"",
-    "Console_Hint_Shortcuts": "Rail button that types text; the label is its tooltip and the icon is a Bootstrap name. Example: Run tests | bs-play-fill | pytest -q"
+    "Console_Hint_Runners": "Run a file in this console from the Explorer Run menu.",
+    "Console_Hint_Shortcuts": "Buttons on the console rail, in rail order, that type a command into the session.",
+    "Console_Hint_RunnerExtensions": "File extensions this runner handles. Example: .py, .ipy",
+    "Console_Hint_RunnerCommand": "{script_path} is the path of the file being run. Example: %run \"{script_path}\"",
+    "Console_Hint_ShortcutIcon": "A Bootstrap Icons name. Example: bs-play-fill"
 }

--- a/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
+++ b/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
@@ -47,8 +47,7 @@
     "Console_Runner_Untitled": "New script runner",
     "Console_Shortcut_Untitled": "New shortcut",
     "Console_Card_Delete": "Delete",
-    "Console_Card_MoveUp": "Move up",
-    "Console_Card_MoveDown": "Move down",
+    "Console_Card_Reorder": "Drag to reorder, or press Alt+Up and Alt+Down on the header.",
     "Console_Warning_UnknownIcon": "Unknown icon. The button will use the default glyph.",
 
     "Console_Type_Shell": "Shell",
@@ -75,7 +74,7 @@
     "Console_Hint_StartupScript": "Runs each time the console opens, once it is ready. Example: import numpy as np",
     "Console_Hint_Environment": "Injected before launch, one per line. Example: PYTHONWARNINGS=default",
     "Console_Hint_Runners": "Run a file in this console from the Explorer Run menu.",
-    "Console_Hint_Shortcuts": "Buttons on the console rail, in rail order, that type a command into the session.",
+    "Console_Hint_Shortcuts": "Buttons on the console rail that type a command into the session.",
     "Console_Hint_RunnerExtensions": "File extensions this runner handles. Example: .py, .ipy",
     "Console_Hint_RunnerCommand": "{script_path} is the path of the file being run. Example: %run \"{script_path}\"",
     "Console_Hint_ShortcutIcon": "A Bootstrap Icons name. Example: bs-play-fill"

--- a/Source/Workspace/Celbridge.Console/Web/Console/tests/console-cards.test.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/tests/console-cards.test.js
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createCardList } from '../console-cards.js';
+
+// A minimal stand-in for the shortcut card template: the classes the card list drives, and one input.
+const CARD_TEMPLATE = `
+    <details class="cel-expander card">
+        <summary>
+            <span class="card-title"></span>
+            <span class="card-actions">
+                <button class="cel-icon-button card-move-up" type="button"></button>
+                <button class="cel-icon-button card-move-down" type="button"></button>
+                <button class="cel-icon-button card-delete" type="button"></button>
+            </span>
+        </summary>
+        <div class="cel-expander-body">
+            <input class="card-name" type="text">
+        </div>
+    </details>`;
+
+function buildList(overrides = {}) {
+    document.body.innerHTML = `
+        <div id="cards" class="card-list"></div>
+        <p id="empty"></p>
+        <button id="add" type="button"></button>
+        <template id="template">${CARD_TEMPLATE}</template>`;
+
+    const onChanged = vi.fn();
+    const list = createCardList({
+        listElement: document.getElementById('cards'),
+        emptyElement: document.getElementById('empty'),
+        addButton: document.getElementById('add'),
+        template: document.getElementById('template'),
+        blankItem: () => ({ name: '' }),
+        focusSelector: '.card-name',
+        reorderable: true,
+        localize: () => { },
+        onChanged,
+        isWritable: () => true,
+        fillCard(card, item) {
+            card.querySelector('.card-name').value = item.name || '';
+        },
+        readCard(card) {
+            const name = card.querySelector('.card-name').value.trim();
+            if (name === '') {
+                return null;
+            }
+
+            return { name };
+        },
+        updateHeader(card) {
+            card.querySelector('.card-title').textContent = card.querySelector('.card-name').value;
+        },
+        ...overrides,
+    });
+
+    return { list, onChanged };
+}
+
+function names() {
+    return [...document.querySelectorAll('#cards .card-name')].map((input) => input.value);
+}
+
+function cardAt(index) {
+    return document.getElementById('cards').children[index];
+}
+
+describe('createCardList', () => {
+    let list;
+    let onChanged;
+
+    beforeEach(() => {
+        ({ list, onChanged } = buildList());
+        list.populate([{ name: 'first' }, { name: 'second' }, { name: 'third' }]);
+        onChanged.mockClear();
+    });
+
+    it('renders one card per entry and reads them back in order', () => {
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(list.read()).toEqual([{ name: 'first' }, { name: 'second' }, { name: 'third' }]);
+    });
+
+    it('replaces the previous cards on repopulate', () => {
+        list.populate([{ name: 'only' }]);
+
+        expect(names()).toEqual(['only']);
+    });
+
+    it('drops cards the reader rejects', () => {
+        cardAt(1).querySelector('.card-name').value = '   ';
+
+        expect(list.read()).toEqual([{ name: 'first' }, { name: 'third' }]);
+    });
+
+    it('shows the empty message only when the list has no cards', () => {
+        expect(document.getElementById('empty').classList.contains('hidden')).toBe(true);
+
+        list.populate([]);
+
+        expect(document.getElementById('empty').classList.contains('hidden')).toBe(false);
+    });
+
+    it('appends an expanded card on add, without reporting a change yet', () => {
+        document.getElementById('add').click();
+
+        expect(names()).toEqual(['first', 'second', 'third', '']);
+        expect(cardAt(3).open).toBe(true);
+        // The blank card contributes nothing, so the document is not dirty until something is typed.
+        expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('reports a change when a card is edited', () => {
+        const input = cardAt(0).querySelector('.card-name');
+        input.value = 'edited';
+        input.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+        expect(onChanged).toHaveBeenCalled();
+        expect(cardAt(0).querySelector('.card-title').textContent).toBe('edited');
+    });
+
+    it('removes a card on delete and reports the change', () => {
+        cardAt(1).querySelector('.card-delete').click();
+
+        expect(names()).toEqual(['first', 'third']);
+        expect(onChanged).toHaveBeenCalled();
+    });
+
+    it('moves a card up and down, reporting each change', () => {
+        cardAt(2).querySelector('.card-move-up').click();
+        expect(names()).toEqual(['first', 'third', 'second']);
+
+        cardAt(0).querySelector('.card-move-down').click();
+        expect(names()).toEqual(['third', 'first', 'second']);
+        expect(onChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it('disables the move buttons at each end of the list', () => {
+        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(true);
+        expect(cardAt(0).querySelector('.card-move-down').disabled).toBe(false);
+        expect(cardAt(2).querySelector('.card-move-up').disabled).toBe(false);
+        expect(cardAt(2).querySelector('.card-move-down').disabled).toBe(true);
+    });
+
+    it('re-evaluates the end cards after a move', () => {
+        cardAt(0).querySelector('.card-move-down').click();
+
+        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(true);
+        expect(names()).toEqual(['second', 'first', 'third']);
+    });
+
+    it('keeps a card open and its edits intact across a move', () => {
+        cardAt(0).open = true;
+        cardAt(0).querySelector('.card-name').value = 'in progress';
+
+        cardAt(0).querySelector('.card-move-down').click();
+
+        expect(cardAt(1).open).toBe(true);
+        expect(cardAt(1).querySelector('.card-name').value).toBe('in progress');
+    });
+
+    it('does not report a change when a move is a no-op', () => {
+        cardAt(0).querySelector('.card-move-up').disabled = false;
+        cardAt(0).querySelector('.card-move-up').click();
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('disables every control while the document is read-only', () => {
+        const readOnly = buildList({ isWritable: () => false });
+        readOnly.list.populate([{ name: 'first' }, { name: 'second' }]);
+
+        expect(document.getElementById('add').disabled).toBe(true);
+        expect(cardAt(0).querySelector('.card-name').disabled).toBe(true);
+        expect(cardAt(0).querySelector('.card-delete').disabled).toBe(true);
+        expect(cardAt(0).querySelector('.card-move-down').disabled).toBe(true);
+    });
+
+    it('leaves the move buttons alone for a list that is not reorderable', () => {
+        const plain = buildList({ reorderable: false });
+        plain.list.populate([{ name: 'first' }, { name: 'second' }]);
+
+        // Untouched by refreshState beyond the blanket writable pass, which leaves them enabled.
+        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(false);
+        expect(plain.list.read()).toEqual([{ name: 'first' }, { name: 'second' }]);
+    });
+});

--- a/Source/Workspace/Celbridge.Console/Web/Console/tests/console-cards.test.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/tests/console-cards.test.js
@@ -1,16 +1,54 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createCardList } from '../console-cards.js';
+import { createCardList, placementForPointer } from '../console-cards.js';
+
+const ROW_HEIGHT = 40;
+const ROW_GAP = 8;
+const ROW_PITCH = ROW_HEIGHT + ROW_GAP;
+const LIST_TOP = 100;
+// Every drag below grabs a row 10px down from its top, so the pointer positions read as row top + 10.
+const GRAB_OFFSET = 10;
+
+// jsdom reports no layout, so the list and its rows are given stacked rects. The drag measures the pitch and
+// the grab offset once, at grab time, and reads the list's own top as it goes.
+function stubCardLayout() {
+    const list = document.getElementById('cards');
+    list.getBoundingClientRect = () => ({
+        top: LIST_TOP, bottom: LIST_TOP + 400, height: 400, left: 0, right: 200, width: 200, x: 0, y: LIST_TOP,
+    });
+
+    [...list.children].forEach((card, index) => {
+        const top = LIST_TOP + index * ROW_PITCH;
+        card.getBoundingClientRect = () => ({
+            top, bottom: top + ROW_HEIGHT, height: ROW_HEIGHT,
+            left: 0, right: 200, width: 200, x: 0, y: top,
+        });
+    });
+}
+
+// Grabs the row at its own index's resting position, so the grab offset is a known 10px.
+function startDrag(card) {
+    stubCardLayout();
+    const clientY = card.getBoundingClientRect().top + GRAB_OFFSET;
+    card.querySelector('.card-grip').dispatchEvent(
+        new window.PointerEvent('pointerdown', { button: 0, clientY, bubbles: true, cancelable: true }));
+}
+
+// Moves the pointer so the dragged row's top lands at the given offset from the top of the list.
+function dragToRowTop(offsetFromListTop) {
+    window.dispatchEvent(new window.PointerEvent('pointermove', {
+        clientY: LIST_TOP + offsetFromListTop + GRAB_OFFSET, bubbles: true,
+    }));
+}
 
 // A minimal stand-in for the shortcut card template: the classes the card list drives, and one input.
 const CARD_TEMPLATE = `
     <details class="cel-expander card">
         <summary>
+            <span class="card-grip"></span>
             <span class="card-title"></span>
             <span class="card-actions">
-                <button class="cel-icon-button card-move-up" type="button"></button>
-                <button class="cel-icon-button card-move-down" type="button"></button>
                 <button class="cel-icon-button card-delete" type="button"></button>
             </span>
         </summary>
@@ -64,6 +102,11 @@ function names() {
 
 function cardAt(index) {
     return document.getElementById('cards').children[index];
+}
+
+function pressOnHeader(card, key, { altKey = true } = {}) {
+    card.querySelector('summary').dispatchEvent(
+        new window.KeyboardEvent('keydown', { key, altKey, bubbles: true, cancelable: true }));
 }
 
 describe('createCardList', () => {
@@ -126,45 +169,215 @@ describe('createCardList', () => {
         expect(onChanged).toHaveBeenCalled();
     });
 
-    it('moves a card up and down, reporting each change', () => {
-        cardAt(2).querySelector('.card-move-up').click();
+    it('moves a card with Alt+Up and Alt+Down, reporting each change', () => {
+        pressOnHeader(cardAt(2), 'ArrowUp');
         expect(names()).toEqual(['first', 'third', 'second']);
 
-        cardAt(0).querySelector('.card-move-down').click();
+        pressOnHeader(cardAt(0), 'ArrowDown');
         expect(names()).toEqual(['third', 'first', 'second']);
         expect(onChanged).toHaveBeenCalledTimes(2);
     });
 
-    it('disables the move buttons at each end of the list', () => {
-        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(true);
-        expect(cardAt(0).querySelector('.card-move-down').disabled).toBe(false);
-        expect(cardAt(2).querySelector('.card-move-up').disabled).toBe(false);
-        expect(cardAt(2).querySelector('.card-move-down').disabled).toBe(true);
+    it('ignores an arrow key without Alt, leaving it to the page', () => {
+        pressOnHeader(cardAt(1), 'ArrowUp', { altKey: false });
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
     });
 
-    it('re-evaluates the end cards after a move', () => {
-        cardAt(0).querySelector('.card-move-down').click();
+    it('does not report a change when a move runs off either end', () => {
+        pressOnHeader(cardAt(0), 'ArrowUp');
+        pressOnHeader(cardAt(2), 'ArrowDown');
 
-        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(true);
-        expect(names()).toEqual(['second', 'first', 'third']);
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
     });
 
     it('keeps a card open and its edits intact across a move', () => {
         cardAt(0).open = true;
         cardAt(0).querySelector('.card-name').value = 'in progress';
 
-        cardAt(0).querySelector('.card-move-down').click();
+        pressOnHeader(cardAt(0), 'ArrowDown');
 
         expect(cardAt(1).open).toBe(true);
         expect(cardAt(1).querySelector('.card-name').value).toBe('in progress');
     });
 
-    it('does not report a change when a move is a no-op', () => {
-        cardAt(0).querySelector('.card-move-up').disabled = false;
-        cardAt(0).querySelector('.card-move-up').click();
+    it('collapses the list instead of dragging when a card is expanded', () => {
+        cardAt(0).open = true;
+        cardAt(2).open = true;
+
+        startDrag(cardAt(0));
+
+        expect([...document.getElementById('cards').children].every((card) => !card.open)).toBe(true);
+        expect(document.getElementById('cards').classList.contains('reordering')).toBe(false);
+
+        // No drag is in progress, so the pointer moving does not reorder anything.
+        dragToRowTop(ROW_PITCH * 2);
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('drags on the next press, once the list is collapsed', () => {
+        cardAt(0).open = true;
+
+        startDrag(cardAt(0));
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
+        startDrag(cardAt(0));
+        dragToRowTop(ROW_PITCH);
+
+        expect(names()).toEqual(['second', 'first', 'third']);
+    });
+
+    it('leaves the cards collapsed after a drop', () => {
+        startDrag(cardAt(0));
+        dragToRowTop(ROW_PITCH);
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
+
+        expect([...document.getElementById('cards').children].every((card) => !card.open)).toBe(true);
+    });
+
+    it('does not toggle a card open when its grip is pressed', () => {
+        const clickEvent = new window.MouseEvent('click', { bubbles: true, cancelable: true });
+        cardAt(0).querySelector('.card-grip').dispatchEvent(clickEvent);
+
+        expect(clickEvent.defaultPrevented).toBe(true);
+    });
+
+    it('reorders the list live as the pointer crosses each row', () => {
+        startDrag(cardAt(0));
+
+        dragToRowTop(ROW_PITCH);
+        expect(names()).toEqual(['second', 'first', 'third']);
+
+        dragToRowTop(ROW_PITCH * 2);
+        expect(names()).toEqual(['second', 'third', 'first']);
+
+        // Dragging back up returns it, so the live reorder is not one-way.
+        dragToRowTop(0);
+        expect(names()).toEqual(['first', 'second', 'third']);
+    });
+
+    it('holds the dragged card under the pointer between slots', () => {
+        startDrag(cardAt(0));
+
+        // Short of half a row, so no slot change yet and the card carries the whole travel.
+        dragToRowTop(20);
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(cardAt(0).style.transform).toBe('translateY(20px)');
+
+        // Past a whole row: the slot absorbs the pitch and the transform carries only the overshoot.
+        dragToRowTop(ROW_PITCH + 6);
+        expect(names()).toEqual(['second', 'first', 'third']);
+        expect(cardAt(1).style.transform).toBe('translateY(6px)');
+    });
+
+    it('pins the dragged card to the first slot when dragged above the list', () => {
+        startDrag(cardAt(1));
+
+        dragToRowTop(-ROW_PITCH * 10);
+
+        expect(names()).toEqual(['second', 'first', 'third']);
+        // Pinned rather than carried off: no leftover offset above the first slot.
+        expect(cardAt(0).style.transform).toBe('translateY(0px)');
+    });
+
+    it('pins the dragged card to the last slot when dragged below the list', () => {
+        startDrag(cardAt(1));
+
+        dragToRowTop(ROW_PITCH * 10);
+
+        expect(names()).toEqual(['first', 'third', 'second']);
+        expect(cardAt(2).style.transform).toBe('translateY(0px)');
+    });
+
+    it('clears the dragged card transform once the drag ends', () => {
+        startDrag(cardAt(0));
+        dragToRowTop(20);
+        expect(cardAt(0).style.transform).not.toBe('');
+
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
+
+        expect(cardAt(0).style.transform).toBe('');
+    });
+
+    it('clears the dragged card transform when the drag is cancelled', () => {
+        startDrag(cardAt(0));
+        dragToRowTop(ROW_PITCH + 6);
+
+        window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(cardAt(0).style.transform).toBe('');
+    });
+
+    it('reports one change on drop rather than one per slot', () => {
+        startDrag(cardAt(0));
+
+        dragToRowTop(ROW_PITCH);
+        dragToRowTop(ROW_PITCH * 2);
+        expect(onChanged).not.toHaveBeenCalled();
+
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
+
+        expect(onChanged).toHaveBeenCalledTimes(1);
+        expect(names()).toEqual(['second', 'third', 'first']);
+    });
+
+    it('reports no change when the card is dropped back in its original slot', () => {
+        startDrag(cardAt(0));
+
+        dragToRowTop(ROW_PITCH * 2);
+        dragToRowTop(0);
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
 
         expect(names()).toEqual(['first', 'second', 'third']);
         expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('restores the original order when the drag is cancelled with Escape', () => {
+        startDrag(cardAt(0));
+        dragToRowTop(ROW_PITCH * 2);
+        expect(names()).toEqual(['second', 'third', 'first']);
+
+        window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
+        expect(document.getElementById('cards').classList.contains('reordering')).toBe(false);
+    });
+
+    it('restores the original order when the browser cancels the pointer', () => {
+        startDrag(cardAt(2));
+        dragToRowTop(0);
+        expect(names()).toEqual(['third', 'first', 'second']);
+
+        window.dispatchEvent(new window.PointerEvent('pointercancel', { bubbles: true }));
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('stops tracking the pointer once the drag has ended', () => {
+        startDrag(cardAt(0));
+        window.dispatchEvent(new window.PointerEvent('pointerup', { bubbles: true }));
+
+        dragToRowTop(ROW_PITCH * 2);
+
+        expect(names()).toEqual(['first', 'second', 'third']);
+        expect(document.getElementById('cards').classList.contains('reordering')).toBe(false);
+    });
+
+    it('refuses to start a drag while the document is read-only', () => {
+        const readOnly = buildList({ isWritable: () => false });
+        readOnly.list.populate([{ name: 'first' }, { name: 'second' }]);
+        cardAt(0).open = true;
+
+        startDrag(cardAt(0));
+        dragToRowTop(ROW_PITCH);
+
+        expect(names()).toEqual(['first', 'second']);
+        expect(cardAt(0).open).toBe(true);
     });
 
     it('disables every control while the document is read-only', () => {
@@ -174,15 +387,68 @@ describe('createCardList', () => {
         expect(document.getElementById('add').disabled).toBe(true);
         expect(cardAt(0).querySelector('.card-name').disabled).toBe(true);
         expect(cardAt(0).querySelector('.card-delete').disabled).toBe(true);
-        expect(cardAt(0).querySelector('.card-move-down').disabled).toBe(true);
+        expect(document.getElementById('cards').classList.contains('reorder-disabled')).toBe(true);
     });
 
-    it('leaves the move buttons alone for a list that is not reorderable', () => {
+    it('refuses a keyboard move while the document is read-only', () => {
+        const readOnly = buildList({ isWritable: () => false });
+        readOnly.list.populate([{ name: 'first' }, { name: 'second' }]);
+
+        pressOnHeader(cardAt(1), 'ArrowUp');
+
+        expect(names()).toEqual(['first', 'second']);
+        expect(readOnly.onChanged).not.toHaveBeenCalled();
+    });
+
+    it('leaves a list that is not reorderable without reorder handling', () => {
         const plain = buildList({ reorderable: false });
         plain.list.populate([{ name: 'first' }, { name: 'second' }]);
 
-        // Untouched by refreshState beyond the blanket writable pass, which leaves them enabled.
-        expect(cardAt(0).querySelector('.card-move-up').disabled).toBe(false);
+        pressOnHeader(cardAt(1), 'ArrowUp');
+
+        expect(names()).toEqual(['first', 'second']);
+        expect(document.getElementById('cards').classList.contains('reorder-disabled')).toBe(false);
         expect(plain.list.read()).toEqual([{ name: 'first' }, { name: 'second' }]);
+    });
+});
+
+describe('placementForPointer', () => {
+    // Four rows of pitch 48 starting at y=100, grabbed 10px down from the row's top.
+    const place = (pointerY) => placementForPointer({
+        pointerY, grabOffset: 10, listTop: 100, rowPitch: 48, rowCount: 4,
+    });
+
+    it('keeps the row at its slot with no offset when the pointer has not moved', () => {
+        expect(place(110)).toEqual({ slotIndex: 0, offset: 0 });
+    });
+
+    it('holds the slot and carries the travel as an offset, up to half a row', () => {
+        expect(place(130)).toEqual({ slotIndex: 0, offset: 20 });
+    });
+
+    it('takes the next slot past half a row, leaving only the overshoot as an offset', () => {
+        expect(place(158)).toEqual({ slotIndex: 1, offset: 0 });
+        expect(place(164)).toEqual({ slotIndex: 1, offset: 6 });
+    });
+
+    it('pins to the first slot above the list rather than carrying the row off it', () => {
+        expect(place(-1000)).toEqual({ slotIndex: 0, offset: 0 });
+    });
+
+    it('pins to the last slot below the list', () => {
+        expect(place(1000)).toEqual({ slotIndex: 3, offset: 0 });
+    });
+
+    it('follows the list when the panel scrolls under the drag', () => {
+        const scrolled = placementForPointer({
+            pointerY: 110, grabOffset: 10, listTop: 60, rowPitch: 48, rowCount: 4,
+        });
+
+        expect(scrolled).toEqual({ slotIndex: 1, offset: -8 });
+    });
+
+    it('declines to place a list too small to measure, rather than dividing by zero', () => {
+        expect(placementForPointer({ pointerY: 500, grabOffset: 0, listTop: 0, rowPitch: 0, rowCount: 4 }))
+            .toBeNull();
     });
 });

--- a/Source/Workspace/Celbridge.Console/Web/Console/tests/console-config.test.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/tests/console-config.test.js
@@ -2,10 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     splitLines,
     parseEnvironmentLines,
-    parseRunnerLines,
-    formatRunnerLines,
-    parseShortcutLines,
-    formatShortcutLines,
+    parseExtensionList,
     normalizeConfig,
     configsEqual,
     buildStartConfig,
@@ -35,61 +32,17 @@ describe('parseEnvironmentLines', () => {
     });
 });
 
-describe('runner lines', () => {
-    it('parses comma-separated extensions and the command', () => {
-        expect(parseRunnerLines('.py, .ipy = %run "{script_path}"')).toEqual([
-            { extensions: ['.py', '.ipy'], command: '%run "{script_path}"' },
-        ]);
+describe('parseExtensionList', () => {
+    it('splits on commas and trims each extension', () => {
+        expect(parseExtensionList(' .py , .ipy ')).toEqual(['.py', '.ipy']);
     });
 
-    it('skips lines with no extensions or no command', () => {
-        expect(parseRunnerLines('= nothing\n.py =\n\n.sh = bash')).toEqual([
-            { extensions: ['.sh'], command: 'bash' },
-        ]);
+    it('drops empty entries so a trailing comma is harmless', () => {
+        expect(parseExtensionList('.sh,,')).toEqual(['.sh']);
     });
 
-    it('round-trips through format and parse', () => {
-        const runners = [
-            { extensions: ['.py', '.ipy'], command: '%run "{script_path}"' },
-            { extensions: ['.sh'], command: 'bash "{script_path}"' },
-        ];
-        expect(parseRunnerLines(formatRunnerLines(runners))).toEqual(runners);
-    });
-});
-
-describe('shortcut lines', () => {
-    it('parses label | icon | text', () => {
-        expect(parseShortcutLines('Run tests | bs-play-fill | pytest -q')).toEqual([
-            { label: 'Run tests', icon: 'bs-play-fill', text: 'pytest -q' },
-        ]);
-    });
-
-    it('treats a two-part line as label + text with no icon', () => {
-        expect(parseShortcutLines('Clear | clear')).toEqual([
-            { label: 'Clear', icon: '', text: 'clear' },
-        ]);
-    });
-
-    it('keeps pipes and spacing inside the injected text', () => {
-        expect(parseShortcutLines('Pipeline | bs-x | ls -la | grep foo')).toEqual([
-            { label: 'Pipeline', icon: 'bs-x', text: 'ls -la | grep foo' },
-        ]);
-    });
-
-    it('round-trips a shortcut whose text is a shell pipeline', () => {
-        const shortcuts = [{ label: 'Pipeline', icon: 'bs-x', text: 'ls -la | grep foo' }];
-        expect(parseShortcutLines(formatShortcutLines(shortcuts))).toEqual(shortcuts);
-    });
-
-    it('skips lines with neither a label nor injected text', () => {
-        expect(parseShortcutLines(' | | \nKeep | echo')).toEqual([
-            { label: 'Keep', icon: '', text: 'echo' },
-        ]);
-    });
-
-    it('round-trips a fully-specified shortcut', () => {
-        const shortcuts = [{ label: 'Run', icon: 'bs-play', text: 'pytest' }];
-        expect(parseShortcutLines(formatShortcutLines(shortcuts))).toEqual(shortcuts);
+    it('returns an empty array for blank text', () => {
+        expect(parseExtensionList('  ')).toEqual([]);
     });
 });
 


### PR DESCRIPTION
This pull request introduces a new card-list editor pattern for editing lists of entries (such as script runners and shortcuts) in the console's settings, replacing the previous line-based editing approach. It implements this pattern with a reusable `createCardList` function in JavaScript, updates documentation to describe the new UX, and adds supporting style tokens and CSS for the new card list and expander content. The previous parsing and formatting logic for runners and shortcuts has been removed, in favor of card-based editing.

The most important changes are:

**New Card List Editor Implementation:**
* Introduced `createCardList` and supporting functions in `console-cards.js` to provide a user-friendly, card-based UI for editing lists of entries, with support for adding, deleting, and reordering entries via drag-and-drop or keyboard. The implementation carefully handles drag gestures, live reordering, and accessibility, and is decoupled from the rest of the client for reusability. (`Source/Workspace/Celbridge.Console/Web/Console/console-cards.js`)

**Documentation Updates:**
* Updated the documentation in `document_editor_contributions.md` to describe the new card-list editing pattern, including rationale, UX details, and code usage examples, and to clarify the ordering of shortcut buttons and the settings toggle in the editor rail. (`Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md`)

**Removal of Legacy Parsing Logic:**
* Removed the old line-based parsing and formatting functions for runners and shortcuts (`parseRunnerLines`, `formatRunnerLines`, `parseShortcutLines`, `formatShortcutLines`) from `console-config.js`, replacing them with a simpler `parseExtensionList` function for comma-separated extension lists, since editing is now card-based. (`Source/Workspace/Celbridge.Console/Web/Console/console-config.js`)

**Styling and Theming:**
* Added new CSS variables for expander content backgrounds in both light and dark themes, and updated comments to clarify their relationship to WinUI Expander brushes. (`celbridge-tokens.css`) [[1]](diffhunk://#diff-1bf0341b9a958a155f458e7e1b710ca224c754e1accc2740961d09d7db794136L62-R69) [[2]](diffhunk://#diff-1bf0341b9a958a155f458e7e1b710ca224c754e1accc2740961d09d7db794136R96)
* Updated `.cel-expander-body` CSS to use the new content background variable, ensuring expanded card bodies are visually distinct and belong to the card. (`celbridge.css`)