### PR TITLE
Use shared theme token for code editor toolbar background

### DIFF
--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css
@@ -134,8 +134,8 @@
     --cel-search-highlight: #FFD966;
     --cel-list-selected-bg: rgba(0, 120, 212, 0.235);
 
-    /* Stepped off the content background, which an editor's body takes, so a control has no more contrast
-       against a content surface than the same control has against chrome. */
+    /* Stepped off the content background, which an editor's body takes, by the same amount a control used to
+       step off chrome, so a control on a content surface reads no more inflated than it did before. */
     --cel-control-bg: #2B2C30;
     --cel-control-hover-bg: #36383C;
     --cel-control-border: #323335;

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/css/editor.css
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/css/editor.css
@@ -4,16 +4,17 @@ html, body {
     overflow: hidden;
 }
 
-/* Theme via [data-theme] attribute (WebView2 doesn't reliably re-evaluate prefers-color-scheme). The accent
-   and toolbar-foreground colors derive from the shared tokens (celbridge-tokens.css, linked before this file),
-   so they are single-sourced from Colors.xaml and need no per-theme override here. The remaining tokens are
-   the editor's own translucent divider, toolbar surface, and button-overlay colors, which have no shared
-   equivalent and stay defined per theme below. */
+/* Theme via [data-theme] attribute (WebView2 doesn't reliably re-evaluate prefers-color-scheme). The accent,
+   toolbar-foreground and toolbar-surface colors derive from the shared tokens (celbridge-tokens.css, linked
+   before this file), so they are single-sourced from Colors.xaml and need no per-theme override here. The
+   toolbar takes the chrome role, so it reads as one band with the native tab strip above it and steps off
+   the Monaco canvas below. The remaining tokens are the editor's own translucent divider and button-overlay
+   colors, which have no shared equivalent and stay defined per theme below. */
 :root {
     --accent-color: var(--cel-accent);
     --toolbar-btn-fg: var(--cel-text-primary);
+    --toolbar-bg: var(--cel-chrome-bg);
     --divider-base-color: rgba(0, 0, 0, 0.0803);
-    --toolbar-bg: #F3F3F3;
     --toolbar-border: rgba(0, 0, 0, 0.0803);
     --toolbar-btn-hover-bg: rgba(0, 0, 0, 0.0402);
     --toolbar-btn-active-bg: rgba(0, 120, 212, 0.12);
@@ -22,7 +23,6 @@ html, body {
 
 [data-theme="dark"] {
     --divider-base-color: rgba(255, 255, 255, 0.0837);
-    --toolbar-bg: #202020;
     --toolbar-border: rgba(255, 255, 255, 0.0837);
     --toolbar-btn-hover-bg: rgba(255, 255, 255, 0.0605);
     --toolbar-btn-active-bg: rgba(96, 205, 255, 0.18);


### PR DESCRIPTION
This pull request updates the CSS theming for the code editor and shared tokens to improve consistency and clarify comments. The main changes involve sourcing toolbar background color from shared tokens, updating comments for clarity, and ensuring consistent theming between light and dark modes.

**Theming and color sourcing improvements:**

* The toolbar background (`--toolbar-bg`) in `editor.css` now uses the shared token `--cel-chrome-bg` instead of a hardcoded value, ensuring it stays consistent with the application's overall chrome color.
* In dark mode, the toolbar background override is removed so it also uses the shared token, keeping theming consistent between light and dark.

**Documentation and comment updates:**

* Updated comments in both `celbridge-tokens.css` and `editor.css` to clarify the intent and effect of background and control color variables, making it easier to understand the rationale behind color choices. [[1]](diffhunk://#diff-1bf0341b9a958a155f458e7e1b710ca224c754e1accc2740961d09d7db794136L137-R138) [[2]](diffhunk://#diff-5e339ecfe3f0453c7566f733bf7b7d666eb58cc2187e08080185191eebb142d5L7-L16)Switches the code editor toolbar background to `--cel-chrome-bg` from shared theme tokens and removes hardcoded light/dark toolbar colors. This keeps toolbar/chrome surfaces aligned across themes and centralizes color sourcing in `celbridge-tokens.css`. The accompanying comments were updated to explain the surface-role intent and contrast rationale.