### PR TITLE
Refine toolbar passthrough hit regions for improved drag behavior

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
@@ -85,26 +85,25 @@ public sealed partial class ApplicationToolbar : UserControl
 
     /// <summary>
     /// The toolbar elements that should pass pointer input through to the application rather than the
-    /// window-drag chrome. The set depends on whether a workspace is active.
+    /// window-drag chrome.
     /// </summary>
     internal IReadOnlyList<FrameworkElement> GetPassthroughElements()
     {
+        var candidates = new List<FrameworkElement>();
+
+        candidates.AddRange(NavigationToolbar.GetInteractiveElements());
+        candidates.AddRange(LayoutToolbar.GetInteractiveElements());
+        candidates.Add(SettingsButton);
+
         var elements = new List<FrameworkElement>();
-
-        if (NavigationToolbar.ActualWidth > 0)
+        foreach (var candidate in candidates)
         {
-            elements.Add(NavigationToolbar);
-        }
-
-        if (ViewModel.IsWorkspaceActive
-            && LayoutToolbar.ActualWidth > 0)
-        {
-            elements.Add(LayoutToolbar);
-        }
-
-        if (SettingsButton.ActualWidth > 0)
-        {
-            elements.Add(SettingsButton);
+            // A collapsed control, or one that has not been laid out yet, has no region to carve out.
+            if (candidate.ActualWidth > 0
+                && candidate.ActualHeight > 0)
+            {
+                elements.Add(candidate);
+            }
         }
 
         return elements;

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
@@ -66,6 +66,22 @@ public sealed partial class LayoutToolbar : UserControl
         Unloaded -= LayoutToolbar_Unloaded;
     }
 
+    /// <summary>
+    /// The controls in this toolbar that a user can click.
+    /// </summary>
+    internal IReadOnlyList<FrameworkElement> GetInteractiveElements()
+    {
+        var elements = new List<FrameworkElement>
+        {
+            PanelLayoutButton,
+            ToggleUtilityPanelButton,
+            ToggleBottomAreaButton,
+            ToggleSideAreaButton
+        };
+
+        return elements;
+    }
+
     private void UpdateWorkspaceControlsVisibility()
     {
         // Panel toggles, layout-mode radios, and the reset button only make sense on the Workspace page.

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/NavigationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/NavigationToolbar.xaml.cs
@@ -60,6 +60,22 @@ public sealed partial class NavigationToolbar : UserControl
         _messengerService.UnregisterAll(this);
     }
 
+    /// <summary>
+    /// The controls in this toolbar that a user can click.
+    /// </summary>
+    internal IReadOnlyList<FrameworkElement> GetInteractiveElements()
+    {
+        var elements = new List<FrameworkElement>
+        {
+            MainMenuButton,
+            HomeNavItem,
+            CommunityNavItem,
+            ProjectSwitcher
+        };
+
+        return elements;
+    }
+
     private void ApplyTooltips()
     {
         var mainMenuTooltip = _stringLocalizer.GetString("TitleBar_MainMenuTooltip");


### PR DESCRIPTION
This pull request refactors how interactive elements are identified in the application toolbars. Instead of directly referencing toolbar controls, each toolbar now exposes a `GetInteractiveElements` method that returns its clickable controls. This approach centralizes the logic for determining interactive elements and makes the code more maintainable and extensible.

**Refactoring and code organization:**

* Added `GetInteractiveElements` methods to both `NavigationToolbar` and `LayoutToolbar`, allowing each toolbar to specify its own set of interactive controls. [[1]](diffhunk://#diff-9d08b02a8037818a240567746660dd00ff701855bb9c9c5f9e5bf562f8c0df36R63-R78) [[2]](diffhunk://#diff-e79a691869f29b73b6f2b820e317ca7597b4d8415b2bba8d74ddd531c8dbace4R69-R84)
* Updated the `GetPassthroughElements` method in `ApplicationToolbar` to aggregate interactive elements from both toolbars and the settings button, and to filter out controls that are not visible or not laid out.Update title-bar passthrough element selection to use each toolbar’s interactive controls instead of whole toolbar containers. This avoids treating empty layout gaps as clickable regions and filters out controls with no rendered size, improving drag-chrome behavior around toolbar buttons.