### PR TITLE
Set initial WKWebView viewport size during Skia initialization

### DIFF
--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -348,6 +348,25 @@ public static class MacOSWebViewInterop
     }
 
     /// <summary>
+    /// Sets the native view's frame, which is what the page reads as its viewport. Uno arranges the frame
+    /// only while the control is in the visual tree, so a surface that loads before it is ever arranged
+    /// (a document restored into a background tab, a utility that runs from project load) would otherwise
+    /// report a zero-sized window to its page.
+    /// </summary>
+    public static void SetViewportSize(IntPtr webView, double width, double height)
+    {
+        var frame = new CGRect
+        {
+            X = 0,
+            Y = 0,
+            Width = width,
+            Height = height
+        };
+
+        SendMessageVoidCGRect(webView, GetSelector("setFrame:"), frame);
+    }
+
+    /// <summary>
     /// Delivers a native key event straight to the WKWebView's keyDown: handler, bypassing the managed key
     /// pipeline. Used for keys the managed pipeline would otherwise consume (Tab), so the page can apply
     /// its own behaviour, such as moving focus between its form fields. A direct method call, not an event

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -79,6 +79,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
                 {
                     MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
                     CheckBackgroundPageActivityOnce(nativeWebViewHandle);
+                    ApplyInitialViewportSize(nativeWebViewHandle);
                 }
                 else
                 {
@@ -115,6 +116,33 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         {
             _logger.LogWarning("Could not remove the WebView script message handler: {Detail}", detail);
         }
+    }
+
+    // Used until the window can supply a size, and as the floor for a window too small to lay a page out in.
+    // A page that loads at this size is corrected by the arrange that follows when its surface is shown.
+    private const double MinimumViewportWidth = 1024;
+    private const double MinimumViewportHeight = 768;
+
+    // Gives the native view a usable frame before anything loads into it. Uno arranges the frame only while
+    // the control is in the visual tree, so a surface that loads while it is not (a document restored into a
+    // background tab, a utility running from project load) reports a zero-sized window to its page: layout
+    // collapses, and a page that derives geometry from the viewport at startup divides by zero and stays
+    // broken even after the real arrange arrives.
+    private void ApplyInitialViewportSize(IntPtr nativeWebViewHandle)
+    {
+        var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
+
+        double width = MinimumViewportWidth;
+        double height = MinimumViewportHeight;
+
+        if (userInterfaceService.MainWindow is Window mainWindow
+            && mainWindow.Content is FrameworkElement windowContent)
+        {
+            width = Math.Max(windowContent.ActualWidth, MinimumViewportWidth);
+            height = Math.Max(windowContent.ActualHeight, MinimumViewportHeight);
+        }
+
+        MacOSWebViewInterop.SetViewportSize(nativeWebViewHandle, width, height);
     }
 
     // WebKit suspends a hidden page's process, which stalls host-to-editor RPC for a background document


### PR DESCRIPTION
This pull request addresses an issue where web pages loaded into a `WebView` on macOS could incorrectly report a zero-sized viewport if the control was not yet arranged in the visual tree (e.g., background tabs or utilities loaded at startup). The changes ensure that the native view is assigned a usable frame before any content loads, preventing layout collapses and related errors.

The most important changes are:

**Viewport Initialization and Sizing**

* Added a new method `SetViewportSize` to `MacOSWebViewInterop` that sets the native view's frame, ensuring the page has a valid viewport size even if the control isn't yet arranged.
* Introduced `ApplyInitialViewportSize` in `SkiaWebViewAdapter`, which sets a minimum viewport size on the native view before any content loads, using either the window's actual size or a defined minimum.
* Defined `MinimumViewportWidth` and `MinimumViewportHeight` constants to provide a fallback size for the viewport.
* Updated the WebView initialization flow to call `ApplyInitialViewportSize` after retaining the native view, ensuring the frame is set early in the lifecycle.Add `MacOSWebViewInterop.SetViewportSize` and call it during Skia web view initialization so native WKWebView instances get a non-zero frame before first arrange. This prevents background-loaded pages from seeing a zero-sized viewport at startup, avoiding collapsed layout and startup math errors until normal layout sizing takes over.