### PR TITLE
Bump Uno version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.36"
+    "Uno.Sdk": "6.6.29"
   },
   "sdk": {
     "version": "10.0.100",


### PR DESCRIPTION
This pull request updates the version of the Uno SDK used in the project. The version is incremented from 6.5.36 to 6.6.29 in the `global.json` configuration file.

- Upgraded Uno SDK version from 6.5.36 to 6.6.29 in `global.json` to ensure compatibility with the latest features and fixes.