### PR TITLE
Standardize package names to hyphen-only format

### DIFF
--- a/Source/Core/Celbridge.Foundation/Packages/BuiltInEditors.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/BuiltInEditors.cs
@@ -56,9 +56,9 @@ public static class BuiltInEditors
     /// </summary>
     public static readonly IReadOnlyList<string> AlwaysActivePackages =
     [
-        "celbridge.code-editor",
-        "celbridge.file-viewer",
-        "celbridge.spreadsheet",
+        "celbridge-code-editor",
+        "celbridge-file-viewer",
+        "celbridge-spreadsheet",
     ];
 
     /// <summary>
@@ -69,10 +69,10 @@ public static class BuiltInEditors
     /// </summary>
     public static readonly IReadOnlyList<BuiltInEditorDefinition> PackageBuiltIns =
     [
-        new BuiltInEditorDefinition(MarkdownEditorId, "celbridge.code-editor", "markdown"),
-        new BuiltInEditorDefinition(SpreadsheetEditorId, "celbridge.spreadsheet", "spreadsheet", Optional: true),
-        new BuiltInEditorDefinition(FileViewerId, "celbridge.file-viewer", "file-viewer"),
-        new BuiltInEditorDefinition(CodeEditorId, "celbridge.code-editor", "code"),
+        new BuiltInEditorDefinition(MarkdownEditorId, "celbridge-code-editor", "markdown"),
+        new BuiltInEditorDefinition(SpreadsheetEditorId, "celbridge-spreadsheet", "spreadsheet", Optional: true),
+        new BuiltInEditorDefinition(FileViewerId, "celbridge-file-viewer", "file-viewer"),
+        new BuiltInEditorDefinition(CodeEditorId, "celbridge-code-editor", "code"),
     ];
 
     /// <summary>

--- a/Source/Core/Celbridge.Foundation/Packages/PackageConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/PackageConstants.cs
@@ -23,7 +23,7 @@ public static class PackageConstants
     /// <summary>
     /// Name prefix reserved for first-party packages shipped inside Celbridge module DLLs.
     /// </summary>
-    public const string ReservedNamePrefix = "celbridge.";
+    public const string ReservedNamePrefix = "celbridge-";
 
     /// <summary>
     /// Name of the server-managed alias that points at a package's highest live version.

--- a/Source/Core/Celbridge.Foundation/Packages/PackageDiscoveryReport.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/PackageDiscoveryReport.cs
@@ -18,13 +18,6 @@ public enum PackageLoadFailureReason
     ReservedNamePrefix,
 
     /// <summary>
-    /// A project package used a dotted name but no namespace registry exists yet
-    /// to validate the prefix. Only flat names are currently permitted for
-    /// project packages.
-    /// </summary>
-    UnregisteredNamespace,
-
-    /// <summary>
     /// The package name collides with another loaded package. Covers bundled vs
     /// bundled, project vs bundled, and project vs project conflicts.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Packages/PackageName.cs
+++ b/Source/Core/Celbridge.Foundation/Packages/PackageName.cs
@@ -53,31 +53,4 @@ public static class PackageName
         return true;
     }
 
-    /// <summary>
-    /// Returns true if the string is a well-formed bundled package name: one
-    /// or more valid package name segments separated by single dots (e.g.
-    /// "celbridge.notes"). Dotted names are internal to first-party bundled
-    /// packages and are never published to a workshop.
-    /// </summary>
-    public static bool IsValidBundledName(string name)
-    {
-        if (string.IsNullOrEmpty(name) ||
-            name.Length > PackageConstants.MaxNameLength)
-        {
-            return false;
-        }
-
-        // An empty segment (leading, trailing, or consecutive dots) fails the
-        // per-segment check.
-        var segments = name.Split('.');
-        foreach (var segment in segments)
-        {
-            if (!IsValid(segment))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/Source/Core/Celbridge.Tools/Guides/Concepts/webview_devtools.md
+++ b/Source/Core/Celbridge.Tools/Guides/Concepts/webview_devtools.md
@@ -13,7 +13,7 @@ The `webview_*` tools give the agent a feedback loop into a running contribution
 
 ## Confirm the right editor opened the document
 
-`document_get_state` returns an `editorId` per open document (e.g. `celbridge.html-viewer`, `celbridge.code-editor`). If you opened a `.html` file expecting the HTML viewer but `editorId` is the code editor, devtools will not work against it — check before any `webview_*` call.
+`document_get_state` returns an `editorId` per open document (e.g. `celbridge.html-viewer`, `celbridge.code`). If you opened a `.html` file expecting the HTML viewer but `editorId` is the code editor, devtools will not work against it — check before any `webview_*` call.
 
 ## Synthetic events have `isTrusted: false`
 

--- a/Source/Core/Celbridge.Tools/Guides/Tools/document_get_state.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/document_get_state.md
@@ -15,4 +15,4 @@ A JSON object with these fields:
   - `sectionIndex` (int) — which section (0 = left, 1 = center, 2 = right) the tab lives in.
   - `tabOrder` (int) — position within that section's tab strip.
   - `isActive` (bool) — `true` for the active tab in its section.
-  - `editorId` (string) — the bound editor id (e.g. `"celbridge.code-editor"`), or empty when no editor is bound yet.
+  - `editorId` (string) — the bound editor id (e.g. `"celbridge.code"`), or empty when no editor is bound yet.

--- a/Source/Core/Celbridge.UserInterface/Helpers/PackageDisplayText.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/PackageDisplayText.cs
@@ -42,14 +42,4 @@ public static class PackageDisplayText
 
         return string.Join(" ", words);
     }
-
-    /// <summary>
-    /// Humanizes the last dot-separated segment of an identifier (e.g. "celbridge.notes" becomes
-    /// "Notes").
-    /// </summary>
-    public static string HumanizeLastSegment(string identifier)
-    {
-        var segments = identifier.Split('.');
-        return Humanize(segments[^1]);
-    }
 }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/README.md
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/README.md
@@ -1,4 +1,4 @@
-# celbridge.code-editor
+# celbridge-code-editor
 
 Monaco-based text editor contribution package. Hosts arbitrary code files and — when
 the package's options opt in — an adjacent preview pane driven by a format-specific

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/package.toml
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.code-editor"
+name = "celbridge-code-editor"
 title = "CodeEditor_Package_Name"
 
 [contributes]

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/package.toml
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/FileViewer/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.file-viewer"
+name = "celbridge-file-viewer"
 title = "FileViewer_Package_Name"
 
 [contributes]

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/package.toml
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.notes"
+name = "celbridge-notes"
 title = "Notes_Package_Name"
 
 [contributes]

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/SceneViewer/package.toml
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/SceneViewer/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.scene-viewer"
+name = "celbridge-scene-viewer"
 title = "SceneViewer_Package_Name"
 
 [contributes]

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/package.toml
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.utility-demo"
+name = "celbridge-utility-demo"
 title = "UtilityDemo_Package"
 
 [contributes]

--- a/Source/Modules/Celbridge.Spreadsheet/Module.cs
+++ b/Source/Modules/Celbridge.Spreadsheet/Module.cs
@@ -10,7 +10,7 @@ namespace Celbridge.Spreadsheet;
 
 /// <summary>
 /// SpreadJS spreadsheet editor integration.
-/// Bundles the "celbridge.spreadsheet" package.
+/// Bundles the "celbridge-spreadsheet" package.
 /// </summary>
 public class Module : IModule
 {

--- a/Source/Modules/Celbridge.Spreadsheet/Package/package.toml
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.spreadsheet"
+name = "celbridge-spreadsheet"
 title = "Spreadsheet_Package_Name"
 
 [contributes]

--- a/Source/Modules/Celbridge.Spreadsheet/Services/SyntheticOriginEditorLoader.cs
+++ b/Source/Modules/Celbridge.Spreadsheet/Services/SyntheticOriginEditorLoader.cs
@@ -13,7 +13,7 @@ namespace Celbridge.Spreadsheet.Services;
 /// </summary>
 public sealed class SyntheticOriginEditorLoader : ICustomEditorLoader
 {
-    private const string SpreadsheetPackageName = "celbridge.spreadsheet";
+    private const string SpreadsheetPackageName = "celbridge-spreadsheet";
     private const string SyntheticHost = "spreadjs.celbridge";
 
     private readonly IFileServer _fileServer;

--- a/Source/Modules/Celbridge.Spreadsheet/SpreadsheetBundledPackageProvider.cs
+++ b/Source/Modules/Celbridge.Spreadsheet/SpreadsheetBundledPackageProvider.cs
@@ -4,7 +4,7 @@ using Celbridge.Packages;
 namespace Celbridge.Spreadsheet;
 
 /// <summary>
-/// Registers the "celbridge.spreadsheet" package when the SpreadJS library is present. The public GitHub
+/// Registers the "celbridge-spreadsheet" package when the SpreadJS library is present. The public GitHub
 /// repo does not ship the licensed library files, so the package is skipped when they are absent.
 /// </summary>
 public sealed class SpreadsheetBundledPackageProvider : IBundledPackageProvider
@@ -44,7 +44,7 @@ public sealed class SpreadsheetBundledPackageProvider : IBundledPackageProvider
 
         if (!isLibraryPresent)
         {
-            _logger.LogInformation("SpreadJS library not found under '{LibraryFolder}'; skipping celbridge.spreadsheet package registration", libraryFolder);
+            _logger.LogInformation("SpreadJS library not found under '{LibraryFolder}'; skipping celbridge-spreadsheet package registration", libraryFolder);
 
             return Array.Empty<BundledPackageDescriptor>();
         }

--- a/Source/Tests/Packages/FileTypeProviderTests.cs
+++ b/Source/Tests/Packages/FileTypeProviderTests.cs
@@ -238,7 +238,7 @@ public class PackageServiceDocumentTypeTests
 
         File.WriteAllText(Path.Combine(packageDir, "package.toml"), """
             [package]
-            name = "test.widget"
+            name = "test-widget"
             title = "Widget"
 
             [contributes]
@@ -378,7 +378,7 @@ public class PackageServiceDocumentTypeTests
         var packageDir = Path.Combine(_tempProjectFolder, "bundled", dirName);
         Directory.CreateDirectory(packageDir);
 
-        var bundledName = $"test.{dirName}";
+        var bundledName = $"test-{dirName}";
 
         File.WriteAllText(Path.Combine(packageDir, "package.toml"), $"""
             [package]

--- a/Source/Tests/Packages/ManifestTests.cs
+++ b/Source/Tests/Packages/ManifestTests.cs
@@ -29,7 +29,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.my-editor"
+            name = "test-my-editor"
             title = "My Editor"
 
             [contributes]
@@ -223,12 +223,9 @@ public class ManifestTests
         result.FirstErrorMessage.Should().Contain("invalid");
     }
 
-    [TestCase("celbridge.notes", Description = "reserved namespace prefix")]
-    [TestCase("my-org.my-tool", Description = "dotted namespace")]
-    [TestCase("a.b", Description = "minimal dotted")]
-    [TestCase("a.b.c.d", Description = "deeply nested")]
-    [TestCase("digits123.allowed", Description = "digits in namespace")]
-    [TestCase("hyphens-are-fine.here", Description = "hyphens in namespace")]
+    [TestCase("celbridge-notes", Description = "reserved name prefix")]
+    [TestCase("digits123", Description = "digits")]
+    [TestCase("hyphens-are-fine", Description = "interior hyphens")]
     [TestCase("flat-name", Description = "flat global namespace name")]
     [TestCase("simple", Description = "single-word flat name")]
     [TestCase("a", Description = "single character")]
@@ -299,7 +296,7 @@ public class ManifestTests
         // References in [contributes].editors must use the ".editor.toml" extension.
         WritePackageToml("""
             [package]
-            name = "test.wrong-ext"
+            name = "test-wrong-ext"
             title = "WrongExtension"
 
             [contributes]
@@ -328,7 +325,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.missing-editor"
+            name = "test-missing-editor"
             title = "MissingEditor"
 
             [contributes]
@@ -345,7 +342,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.duplicate"
+            name = "test-duplicate"
             title = "Duplicate"
 
             [contributes]
@@ -387,7 +384,7 @@ public class ManifestTests
         // silently skipped.
         WritePackageToml("""
             [package]
-            name = "test.partial"
+            name = "test-partial"
             title = "Partial"
 
             [contributes]
@@ -724,7 +721,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.multi"
+            name = "test-multi"
             title = "Multi"
 
             [contributes]
@@ -766,7 +763,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.shared"
+            name = "test-shared"
             title = "Shared"
 
             [contributes]
@@ -810,7 +807,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.permissions-section"
+            name = "test-permissions-section"
             title = "PermissionsSection"
 
             [permissions]
@@ -831,7 +828,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.no-permissions"
+            name = "test-no-permissions"
             title = "NoPermissions"
 
             [contributes]
@@ -848,7 +845,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.mixed"
+            name = "test-mixed"
             title = "Mixed"
 
             [permissions]
@@ -868,7 +865,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.secrets"
+            name = "test-secrets"
             title = "WithSecrets"
 
             [contributes]
@@ -896,7 +893,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.no-secrets"
+            name = "test-no-secrets"
             title = "NoSecrets"
 
             [contributes]
@@ -1730,7 +1727,7 @@ public class ManifestTests
     {
         WritePackageToml("""
             [package]
-            name = "test.widget"
+            name = "test-widget"
             title = "Widget"
 
             [contributes]

--- a/Source/Tests/Packages/PackageNameTests.cs
+++ b/Source/Tests/Packages/PackageNameTests.cs
@@ -54,38 +54,14 @@ public class PackageNameTests
         PackageName.IsValid(overLongName).Should().BeFalse();
     }
 
-    [TestCase("celbridge.notes", Description = "reserved bundled namespace")]
+    // One grammar for every origin, so a bundled name is an ordinary name carrying the reserved prefix.
+    [TestCase("celbridge-notes", Description = "bundled name")]
+    [TestCase("celbridge.notes", Description = "dotted name rejected for every origin")]
     [TestCase("a.b", Description = "minimal dotted")]
-    [TestCase("a.b.c.d", Description = "deeply nested")]
-    [TestCase("digits123.allowed", Description = "digits in namespace")]
-    [TestCase("hyphens-are-fine.here", Description = "hyphens in segments")]
-    [TestCase("flat-name", Description = "flat names are also valid bundled names")]
-    public void IsValidBundledName_WellFormedNames_Accepted(string name)
+    [TestCase("Celbridge-Notes", Description = "uppercase rejected")]
+    [TestCase("has_underscore", Description = "underscore rejected")]
+    public void IsValid_DottedAndMalformedNames_Rejected(string name)
     {
-        PackageName.IsValidBundledName(name).Should().BeTrue();
-    }
-
-    [TestCase("", Description = "empty")]
-    [TestCase(".", Description = "bare dot rejected")]
-    [TestCase(".leading-dot", Description = "leading dot rejected")]
-    [TestCase("trailing-dot.", Description = "trailing dot rejected")]
-    [TestCase("double..dot", Description = "consecutive dots rejected")]
-    [TestCase("Celbridge.Notes", Description = "uppercase rejected")]
-    [TestCase("has_underscore.notes", Description = "underscore rejected")]
-    [TestCase("has spaces.notes", Description = "whitespace rejected")]
-    [TestCase("celbridge.-notes", Description = "segment with leading hyphen rejected")]
-    [TestCase("celbridge.no--tes", Description = "segment with consecutive hyphens rejected")]
-    public void IsValidBundledName_MalformedNames_Rejected(string name)
-    {
-        PackageName.IsValidBundledName(name).Should().BeFalse();
-    }
-
-    [Test]
-    public void IsValidBundledName_NameOverMaxLength_Rejected()
-    {
-        var segment = new string('a', PackageConstants.MaxNameLength);
-        var overLongName = $"celbridge.{segment}";
-
-        PackageName.IsValidBundledName(overLongName).Should().BeFalse();
+        PackageName.IsValid(name).Should().Be(name == "celbridge-notes");
     }
 }

--- a/Source/Tests/Packages/PackageRegistryTests.cs
+++ b/Source/Tests/Packages/PackageRegistryTests.cs
@@ -430,7 +430,7 @@ public class PackageServiceTests
     [Test]
     public async Task RegisterPackages_IncludesModulePackages()
     {
-        var bundledDir = CreateBundledPackage("bundled-editor", "celbridge.bundled", "Bundled", ".bnd");
+        var bundledDir = CreateBundledPackage("bundled-editor", "celbridge-bundled", "Bundled", ".bnd");
 
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = bundledDir } });
 
@@ -445,7 +445,7 @@ public class PackageServiceTests
     public async Task RegisterPackages_CombinesProjectAndBundled()
     {
         CreateProjectPackage("proj-editor", "proj", "Project", ".proj");
-        var bundledDir = CreateBundledPackage("bundled-editor", "celbridge.bundled", "Bundled", ".bnd");
+        var bundledDir = CreateBundledPackage("bundled-editor", "celbridge-bundled", "Bundled", ".bnd");
 
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = bundledDir } });
 
@@ -461,8 +461,8 @@ public class PackageServiceTests
     [Test]
     public async Task RegisterPackages_ProjectPackageWithReservedNamePrefix_Skipped()
     {
-        // Project packages may not claim a name under the reserved "celbridge." namespace.
-        CreateProjectPackage("impostor", "celbridge.notes", "Impostor Notes", ".imp");
+        // Project packages may not claim a name under the reserved "celbridge-" prefix.
+        CreateProjectPackage("impostor", "celbridge-notes", "Impostor Notes", ".imp");
         CreateProjectPackage("legit", "legit", "Legit", ".legit");
 
         await _service.RegisterPackagesAsync(_tempProjectFolder);
@@ -536,7 +536,7 @@ public class PackageServiceTests
     public async Task RegisterPackages_BundledPackageWithCelExtension_Skipped()
     {
         // The reservation applies to bundled and project packages alike.
-        var reservedDir = CreateBundledPackage("bundled-reserved", "celbridge.reserved", "Bundled Reserved", ".cel");
+        var reservedDir = CreateBundledPackage("bundled-reserved", "celbridge-reserved", "Bundled Reserved", ".cel");
 
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = reservedDir } });
 
@@ -548,8 +548,8 @@ public class PackageServiceTests
     [Test]
     public async Task RegisterPackages_BundledPackageWithReservedNamePrefix_Allowed()
     {
-        // Bundled packages are the intended owners of the "celbridge." namespace.
-        var bundledDir = CreateBundledPackage("bundled-official", "celbridge.notes", "Official Notes", ".note");
+        // Bundled packages are the intended owners of the "celbridge-" prefix.
+        var bundledDir = CreateBundledPackage("bundled-official", "celbridge-notes", "Official Notes", ".note");
 
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = bundledDir } });
 
@@ -557,7 +557,7 @@ public class PackageServiceTests
 
         var contributions = _service.GetAllEditors();
         contributions.Should().HaveCount(1);
-        contributions[0].Package.Name.Should().Be("celbridge.notes");
+        contributions[0].Package.Name.Should().Be("celbridge-notes");
     }
 
     [Test]
@@ -565,8 +565,8 @@ public class PackageServiceTests
     {
         // Two bundled packages with the same name is a first-party build bug.
         // Both are skipped rather than silently picking a winner.
-        var dirA = CreateBundledPackage("bundled-a", "celbridge.conflict", "Conflict A", ".a");
-        var dirB = CreateBundledPackage("bundled-b", "celbridge.conflict", "Conflict B", ".b");
+        var dirA = CreateBundledPackage("bundled-a", "celbridge-conflict", "Conflict A", ".a");
+        var dirB = CreateBundledPackage("bundled-b", "celbridge-conflict", "Conflict B", ".b");
 
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor>
         {
@@ -757,16 +757,16 @@ public class PackageServiceTests
     [Test]
     public async Task GetContributingPackage_ActiveContributionId_ReturnsThePackage()
     {
-        var bundledDir = CreateBundledPackage("notes-pkg", "celbridge.notes", "Notes", ".note");
+        var bundledDir = CreateBundledPackage("notes-pkg", "celbridge-notes", "Notes", ".note");
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = bundledDir } });
         SetProjectConfig();
 
         await _service.RegisterPackagesAsync(_tempProjectFolder);
 
-        var package = _service.GetContributingPackage(EditorId.Create("celbridge.notes", "editor"));
+        var package = _service.GetContributingPackage(EditorId.Create("celbridge-notes", "editor"));
 
         package.Should().NotBeNull();
-        package!.Info.Name.Should().Be("celbridge.notes");
+        package!.Info.Name.Should().Be("celbridge-notes");
     }
 
     [Test]
@@ -786,13 +786,13 @@ public class PackageServiceTests
     {
         // Editors are addressed by the "{package}.{contribution}" reference, not the bare package
         // name, so a lookup by package name alone resolves to nothing.
-        var bundledDir = CreateBundledPackage("notes-pkg", "celbridge.notes", "Notes", ".note");
+        var bundledDir = CreateBundledPackage("notes-pkg", "celbridge-notes", "Notes", ".note");
         _bundledPackageProvider.GetBundledPackages().Returns(new List<BundledPackageDescriptor> { new() { Folder = bundledDir } });
         SetProjectConfig();
 
         await _service.RegisterPackagesAsync(_tempProjectFolder);
 
-        var package = _service.GetContributingPackage(new EditorId("celbridge.notes"));
+        var package = _service.GetContributingPackage(new EditorId("celbridge-notes"));
 
         package.Should().BeNull();
     }
@@ -936,7 +936,7 @@ public class PackageServiceTests
 
         File.WriteAllText(Path.Combine(packageDir, "package.toml"), """
             [package]
-            name = "celbridge.code-editor"
+            name = "celbridge-code-editor"
             title = "Code Editor"
 
             [contributes]
@@ -968,7 +968,7 @@ public class PackageServiceTests
 
         File.WriteAllText(Path.Combine(packageDir, "package.toml"), """
             [package]
-            name = "celbridge.spreadsheet"
+            name = "celbridge-spreadsheet"
             title = "Spreadsheet"
 
             [contributes]

--- a/Source/Workspace/Celbridge.Console/Services/ConsoleSessionChannelProvider.cs
+++ b/Source/Workspace/Celbridge.Console/Services/ConsoleSessionChannelProvider.cs
@@ -10,7 +10,7 @@ namespace Celbridge.Console.Services;
 public sealed class ConsoleSessionChannelProvider : ICustomEditorChannelProvider
 {
     // This provider only backs the console package, so it matches by name.
-    private const string ConsolePackageName = "celbridge.console";
+    private const string ConsolePackageName = "celbridge-console";
 
     private readonly IServiceProvider _serviceProvider;
 

--- a/Source/Workspace/Celbridge.Console/Web/Console/package.toml
+++ b/Source/Workspace/Celbridge.Console/Web/Console/package.toml
@@ -1,5 +1,5 @@
 [package]
-name = "celbridge.console"
+name = "celbridge-console"
 title = "Console_Package_Name"
 
 [contributes]

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -346,7 +346,7 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         // file server, so register this package's folder there. The resolved loader decides where the
         // entry page itself loads from.
         var fileServer = _serviceProvider.GetRequiredService<IFileServer>();
-        var packageUrlName = _contribution.Package.Name.Replace('.', '-');
+        var packageUrlName = _contribution.Package.Name;
 
         fileServer.RegisterPackageFolder(packageUrlName, _contribution.Package.PackageFolder);
 

--- a/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageManifestLoader.cs
@@ -100,11 +100,9 @@ public static class PackageManifestLoader
                 return Result.Fail($"Package missing required '{NameKey}' field: {packageTomlPath}");
             }
 
-            // Bundled first-party packages use dotted names (e.g. "celbridge.notes"),
-            // so structural validation accepts the dotted form for every origin.
-            // Project discovery rejects dotted names downstream with a specific
-            // failure reason.
-            if (!PackageName.IsValidBundledName(packageName))
+            // One name grammar for every origin. The reserved "celbridge-" prefix is what marks a
+            // bundled package, so a project package cannot impersonate one.
+            if (!PackageName.IsValid(packageName))
             {
                 return Result.Fail($"Package has invalid '{NameKey}' value '{packageName}': {packageTomlPath}. Package names must be lowercase ASCII letters and digits with single interior hyphens, at most {PackageConstants.MaxNameLength} characters.");
             }

--- a/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
+++ b/Source/Workspace/Celbridge.Packages/Services/PackageRegistry.cs
@@ -827,21 +827,6 @@ public class PackageRegistry
                 continue;
             }
 
-            // Any other dotted name claims a namespace whose ownership a registry
-            // would need to validate. Until such a registry exists, project
-            // packages must use flat global-namespace names.
-            if (package.Info.Name.Contains('.'))
-            {
-                _logger.LogWarning(
-                    $"Skipping project package '{package.Info.Name}' with dotted name: no namespace registry is available to validate the prefix.");
-                failures.Add(new PackageLoadFailure
-                {
-                    Folder = packageFolder,
-                    PackageName = package.Info.Name,
-                    Reason = PackageLoadFailureReason.UnregisteredNamespace
-                });
-                continue;
-            }
 
             if (_bundledPackages.Any(b => b.Info.Name.Equals(package.Info.Name, StringComparison.Ordinal)))
             {

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PackagesSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PackagesSectionViewModel.cs
@@ -236,7 +236,7 @@ public class PackagesSectionViewModel : ProjectSettingsSectionViewModel
         string name;
         if (string.IsNullOrWhiteSpace(title))
         {
-            name = PackageDisplayText.HumanizeLastSegment(package.Info.Name);
+            name = PackageDisplayText.Humanize(package.Info.Name);
         }
         else
         {


### PR DESCRIPTION
This pull request standardizes package naming conventions across the codebase, switching from dot-separated (`celbridge.something`) to hyphen-separated (`celbridge-something`) names for all first-party and test packages. It also removes support for dotted package names, updates documentation and tests, and cleans up several obsolete methods. These changes ensure consistency and prevent ambiguity in package identification.

**Package Naming Standardization**

* Renamed all first-party package names from dot-separated (e.g., `celbridge.code-editor`) to hyphen-separated (e.g., `celbridge-code-editor`) in package manifests, code references, and documentation. [[1]](diffhunk://#diff-493f65c401a0249f06840828e73ad9720b078b6c20df280dd2111d8822cbe5b4L59-R61) [[2]](diffhunk://#diff-493f65c401a0249f06840828e73ad9720b078b6c20df280dd2111d8822cbe5b4L72-R75) [[3]](diffhunk://#diff-1420c09d44443a0da5f51bdd4c3d0305bc5c348e7632d62276342855f0877c75L26-R26) [[4]](diffhunk://#diff-5b723cfd233319b6f6d42a0cceeeb46eaf0e741977f140796ed57e2626a90564L1-R1) [[5]](diffhunk://#diff-f8ea36ee9720ec4dbe025812fbaf75d704dd176e0a2f22b8a0c2ae511bf30c53L2-R2) [[6]](diffhunk://#diff-8f3d169f301c5012be2af6513229460cedb8c5f126e70beda4d5d1ac65786273L2-R2) [[7]](diffhunk://#diff-16884b54a0197e613b1bffd37304469d5b732db6d48ff490646be2804f0c8abcL2-R2) [[8]](diffhunk://#diff-5df248895da22549cab7735a25163c9beedde2d4e1edf7442f835be1ef3a8f96L2-R2) [[9]](diffhunk://#diff-1d2cd1484abf0ef20c0fea09845869abf5d7fbcad5f585b029eefaf036f5ab0dL2-R2) [[10]](diffhunk://#diff-e466da97b420a08b81b35229945de091b49288512982d1196cab564fafbebc3eL13-R13) [[11]](diffhunk://#diff-41830f674c49a5cb97016810b0bf77a2820958a328bcaa3b4a8c4c9dd0cac967L16-R16) [[12]](diffhunk://#diff-d4bdae1b65511dcc08d44004bf8920994f3c885c62c9e6618bca741bc2cdfcbdL7-R7) [[13]](diffhunk://#diff-d4bdae1b65511dcc08d44004bf8920994f3c885c62c9e6618bca741bc2cdfcbdL47-R47) [[14]](diffhunk://#diff-e61a72fe043023a28b64cc825ce69dcb32313868b2fc94f7fbdbfa5ce2782e03L2-R2)

* Updated the reserved name prefix for first-party packages from `"celbridge."` to `"celbridge-"` in `PackageConstants`.

**Code and API Changes**

* Removed the `IsValidBundledName` method and the `UnregisteredNamespace` enum value, eliminating support for dotted package names. [[1]](diffhunk://#diff-01237b415911ed500d24a57747130a6070548e2f3f4dfb3e6cc13cb7673344b9L56-L82) [[2]](diffhunk://#diff-949648ba30af227521c7a01762114d560856bed197759579e1f02e88c15a4e36L20-L26)

**Documentation Updates**

* Updated guides and API documentation to use the new hyphen-separated package names and editor IDs (e.g., `"celbridge.code"` instead of `"celbridge.code-editor"`). [[1]](diffhunk://#diff-d6d7f0c59b5b83af8cf523f2b5cb85d2fcd873e28deb5d450552a4a3b47f68a9L16-R16) [[2]](diffhunk://#diff-8eb92f456a704939a51fe96a12decff6fdef8397ac672a1de2a3944e23baa65dL18-R18)

**Test Updates**

* Updated all test package names to use hyphen-separated names, and adjusted test cases to reflect the new naming rules. [[1]](diffhunk://#diff-90bbb395b9d77046a92b8e37b31a60c8bf1265782e30af9404ad468df2847d20L241-R241) [[2]](diffhunk://#diff-90bbb395b9d77046a92b8e37b31a60c8bf1265782e30af9404ad468df2847d20L381-R381) [[3]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L32-R32) [[4]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L226-R228) [[5]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L302-R299) [[6]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L331-R328) [[7]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L348-R345) [[8]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L390-R387) [[9]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L727-R724) [[10]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L769-R766) [[11]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L813-R810) [[12]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L834-R831) [[13]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L851-R848) [[14]](diffhunk://#diff-a84429ed51a1ef61df1ca4529424f783a159e29ea5379b2dd4e49e970f1f8a76L871-R868)

**Code Cleanup**

* Removed the unused `HumanizeLastSegment` method from `PackageDisplayText.cs`.

These changes bring consistency to package naming and help avoid future confusion or conflicts.Standardized package naming across the codebase from dotted identifiers (for example, `celbridge.code-editor`) to flat hyphenated names (for example, `celbridge-code-editor`). This updates built-in package references, manifests, editor/docs examples, and package URL handling so names are used directly without dot-to-hyphen rewriting. It also simplifies validation by removing the separate bundled-name grammar and dotted-name namespace failure path, leaving a single name rule with the reserved `celbridge-` prefix for first-party packages.