### PR TITLE
Update docking defaults and improve utility visibility

### DIFF
--- a/Source/Core/Celbridge.Foundation/Documents/IOpenDocumentCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IOpenDocumentCommand.cs
@@ -24,7 +24,7 @@ public interface IOpenDocumentCommand : IExecutableCommand<OpenDocumentOutcome>
 
     /// <summary>
     /// Optional target section to open the document in.
-    /// If null, the document opens in the active section.
+    /// If null, a new document opens in Main's primary section and an already open document stays where it is.
     /// </summary>
     DocumentSection? TargetSection { get; set; }
 

--- a/Source/Core/Celbridge.Foundation/UserInterface/IconSymbol.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/IconSymbol.cs
@@ -19,6 +19,7 @@ public enum IconSymbol
     Home,
     Refresh,
     Reveal,
+    OpenAsDocument,
     Delete,
     Error,
     Warning,

--- a/Source/Core/Celbridge.Foundation/UserInterface/IconSymbol.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/IconSymbol.cs
@@ -19,7 +19,7 @@ public enum IconSymbol
     Home,
     Refresh,
     Reveal,
-    OpenAsDocument,
+    Dock,
     Delete,
     Error,
     Warning,

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
@@ -39,7 +39,7 @@ public interface IUtilityService
 
     /// <summary>
     /// Docks a utility at the given location, reparenting its single persistent WebView to that location's
-    /// container (the Utility Panel rail or a document tab in the active document's section). Reveals or
+    /// container (the Utility Panel rail or a document tab in Main's primary section). Reveals or
     /// activates the utility at the destination. A no-op when it is already there.
     /// </summary>
     Task<Result> DockUtilityAsync(EditorId utilityId, DockLocation location);

--- a/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
@@ -14,7 +14,7 @@ Call `app_list_utilities` first to discover the valid ids, each utility's curren
 ## Behaviour
 
 - With no `location`, the tool reveals the utility where it already lives: a utility in the **panel** has its rail tab selected (revealing the panel if another tab was showing); a utility docked as a **document** has its tab activated and brought to the front. A custom utility's backing file is seeded on first reveal.
-- With `location`, the utility is first moved to that dock location — reparenting its single live WebView, keeping all its state — and then revealed there. Moving to `"document"` docks it into the active document's section; moving to `"panel"` returns it to the rail.
+- With `location`, the utility is first moved to that dock location — reparenting its single live WebView, keeping all its state — and then revealed there. Moving to `"document"` docks it into `MainLeft`; moving to `"panel"` returns it to the rail.
 
 ## Gotchas
 

--- a/Source/Core/Celbridge.Tools/Guides/Tools/document_open.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/document_open.md
@@ -10,7 +10,7 @@ You do not need to open a document to edit its file. The `file_*` tools work on 
 
 The tab strip to open the document in, as one of `MainLeft`, `MainRight`, `BottomLeft`, `BottomRight`, `SideTop`, `SideBottom`. Matching is case-insensitive; any other value is rejected. See `document_get_state` for what each section is and when it exists.
 
-Empty (the default) opens in the currently active section.
+Empty (the default) always opens in `MainLeft`, the one section that is always present. It never lands in the collapsible Bottom or Side areas, and it does not follow the active document. A document that is already open stays in whichever section it is in — the default never moves it.
 
 Naming a secondary section (`MainRight`, `BottomRight`, `SideBottom`) while its area is not split splits the area so the document opens where it was asked for. If that leaves the area's primary section empty — the area held nothing beforehand — the split folds straight back and the document ends up in the primary section, because a split section is never left empty. Naming a section in a collapsed area opens there without expanding the area, so the user does not see the document until they show it again — prefer `MainLeft` or the default when you want the document on screen.
 

--- a/Source/Core/Celbridge.Tools/Tools/Document/DocumentTools.Open.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Document/DocumentTools.Open.cs
@@ -23,7 +23,7 @@ public partial class DocumentTools
             if (!DocumentLayoutHelper.TryParseSection(section, out var parsedSection))
             {
                 var sectionNames = string.Join(", ", DocumentLayoutHelper.AllSections);
-                return ToolResponse.Error($"Invalid section '{section}': must be one of {sectionNames}, or empty for the active section.");
+                return ToolResponse.Error($"Invalid section '{section}': must be one of {sectionNames}, or empty to open in {DocumentLayoutHelper.DefaultOpenSection}.");
             }
 
             targetSection = parsedSection;

--- a/Source/Core/Celbridge.UserInterface/Services/IconService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/IconService.cs
@@ -50,6 +50,7 @@ public class IconService : IIconService
         { IconSymbol.Home, "bs-house" },
         { IconSymbol.Refresh, "bs-arrow-clockwise" },
         { IconSymbol.Reveal, "bs-box-arrow-up-right" },
+        { IconSymbol.OpenAsDocument, "bs-box-arrow-in-up-right" },
         { IconSymbol.Delete, "bs-trash" },
         { IconSymbol.Error, "bs-exclamation-circle-fill" },
         { IconSymbol.Warning, "bs-exclamation-triangle-fill" },

--- a/Source/Core/Celbridge.UserInterface/Services/IconService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/IconService.cs
@@ -50,7 +50,7 @@ public class IconService : IIconService
         { IconSymbol.Home, "bs-house" },
         { IconSymbol.Refresh, "bs-arrow-clockwise" },
         { IconSymbol.Reveal, "bs-box-arrow-up-right" },
-        { IconSymbol.OpenAsDocument, "bs-box-arrow-in-up-right" },
+        { IconSymbol.Dock, "bs-box-arrow-in-up-right" },
         { IconSymbol.Delete, "bs-trash" },
         { IconSymbol.Error, "bs-exclamation-circle-fill" },
         { IconSymbol.Warning, "bs-exclamation-triangle-fill" },

--- a/Source/Core/Celbridge.Utilities/Helpers/DocumentLayoutHelper.cs
+++ b/Source/Core/Celbridge.Utilities/Helpers/DocumentLayoutHelper.cs
@@ -31,6 +31,12 @@ public static class DocumentLayoutHelper
     ];
 
     /// <summary>
+    /// The section that a document opens in when the caller gives no address. Main's primary section is
+    /// the one section that is always present, so an unaddressed open always has somewhere to land.
+    /// </summary>
+    public static readonly DocumentSection DefaultOpenSection = DocumentSection.MainLeft;
+
+    /// <summary>
     /// The area that contains the given section.
     /// </summary>
     public static DocumentArea GetArea(this DocumentSection section)

--- a/Source/Tests/Documents/DocumentLayoutHelperTests.cs
+++ b/Source/Tests/Documents/DocumentLayoutHelperTests.cs
@@ -1,0 +1,35 @@
+using Celbridge.Documents;
+using Celbridge.Utilities;
+
+namespace Celbridge.Tests.Documents;
+
+/// <summary>
+/// Covers DocumentLayoutHelper: the area and section mapping, and the section an unaddressed open
+/// lands in.
+/// </summary>
+[TestFixture]
+public class DocumentLayoutHelperTests
+{
+    [Test]
+    public void GetArea_MapsEverySectionToItsArea()
+    {
+        DocumentSection.MainLeft.GetArea().Should().Be(DocumentArea.Main);
+        DocumentSection.MainRight.GetArea().Should().Be(DocumentArea.Main);
+        DocumentSection.BottomLeft.GetArea().Should().Be(DocumentArea.Bottom);
+        DocumentSection.BottomRight.GetArea().Should().Be(DocumentArea.Bottom);
+        DocumentSection.SideTop.GetArea().Should().Be(DocumentArea.Side);
+        DocumentSection.SideBottom.GetArea().Should().Be(DocumentArea.Side);
+    }
+
+    [Test]
+    public void DefaultOpenSection_IsTheSectionThatIsAlwaysPresent()
+    {
+        var defaultSection = DocumentLayoutHelper.DefaultOpenSection;
+
+        defaultSection.Should().Be(DocumentSection.MainLeft);
+
+        // An unaddressed open must never land in a section that can be collapsed or unmounted.
+        defaultSection.IsSecondarySection().Should().BeFalse();
+        defaultSection.GetArea().IsCollapsible().Should().BeFalse();
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -202,7 +202,7 @@ public class UtilityService : IUtilityService, IDisposable
         return Result.Fail($"Cannot dock utility '{utilityId}': unknown dock location '{location}'");
     }
 
-    // Docks a utility into a document tab in the active document's section, reusing its live WebView. Activates
+    // Docks a utility into a document tab in Main's primary section, reusing its live WebView. Activates
     // the tab if the utility is already there.
     private Result DockUtilityAsDocument(CustomUtilityView panelView)
     {
@@ -215,7 +215,7 @@ public class UtilityService : IUtilityService, IDisposable
             return Result.Ok();
         }
 
-        // A null address docks into the active document's section and activates the tab.
+        // A null address docks into Main's primary section and activates the tab.
         var placement = new DockUtilityPlacement(Address: null, Activate: true);
         var dockResult = documentsPanel.DockUtility(panelView, placement);
         if (dockResult.IsFailure)

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -259,7 +259,10 @@ public class UtilityService : IUtilityService, IDisposable
         var utilityPanel = _workspaceWrapper.WorkspaceService.UtilityPanel;
         utilityPanel.SetUtilityDockLocation(panelView.UtilityId, DockLocation.UtilityPanel, ResourceKey.Empty);
 
-        // Flash the freed rail button so its now-available home is obvious.
+        // Present the utility at its destination, mirroring the dock as a document, which activates the tab.
+        utilityPanel.ShowUtility(panelView.UtilityId);
+
+        // Flash the rail button so the move is obvious.
         utilityPanel.FlashUtility(panelView.UtilityId);
 
         return Result.Ok();

--- a/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
@@ -23,7 +23,7 @@
                 <Button x:Name="OpenAsDocumentButton"
                         Style="{StaticResource TransparentIconButtonStyle}"
                         Click="OpenAsDocumentButton_Click">
-                    <icons:Icon Symbol="OpenAsDocument"
+                    <icons:Icon Symbol="Dock"
                                 FontSize="{StaticResource IconSizeMedium}"/>
                 </Button>
             </controls:PanelHeader.ToolbarContent>

--- a/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml
@@ -23,7 +23,7 @@
                 <Button x:Name="OpenAsDocumentButton"
                         Style="{StaticResource TransparentIconButtonStyle}"
                         Click="OpenAsDocumentButton_Click">
-                    <icons:Icon Symbol="Windowed"
+                    <icons:Icon Symbol="OpenAsDocument"
                                 FontSize="{StaticResource IconSizeMedium}"/>
                 </Button>
             </controls:PanelHeader.ToolbarContent>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs
@@ -48,7 +48,7 @@ public sealed partial class DocumentSectionContainer : UserControl
 
     /// <summary>
     /// Event raised when the active document changes.
-    /// This is the document that should be inspected and determines where new documents open.
+    /// This is the document that should be inspected.
     /// </summary>
     public event Action<ResourceKey>? ActiveDocumentChanged;
 
@@ -94,7 +94,7 @@ public sealed partial class DocumentSectionContainer : UserControl
     public IReadOnlyList<DocumentSection> VisibleSections => _layoutState.VisibleSections;
 
     /// <summary>
-    /// Gets the active document - the document being inspected and where new documents open.
+    /// Gets the active document - the document being inspected.
     /// </summary>
     public ResourceKey ActiveDocument => _activeDocument;
 

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs
@@ -1,9 +1,9 @@
 namespace Celbridge.Documents.Views;
 
 /// <summary>
-/// Where to place a utility when docking it into a document tab. A null Address docks into the active
-/// document's section and appends the tab. A non-null Address targets a specific section and tab order.
-/// Activate selects the docked tab and makes it the active document.
+/// Where to place a utility when docking it into a document tab. A null Address docks into Main's primary
+/// section and appends the tab. A non-null Address targets a specific section and tab order. Activate
+/// selects the docked tab and makes it the active document.
 /// </summary>
 public record DockUtilityPlacement(DocumentAddress? Address, bool Activate);
 
@@ -32,7 +32,17 @@ public sealed partial class DocumentsPanel
         var filePath = resolveResult.Value;
 
         var address = placement.Address;
-        var section = address is not null ? EnsureSectionMounted(address.Section) : SectionContainer.ActiveSection;
+
+        DocumentSection section;
+        if (address is not null)
+        {
+            section = EnsureSectionMounted(address.Section);
+        }
+        else
+        {
+            section = DocumentLayoutHelper.DefaultOpenSection;
+        }
+
         var sectionView = SectionContainer.GetSection(section);
 
         var documentTab = new DocumentTab();

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs
@@ -561,10 +561,19 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
     {
         var effectiveOptions = options ?? new OpenDocumentOptions();
 
-        // Resolve the target section from the address, defaulting to the active section. An address
-        // naming a section whose area is not split folds into that area's primary section.
+        // Resolve the target section from the address, defaulting to the section unaddressed opens land
+        // in. An address naming a section whose area is not split folds into that area's primary section.
         var address = effectiveOptions.Address;
-        var section = address is not null ? EnsureSectionMounted(address.Section) : SectionContainer.ActiveSection;
+
+        DocumentSection section;
+        if (address is not null)
+        {
+            section = EnsureSectionMounted(address.Section);
+        }
+        else
+        {
+            section = DocumentLayoutHelper.DefaultOpenSection;
+        }
 
         // Check if the file is already opened in any section
         var existingLocation = SectionContainer.FindDocumentTab(fileResource);
@@ -596,15 +605,17 @@ public sealed partial class DocumentsPanel : UserControl, IDocumentsPanel
                 existingSectionView.RemoveTab(existingTab);
                 NotifyLayoutChanged();
 
+                // Without an explicit address the document reopens in the section it was already in.
+                var reopenSection = address is not null ? section : existingSectionView.Section;
                 var tabOrder = effectiveOptions.Address?.TabOrder ?? 0;
-                var reopenAddress = new DocumentAddress(WindowIndex: 0, Section: section, TabOrder: tabOrder);
+                var reopenAddress = new DocumentAddress(WindowIndex: 0, Section: reopenSection, TabOrder: tabOrder);
                 var reopenOptions = effectiveOptions with { Address = reopenAddress };
                 return await OpenDocument(fileResource, reopenOptions);
             }
 
             // Without an explicit address the existing tab stays in its own
-            // section. Moving it to wherever the active section happens to be
-            // would yank it from under the user.
+            // section. Pulling it into the Main area would yank it from under
+            // the user.
             if (address is null)
             {
                 section = existingSectionView.Section;


### PR DESCRIPTION
This pull request standardizes the default behavior for opening documents and docking utilities: when no target section is specified, documents and docked utilities now always open in `MainLeft` (Main's primary section), which is guaranteed to be present and visible. The changes update both the implementation and documentation to reflect this, and add supporting tests and UI improvements.

**Default section behavior**

* Introduced `DocumentLayoutHelper.DefaultOpenSection` (set to `MainLeft`) as the canonical default section for unaddressed document and utility opens, replacing previous logic that used the "active section" (`Source/Core/Celbridge.Utilities/Helpers/DocumentLayoutHelper.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs`, `Source/Core/Celbridge.Tools/Guides/Tools/document_open.md`, `Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md`, `Source/Core/Celbridge.Foundation/Documents/IOpenDocumentCommand.cs`, `Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs`, `Source/Workspace/Celbridge.Documents/Services/UtilityService.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.xaml.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs`, `Source/Core/Celbridge.Tools/Tools/Document/DocumentTools.Open.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.xaml.cs`, `Source/Workspace/Celbridge.Documents/Services/UtilityService.cs`, `Source/Core/Celbridge.Tools/Tools/Document/DocumentTools.Open.cs`, `Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md`, `Source/Core/Celbridge.Tools/Guides/Tools/document_open.md`) [[1]](diffhunk://#diff-d163021634a58a47462ffb79e8c813e055fbd987bb989be5b342a56f7e37161dR33-R38) [[2]](diffhunk://#diff-0268afaa8ce148ad60e4476f39bff8136fc367a2d015c3fb82e9aa953c8970a0L35-R45) [[3]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decL564-R576) [[4]](diffhunk://#diff-6c9610b81711e6925c2b8a4598223afaf513a5f3a41682f6a611cd655f0d9ea4L13-R13) [[5]](diffhunk://#diff-3e6332f2b7afd2eeeff54fd51ca8540cd1babbf54f77604ed5a3a3bc677831acL17-R17) [[6]](diffhunk://#diff-36cbd402ca1f83a6d86058802783cc4df64c57dfa51929b715064255d19dbb35L27-R27) [[7]](diffhunk://#diff-0754556c715b188323f7d9b17e523f8dec8632e49874379841d2f9a4aef7ed8aL42-R42) [[8]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L205-R205) [[9]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L218-R218) [[10]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decR608-R618) [[11]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L51-R51) [[12]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L97-R97) [[13]](diffhunk://#diff-ab5257878df94f584f76bde78fdc0dcb3ae25487bc0c166145cc3c2bfd782643L26-R26) [[14]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L205-R205) [[15]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L218-R218) [[16]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decR608-R618).
* Updated all relevant documentation, code comments, and error messages to clarify that the default is always `MainLeft`, not the active section [[1]](diffhunk://#diff-6c9610b81711e6925c2b8a4598223afaf513a5f3a41682f6a611cd655f0d9ea4L13-R13) [[2]](diffhunk://#diff-3e6332f2b7afd2eeeff54fd51ca8540cd1babbf54f77604ed5a3a3bc677831acL17-R17) [[3]](diffhunk://#diff-36cbd402ca1f83a6d86058802783cc4df64c57dfa51929b715064255d19dbb35L27-R27) [[4]](diffhunk://#diff-0754556c715b188323f7d9b17e523f8dec8632e49874379841d2f9a4aef7ed8aL42-R42) [[5]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L205-R205) [[6]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L218-R218) [[7]](diffhunk://#diff-42078c055e0525bbc268d7f9bf41d9f56fce78924b2e638d261159284f361decR608-R618) [[8]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L51-R51) [[9]](diffhunk://#diff-27a340eb44f3acc555fef925276264897a9110f00e2b6b6d4906eca8bf500256L97-R97) [[10]](diffhunk://#diff-ab5257878df94f584f76bde78fdc0dcb3ae25487bc0c166145cc3c2bfd782643L26-R26).

**UI and icon updates**

* Added a new `Dock` symbol to the `IconSymbol` enum and mapped it to a new icon in `IconService`. Updated the dock utility button to use this icon (`Source/Core/Celbridge.Foundation/UserInterface/IconSymbol.cs`, `Source/Core/Celbridge.UserInterface/Services/IconService.cs`, `Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml`) [[1]](diffhunk://#diff-8ffb8e6ec2627329185252dddc733fb7efda7b68cfce710acd0d1e80b729c31eR22) [[2]](diffhunk://#diff-6aaa374192f2a2e4827c31e807c6c4e9691dc934d5be6f6adaffa46e492a2f93R53) [[3]](diffhunk://#diff-cd9b612bd75697f6ec4af1e3312aca56bfef857608d5a96ad3b86ec6e6cd54c3L26-R26).

**Testing and reliability**

* Added `DocumentLayoutHelperTests` to verify section/area mapping and that the default open section is always present and non-collapsible (`Source/Tests/Documents/DocumentLayoutHelperTests.cs`).

**Utility docking and reveal logic**

* Ensured that when a utility is docked or revealed without a location, it is always shown in `MainLeft` and the UI feedback is consistent (`Source/Workspace/Celbridge.Documents/Services/UtilityService.cs`, `Source/Workspace/Celbridge.Documents/Views/DocumentsPanel.UtilityDocking.cs`) [[1]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L205-R205) [[2]](diffhunk://#diff-9fe084743f8a0106b0d82d11e1eeb5d962a374745cb138a4bf50cd2a209b3f28L218-R218) [[3]](diffhunk://#diff-0268afaa8ce148ad60e4476f39bff8136fc367a2d015c3fb82e9aa953c8970a0L4-R6) [[4]](diffhunk://#diff-0268afaa8ce148ad60e4476f39bff8136fc367a2d015c3fb82e9aa953c8970a0L35-R45).

These changes ensure consistent, predictable behavior for document and utility placement, improving usability and reducing confusion.