### PR TITLE
Unify console resource templates and enhance submit flow

### DIFF
--- a/Source/Core/Celbridge.Foundation/Console/IConsoleSessionProvider.cs
+++ b/Source/Core/Celbridge.Foundation/Console/IConsoleSessionProvider.cs
@@ -24,7 +24,7 @@ public sealed record ConsoleStartupInvocation(
 
 /// <summary>
 /// A default way a session type runs a file: the file extensions it handles and a command template
-/// injected to run a matching file, where "{script_path}" is replaced with the file path.
+/// injected to run a matching file, where "{resource}" is replaced with the file's path.
 /// </summary>
 public sealed record ConsoleRunner(
     IReadOnlyList<string> FileExtensions,

--- a/Source/Core/Celbridge.Foundation/Console/IConsoleSessionService.cs
+++ b/Source/Core/Celbridge.Foundation/Console/IConsoleSessionService.cs
@@ -132,4 +132,10 @@ public interface IConsoleSessionService
     /// Fails if the session has ended or has lost its client connection.
     /// </summary>
     Result SubmitInvocation(Guid sessionId, string invocation);
+
+    /// <summary>
+    /// Submits an invocation to whichever session a console document is currently running, rather than to
+    /// one specific launch. A resource with no session is ignored.
+    /// </summary>
+    void SubmitInvocation(ResourceKey resource, string invocation);
 }

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/document_editor_contributions.md
@@ -161,6 +161,18 @@ tabs.selected();              // persist this in onRequestState()
 
 Each tab is an icon with a tooltip, not a text label, so the strip stays a fixed width however many sections a panel has; the section name below it is what names the selection. Add a `<span class="cel-nav-tab-pip">` inside a tab's icon to flag that its section needs attention.
 
+### Field help
+
+Three things can explain a settings field, and each has its own job:
+
+- **Label** — what the setting is.
+- **Placeholder** — the shape of the value: "Comma-separated file extensions", "Shown as the button tooltip".
+- **Inline hint** (`.field-hint`) — syntax, a format constraint, or an example the user has to reproduce, and nothing else. A hint that restates the label or the placeholder is the common failure; delete it.
+
+A field whose label and placeholder already say everything gets no hint. That is why the console's shortcut Label and Command carry none while its Icon does: `bs-play-fill` is a naming scheme nobody guesses.
+
+The native XAML settings panels use tooltips for this instead, and an editor panel should not copy them. Their fields hold values you read once, where a tooltip is fine. An editor's settings tend to hold syntax you type, and a tooltip disappears the moment the pointer moves to the field it describes. Keep tooltips for background nobody needs in hand while typing.
+
 ### Inspector rail
 
 An editor that needs a side panel puts it behind `.cel-rail`, a vertical icon rail down the right edge of its content, mirroring the workspace utility rail. The settings button sits at the top, the editor's own action buttons below it, separated by a `.cel-rail-separator`; the settings button uses `bi-sliders`, the same glyph as the workspace Project Settings button, and toggles the panel.

--- a/Source/Tests/Console/ConsoleDocumentConfigParserTests.cs
+++ b/Source/Tests/Console/ConsoleDocumentConfigParserTests.cs
@@ -38,7 +38,7 @@ public class ConsoleDocumentConfigParserTests
             "",
             "[[session.runner]]",
             "extensions = [\".py\", \".ipy\"]",
-            "command = '%run \"{script_path}\"'",
+            "command = '%run \"{resource}\"'",
         });
 
         var result = ConsoleDocumentConfigParser.Parse(toml);
@@ -53,7 +53,7 @@ public class ConsoleDocumentConfigParserTests
         config.Environment.Should().ContainKey("BUILD_CONFIG").WhoseValue.Should().Be("Debug");
         config.Runners.Should().HaveCount(1);
         config.Runners[0].Extensions.Should().Equal(".py", ".ipy");
-        config.Runners[0].Command.Should().Be("%run \"{script_path}\"");
+        config.Runners[0].Command.Should().Be("%run \"{resource}\"");
     }
 
     [Test]

--- a/Source/Tests/Console/ConsoleRunTargetsTests.cs
+++ b/Source/Tests/Console/ConsoleRunTargetsTests.cs
@@ -10,7 +10,7 @@ public class ConsoleRunTargetsTests
 
     private static readonly IReadOnlyList<ConsoleRunner> PythonRunners = new[]
     {
-        new ConsoleRunner(new[] { ".py", ".ipy" }, "%run \"{script_path}\""),
+        new ConsoleRunner(new[] { ".py", ".ipy" }, "%run \"{resource}\""),
     };
 
     // filePath defaults to the resource resolved under the project folder, which is what the service

--- a/Source/Workspace/Celbridge.Console/Helpers/ConsoleInvocationTemplate.cs
+++ b/Source/Workspace/Celbridge.Console/Helpers/ConsoleInvocationTemplate.cs
@@ -1,0 +1,22 @@
+namespace Celbridge.Console.Helpers;
+
+/// <summary>
+/// The command template a runner or a trigger is configured with, and the substitution that turns one into
+/// the invocation submitted to a console.
+/// </summary>
+public static class ConsoleInvocationTemplate
+{
+    /// <summary>
+    /// The placeholder a template substitutes a resource path for: the file being run for a runner, the
+    /// file that changed for a trigger.
+    /// </summary>
+    public const string ResourcePlaceholder = "{resource}";
+
+    /// <summary>
+    /// Returns the template with the resource placeholder replaced by a resource path.
+    /// </summary>
+    public static string Substitute(string commandTemplate, string resourcePath)
+    {
+        return commandTemplate.Replace(ResourcePlaceholder, resourcePath);
+    }
+}

--- a/Source/Workspace/Celbridge.Console/Helpers/ConsoleTriggerMatcher.cs
+++ b/Source/Workspace/Celbridge.Console/Helpers/ConsoleTriggerMatcher.cs
@@ -16,11 +16,6 @@ public sealed record ConsoleTrigger(
 public static class ConsoleTriggerMatcher
 {
     /// <summary>
-    /// The placeholder a trigger command substitutes the changed resource's path for.
-    /// </summary>
-    public const string ResourcePlaceholder = "{resource}";
-
-    /// <summary>
     /// Returns the resolved commands for every trigger a changed resource matches. Triggers watch the
     /// project tree only, so a resource under any other root matches nothing.
     /// </summary>
@@ -43,7 +38,7 @@ public static class ConsoleTriggerMatcher
                 continue;
             }
 
-            var invocation = trigger.CommandTemplate.Replace(ResourcePlaceholder, resource.Path);
+            var invocation = ConsoleInvocationTemplate.Substitute(trigger.CommandTemplate, resource.Path);
             invocations.Add(invocation);
         }
 

--- a/Source/Workspace/Celbridge.Console/Services/ConsoleLiveSession.cs
+++ b/Source/Workspace/Celbridge.Console/Services/ConsoleLiveSession.cs
@@ -12,6 +12,13 @@ namespace Celbridge.Console.Services;
 /// </summary>
 internal sealed class ConsoleLiveSession : IDisposable
 {
+    // Carriage return, the submit key at a shell or REPL prompt.
+    private const string SubmitKey = "\r";
+
+    // How long after the invocation text the submit key is written. Long enough that a terminal app
+    // grouping a burst of stdin does not take the two for one paste.
+    private const int SubmitKeyDelayMs = 100;
+
     // Prefixes the ready marker the injected command emits once it has cleared the screen. The random
     // per-launch suffix guards against a stale marker from a previous launch arriving late on the old
     // pty's stream. What stops the shell's own echo of the injected line matching is that the marker's
@@ -380,7 +387,7 @@ internal sealed class ConsoleLiveSession : IDisposable
     {
         // Clear any partial input (Ctrl+U, U+0015) before submitting, so the invocation is not concatenated
         // with whatever the user had half-typed at the prompt.
-        var submission = "\u0015" + invocation + "\r";
+        var text = "\u0015" + invocation;
 
         // A programmatic injection during startup queues behind the startup lines rather than racing
         // them, so a Run issued at console open still lands as type-ahead for the starting REPL.
@@ -388,12 +395,37 @@ internal sealed class ConsoleLiveSession : IDisposable
         {
             if (_startupInjectionPending)
             {
-                _bufferedInjections.Add(submission);
+                _bufferedInjections.Add(text);
                 return;
             }
         }
 
-        _terminal?.Write(submission);
+        _ = SubmitAsync(text);
+    }
+
+    // The submit key goes in a write of its own, a beat after the text. A terminal app that groups a
+    // burst of stdin into a single paste reads a carriage return inside that burst as a literal newline
+    // rather than a submit, leaving the invocation unsent at its prompt. Typing by hand does not hit this
+    // because each keystroke arrives as its own write. A shell or REPL is unaffected either way.
+    private async Task SubmitAsync(string text)
+    {
+        try
+        {
+            _terminal?.Write(text);
+
+            await Task.Delay(SubmitKeyDelayMs);
+
+            if (_disposed)
+            {
+                return;
+            }
+
+            _terminal?.Write(SubmitKey);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to submit an invocation to the console session");
+        }
     }
 
     // Ends the startup phase, on the injector's worker once the startup lines have been written: the input
@@ -409,9 +441,9 @@ internal sealed class ConsoleLiveSession : IDisposable
             _bufferedInjections.Clear();
         }
 
-        foreach (var text in bufferedInjections)
+        if (bufferedInjections.Count > 0)
         {
-            _terminal?.Write(text);
+            _ = SubmitBufferedAsync(bufferedInjections);
         }
 
         lock (_streamLock)
@@ -421,6 +453,15 @@ internal sealed class ConsoleLiveSession : IDisposable
             {
                 _markerTimeout = new Timer(_ => AbandonMarkerScan(), null, MarkerTimeoutMs, Timeout.Infinite);
             }
+        }
+    }
+
+    // Awaited in turn so buffered invocations submit in order rather than racing each other.
+    private async Task SubmitBufferedAsync(IReadOnlyList<string> submissions)
+    {
+        foreach (var submission in submissions)
+        {
+            await SubmitAsync(submission);
         }
     }
 

--- a/Source/Workspace/Celbridge.Console/Services/ConsoleSessionChannel.cs
+++ b/Source/Workspace/Celbridge.Console/Services/ConsoleSessionChannel.cs
@@ -49,6 +49,11 @@ internal sealed class ConsoleSessionChannel : ICustomEditorChannel, IConsoleSess
         Sessions.Input(_fileResource, data);
     }
 
+    public void OnSubmit(string invocation)
+    {
+        Sessions.SubmitInvocation(_fileResource, invocation);
+    }
+
     public void OnResize(int cols, int rows)
     {
         Sessions.Resize(_fileResource, cols, rows);

--- a/Source/Workspace/Celbridge.Console/Services/ConsoleSessionService.cs
+++ b/Source/Workspace/Celbridge.Console/Services/ConsoleSessionService.cs
@@ -331,7 +331,7 @@ public sealed class ConsoleSessionService : IConsoleSessionService, IDisposable
             return Result<string>.Fail($"Console '{session.Resource}' has no runner for '{extension}'");
         }
 
-        var invocation = runner.CommandTemplate.Replace("{script_path}", scriptPath);
+        var invocation = ConsoleInvocationTemplate.Substitute(runner.CommandTemplate, scriptPath);
         if (!string.IsNullOrEmpty(arguments))
         {
             invocation += " " + arguments;
@@ -353,6 +353,17 @@ public sealed class ConsoleSessionService : IConsoleSessionService, IDisposable
         session.InjectInvocation(invocation);
 
         return Result.Ok();
+    }
+
+    public void SubmitInvocation(ResourceKey resource, string invocation)
+    {
+        ConsoleLiveSession? session;
+        lock (_sessionsLock)
+        {
+            _sessions.TryGetValue(resource, out session);
+        }
+
+        session?.InjectInvocation(invocation);
     }
 
     // A session that can still accept an invocation. A session that bound a client and then lost it is a

--- a/Source/Workspace/Celbridge.Console/Services/IConsoleSessionRpc.cs
+++ b/Source/Workspace/Celbridge.Console/Services/IConsoleSessionRpc.cs
@@ -24,6 +24,7 @@ public static class ConsoleSessionRpcMethods
     public const string Attach = "console/attach";
     public const string Reopen = "console/reopen";
     public const string Input = "console/input";
+    public const string Submit = "console/submit";
     public const string Resize = "console/resize";
 
     // Host to client
@@ -46,6 +47,9 @@ public interface IConsoleSessionRpc
 
     [JsonRpcMethod(ConsoleSessionRpcMethods.Input)]
     void OnInput(string data);
+
+    [JsonRpcMethod(ConsoleSessionRpcMethods.Submit)]
+    void OnSubmit(string invocation);
 
     [JsonRpcMethod(ConsoleSessionRpcMethods.Resize)]
     void OnResize(int cols, int rows);

--- a/Source/Workspace/Celbridge.Console/Web/Console/console-toml.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console-toml.js
@@ -320,7 +320,7 @@ function parseScalar(rawValue) {
         return unescapeBasicString(rawValue.slice(1, -1));
     }
     // TOML literal (single-quoted) strings take their content verbatim, with no escape processing. Used for
-    // values that contain double quotes, such as a runner command like: '%run "{script_path}"'.
+    // values that contain double quotes, such as a runner command like: '%run "{resource}"'.
     if (rawValue.startsWith("'") && rawValue.endsWith("'") && rawValue.length >= 2) {
         return rawValue.slice(1, -1);
     }

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.js
@@ -519,11 +519,14 @@ function renderShortcutRail() {
 }
 
 // Injects a shortcut's text into the pty: clear any partial input (Ctrl+U) then submit with a return.
+// Submitted through console/submit rather than written as raw input, so the host owns how an invocation is
+// entered and confirmed at the prompt. A terminal app that reads a burst of stdin as one paste treats a
+// carriage return inside it as a newline, so the submit key cannot travel with the text.
 function injectShortcut(text) {
     if (!text) {
         return;
     }
-    client.sendNotification('console/input', { data: '\x15' + text + '\r' });
+    client.sendNotification('console/submit', { invocation: text });
     term.focus();
 }
 

--- a/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
+++ b/Source/Workspace/Celbridge.Console/Web/Console/localization/en.json
@@ -74,19 +74,19 @@
     "Console_Placeholder_ShortcutIcon": "Bootstrap icon name",
     "Console_Placeholder_ShortcutText": "Text typed into the console",
 
-    "Console_Hint_Executable": "Typed into the platform shell after it starts; blank leaves just the shell. Example: node",
+    "Console_Hint_Executable": "Blank leaves just the shell. Example: node",
     "Console_Hint_PythonVersion": "Blank uses the default. Examples: 3.13, >=3.12",
-    "Console_Hint_Arguments": "Passed to the command, one per line. Example: -q",
-    "Console_Hint_Dependencies": "Installed with uv, one per line. Examples: numpy, pandas>=2",
-    "Console_Hint_WorkingDirectory": "Relative to the project root; blank uses it. Example: tools",
-    "Console_Hint_StartupScript": "Runs each time the console opens, once it is ready. Example: import numpy as np",
-    "Console_Hint_Environment": "Injected before launch, one per line. Example: PYTHONWARNINGS=default",
+    "Console_Hint_Arguments": "Example: -q",
+    "Console_Hint_Dependencies": "Installed with uv. Examples: numpy, pandas>=2",
+    "Console_Hint_WorkingDirectory": "Relative to the project root. Blank uses the root.",
+    "Console_Hint_StartupScript": "Runs once the session is ready. Example: import numpy as np",
+    "Console_Hint_Environment": "Injected before launch. Example: PYTHONWARNINGS=default",
     "Console_Hint_Runners": "Run a file in this console from the Explorer Run menu.",
     "Console_Hint_Triggers": "Run a command in this console when a matching file in the project changes.",
     "Console_Hint_Shortcuts": "Buttons on the console rail that type a command into the session.",
-    "Console_Hint_RunnerExtensions": "File extensions this runner handles. Example: .py, .ipy",
-    "Console_Hint_RunnerCommand": "{script_path} is the path of the file being run. Example: %run \"{script_path}\"",
+    "Console_Hint_RunnerExtensions": "Example: .py, .ipy",
+    "Console_Hint_RunnerCommand": "{resource} is the path of the file being run. Example: %run \"{resource}\"",
     "Console_Hint_TriggerPattern": "Matched against project paths. Examples: data/**/*.xlsx, *.py",
     "Console_Hint_TriggerCommand": "{resource} is the path of the file that changed. Example: %run clean_data.py",
-    "Console_Hint_ShortcutIcon": "A Bootstrap Icons name. Example: bs-play-fill"
+    "Console_Hint_ShortcutIcon": "Example: bs-play-fill"
 }

--- a/Source/Workspace/Celbridge.Console/Web/Console/tests/console-config.test.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/tests/console-config.test.js
@@ -103,7 +103,7 @@ describe('buildStartConfig', () => {
     it('carries runners and fills missing fields with defaults', () => {
         const built = buildStartConfig({
             type: 'python',
-            runners: [{ extensions: ['.py'], command: '%run "{script_path}"' }],
+            runners: [{ extensions: ['.py'], command: '%run "{resource}"' }],
         });
         expect(built).toEqual({
             type: 'python',
@@ -114,7 +114,7 @@ describe('buildStartConfig', () => {
             workingDirectory: '',
             startupScript: '',
             environment: {},
-            runners: [{ extensions: ['.py'], command: '%run "{script_path}"' }],
+            runners: [{ extensions: ['.py'], command: '%run "{resource}"' }],
             triggers: [],
         });
     });

--- a/Source/Workspace/Celbridge.Console/Web/Console/tests/console-toml.test.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/tests/console-toml.test.js
@@ -83,17 +83,17 @@ describe('parseConsoleToml', () => {
         const toml = [
             '[[session.runner]]',
             'extensions = [".py", ".ipy"]',
-            'command = \'%run "{script_path}"\'',
+            'command = \'%run "{resource}"\'',
             '',
             '[[session.runner]]',
             'extensions = [".sh"]',
-            'command = "bash {script_path}"',
+            'command = "bash {resource}"',
         ].join('\n');
 
         const config = parseConsoleToml(toml);
         expect(config.runners).toEqual([
-            { extensions: ['.py', '.ipy'], command: '%run "{script_path}"' },
-            { extensions: ['.sh'], command: 'bash {script_path}' },
+            { extensions: ['.py', '.ipy'], command: '%run "{resource}"' },
+            { extensions: ['.sh'], command: 'bash {resource}' },
         ]);
     });
 
@@ -237,7 +237,7 @@ describe('serializeConsoleToml', () => {
     it('emits runner and shortcut tables', () => {
         const config = {
             ...defaultConsoleConfig(),
-            runners: [{ extensions: ['.py'], command: '%run "{script_path}"' }],
+            runners: [{ extensions: ['.py'], command: '%run "{resource}"' }],
             shortcuts: [{ label: 'Test', icon: 'bs-play-fill', text: 'pytest' }],
         };
         const toml = serializeConsoleToml(config);
@@ -271,7 +271,7 @@ describe('round-trip', () => {
             workingDirectory: 'tools',
             startupScript: 'import numpy as np\n%load_ext autoreload',
             environment: { A: '1', B: 'two words' },
-            runners: [{ extensions: ['.py', '.ipy'], command: '%run "{script_path}"' }],
+            runners: [{ extensions: ['.py', '.ipy'], command: '%run "{resource}"' }],
             triggers: [{ pattern: 'data/**/*.xlsx', command: '%run clean_data.py' }],
             shortcuts: [{ label: 'Test', icon: 'bs-play-fill', text: 'pytest -q' }],
         };

--- a/Source/Workspace/Celbridge.Python/Services/PythonSessionProvider.cs
+++ b/Source/Workspace/Celbridge.Python/Services/PythonSessionProvider.cs
@@ -44,7 +44,7 @@ public sealed class PythonSessionProvider : IConsoleSessionProvider, IDisposable
 
     public IReadOnlyList<ConsoleRunner> DefaultRunners { get; } = new[]
     {
-        new ConsoleRunner(new[] { ".py", ".ipy" }, "%run \"{script_path}\""),
+        new ConsoleRunner(new[] { ".py", ".ipy" }, "%run \"{resource}\""),
     };
 
     public async Task<Result<ConsoleStartupInvocation>> BuildStartupInvocationAsync(ConsoleSessionContext context)


### PR DESCRIPTION
This pull request standardizes how commands are injected into the console by introducing a single `{resource}` placeholder for resource paths, replacing the previous `{script_path}` usage. It also improves how invocations are submitted to the console, ensuring more reliable command execution, and updates related documentation, localization, and tests for clarity and consistency.

**Placeholder and Command Handling Updates:**

* Introduced the `ConsoleInvocationTemplate` helper to centralize the `{resource}` placeholder and substitution logic, replacing all previous uses of `{script_path}` with `{resource}` in command templates and related code. [[1]](diffhunk://#diff-e55a5958808703b4895ba7d8c952ded6f95be8e3344ba0b03511de73d6178a6fR1-R22) [[2]](diffhunk://#diff-44426e81bbd72b4f8819f45dbb372f41eb5938cfbe2bea159ff32036375762fcL334-R334) [[3]](diffhunk://#diff-7207ae812cfd83b73e4485e02958728cc90421ddfb753ec0865b7a837fd9cb0eL27-R27) [[4]](diffhunk://#diff-7275768a4aadba1ef73176cd728cc45a1dd67dbfe6de5eae1ba694ec1e9cb1b8L41-R41) [[5]](diffhunk://#diff-7275768a4aadba1ef73176cd728cc45a1dd67dbfe6de5eae1ba694ec1e9cb1b8L56-R56) [[6]](diffhunk://#diff-216323ab7a311da07597d128ba19d4d25d04f63bcbe88a61d37e66757fa26f39L13-R13) [[7]](diffhunk://#diff-1bdd462f3b1d096e69256a5595084ff9f799403ee52111cdf11728bcc35874ceL46-R41) [[8]](diffhunk://#diff-1bdd462f3b1d096e69256a5595084ff9f799403ee52111cdf11728bcc35874ceL18-L22) [[9]](diffhunk://#diff-c8996e4632a77426fd0abcb49f712fcf9abc9d9bd1e9f6e0716001059e3a33b4L86-R96) [[10]](diffhunk://#diff-418a0eb04522746d09a1a61e5a941d3b0e530daa01a1b03b33b0f5cc6b40e34aL106-R106) [[11]](diffhunk://#diff-418a0eb04522746d09a1a61e5a941d3b0e530daa01a1b03b33b0f5cc6b40e34aL117-R117) [[12]](diffhunk://#diff-8cfcb6847ec5f8ad637d976cc5f4e5780b4a900f6ee140c56c850430e8fcf11eL323-R323)

**Invocation Submission Reliability:**

* Changed how invocations are submitted to the console: the text and the submit key are now sent in separate writes with a short delay, preventing issues where terminal apps misinterpret a carriage return in a single burst as a literal newline. Buffered invocations are also submitted in order to preserve execution sequence. [[1]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L383-R428) [[2]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700L412-R446) [[3]](diffhunk://#diff-ac7f777c052c0ebf305ec5099d2dad0eec3aa740dd86b362af01f25c82d72700R459-R467)
* Updated the client-side shortcut injection to use a new `console/submit` RPC method, ensuring the host controls how invocations are entered and confirmed. [[1]](diffhunk://#diff-3d9b59aed6109e707dd80970f6b5a1415985f2ea0f057641523b6380ecbbbfc5R27) [[2]](diffhunk://#diff-3d9b59aed6109e707dd80970f6b5a1415985f2ea0f057641523b6380ecbbbfc5R51-R53) [[3]](diffhunk://#diff-91d721154804d65cff693d1e8a0092c1f57852dd8fda2a63621c7eeac09bec83R522-R529)

**API and Service Enhancements:**

* Added a new `SubmitInvocation(ResourceKey, string)` method to `IConsoleSessionService` and implemented it, allowing invocations to be submitted by resource rather than by session ID. [[1]](diffhunk://#diff-116a5d2b03106ff00ec5d6ac750aeca7d62b7ac35ab92d22767f5bb91a3258cdR135-R140) [[2]](diffhunk://#diff-44426e81bbd72b4f8819f45dbb372f41eb5938cfbe2bea159ff32036375762fcR358-R368) [[3]](diffhunk://#diff-f69e119abdadf80a4bbcbd5d5f06fd1b5c88f9b3ec3961748881d323532ce39bR52-R56)

**Documentation and Localization Updates:**

* Updated field help documentation to clarify the roles of labels, placeholders, and hints, and revised localization strings for improved clarity, especially regarding command syntax and examples. [[1]](diffhunk://#diff-b0466c7475ca96248d7a3956a729049b265aee62caa32247eb0ab3a764dae6d4R164-R175) [[2]](diffhunk://#diff-57ccb4a935378a2785ced213016b6f6e042f5e7df2ebccb50bbe4a9cd9518e05L77-R91)

**Test Coverage:**

* Updated tests and test data to use the new `{resource}` placeholder, ensuring consistency with the code changes. [[1]](diffhunk://#diff-7275768a4aadba1ef73176cd728cc45a1dd67dbfe6de5eae1ba694ec1e9cb1b8L41-R41) [[2]](diffhunk://#diff-7275768a4aadba1ef73176cd728cc45a1dd67dbfe6de5eae1ba694ec1e9cb1b8L56-R56) [[3]](diffhunk://#diff-216323ab7a311da07597d128ba19d4d25d04f63bcbe88a61d37e66757fa26f39L13-R13) [[4]](diffhunk://#diff-c8996e4632a77426fd0abcb49f712fcf9abc9d9bd1e9f6e0716001059e3a33b4L86-R96) [[5]](diffhunk://#diff-418a0eb04522746d09a1a61e5a941d3b0e530daa01a1b03b33b0f5cc6b40e34aL106-R106) [[6]](diffhunk://#diff-418a0eb04522746d09a1a61e5a941d3b0e530daa01a1b03b33b0f5cc6b40e34aL117-R117)

These changes collectively improve consistency, reliability, and clarity in how commands are constructed, injected, and documented throughout the console subsystem.Standardized runner/trigger command templates on `{resource}` (replacing `{script_path}`), introduced a shared substitution helper, and updated Python defaults plus tests/docs accordingly. Added a new `console/submit` RPC path so shortcut invocations are submitted through the host session by resource, with delayed enter-key submission in live sessions to avoid terminals treating command+CR as a pasted newline instead of executing it. Also tightened console field-hint copy and documented when inline hints should be used.